### PR TITLE
feat: enhance booking dates with day-of-week and school holiday tooltip

### DIFF
--- a/bookings-extension/panel.js
+++ b/bookings-extension/panel.js
@@ -130,7 +130,29 @@
     });
   }
 
-  // --- Date formatting helpers ---
+  // --- Date formatting and school holiday helpers ---
+
+  // Essex school holidays 2025-2026.
+  // Source: https://www.essex.gov.uk/schools-and-learning/schools/essex-school-terms-and-holidays/academic-year-2025-2026
+  // Update each academic year.
+  const ESSEX_HOLIDAYS = [
+    { name: 'Autumn half term',       shortName: 'Autumn half term', start: new Date('2025-10-27'), end: new Date('2025-10-31') },
+    { name: 'Christmas holiday',      shortName: 'Christmas hols',   start: new Date('2025-12-22'), end: new Date('2026-01-02') },
+    { name: 'Spring half term',       shortName: 'Spring half term', start: new Date('2026-02-16'), end: new Date('2026-02-20') },
+    { name: 'Easter holiday',         shortName: 'Easter hols',      start: new Date('2026-03-30'), end: new Date('2026-04-10') },
+    { name: 'Early May bank holiday', shortName: 'May bank holiday', start: new Date('2026-05-04'), end: new Date('2026-05-04') },
+    { name: 'Summer half term',       shortName: 'Summer half term', start: new Date('2026-05-25'), end: new Date('2026-05-29') },
+    { name: 'Summer holiday',         shortName: 'Summer hols',      start: new Date('2026-07-21'), end: new Date('2026-08-31') },
+  ];
+
+  // Returns the holiday object if `date` falls within any Essex holiday period, otherwise null.
+  function getHolidayForDate(date) {
+    const d = new Date(date.getFullYear(), date.getMonth(), date.getDate());
+    for (const h of ESSEX_HOLIDAYS) {
+      if (d >= h.start && d <= h.end) return h;
+    }
+    return null;
+  }
 
   function formatDate(date, includeYear) {
     const opts = { weekday: 'short', day: 'numeric', month: 'short' };

--- a/bookings-extension/panel.js
+++ b/bookings-extension/panel.js
@@ -135,14 +135,16 @@
   // Essex school holidays 2025-2026.
   // Source: https://www.essex.gov.uk/schools-and-learning/schools/essex-school-terms-and-holidays/academic-year-2025-2026
   // Update each academic year.
+  // Dates use new Date(year, month-1, day) to stay in local time — avoids UTC-midnight
+  // offset issues that arise when using ISO string literals like new Date('2025-10-27').
   const ESSEX_HOLIDAYS = [
-    { name: 'Autumn half term',       shortName: 'Autumn half term', start: new Date('2025-10-27'), end: new Date('2025-10-31') },
-    { name: 'Christmas holiday',      shortName: 'Christmas hols',   start: new Date('2025-12-22'), end: new Date('2026-01-02') },
-    { name: 'Spring half term',       shortName: 'Spring half term', start: new Date('2026-02-16'), end: new Date('2026-02-20') },
-    { name: 'Easter holiday',         shortName: 'Easter hols',      start: new Date('2026-03-30'), end: new Date('2026-04-10') },
-    { name: 'Early May bank holiday', shortName: 'May bank holiday', start: new Date('2026-05-04'), end: new Date('2026-05-04') },
-    { name: 'Summer half term',       shortName: 'Summer half term', start: new Date('2026-05-25'), end: new Date('2026-05-29') },
-    { name: 'Summer holiday',         shortName: 'Summer hols',      start: new Date('2026-07-21'), end: new Date('2026-08-31') },
+    { name: 'Autumn half term',       shortName: 'Autumn half term', start: new Date(2025,  9, 27), end: new Date(2025,  9, 31) },
+    { name: 'Christmas holiday',      shortName: 'Christmas hols',   start: new Date(2025, 11, 22), end: new Date(2026,  0,  2) },
+    { name: 'Spring half term',       shortName: 'Spring half term', start: new Date(2026,  1, 16), end: new Date(2026,  1, 20) },
+    { name: 'Easter holiday',         shortName: 'Easter hols',      start: new Date(2026,  2, 30), end: new Date(2026,  3, 10) },
+    { name: 'Early May bank holiday', shortName: 'May bank holiday', start: new Date(2026,  4,  4), end: new Date(2026,  4,  4) },
+    { name: 'Summer half term',       shortName: 'Summer half term', start: new Date(2026,  4, 25), end: new Date(2026,  4, 29) },
+    { name: 'Summer holiday',         shortName: 'Summer hols',      start: new Date(2026,  6, 21), end: new Date(2026,  7, 31) },
   ];
 
   // Returns the holiday object if `date` falls within any Essex holiday period, otherwise null.

--- a/bookings-extension/panel.js
+++ b/bookings-extension/panel.js
@@ -130,15 +130,23 @@
     });
   }
 
+  // --- Date formatting helpers ---
+
+  function formatDate(date, includeYear) {
+    const opts = { weekday: 'short', day: 'numeric', month: 'short' };
+    if (includeYear) opts.year = 'numeric';
+    return date.toLocaleDateString('en-GB', opts);
+  }
+
   function renderBookingCard(booking, isSuggested) {
     isSuggested = isSuggested || false;
     const status = (booking.status || '').toLowerCase();
     const statusClass = `ba-status-${escapeHtml(status)}`;
     const start = booking.startDate
-      ? new Date(booking.startDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short' })
+      ? formatDate(new Date(booking.startDate), false)
       : '';
     const end = booking.endDate
-      ? new Date(booking.endDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })
+      ? formatDate(new Date(booking.endDate), true)
       : '';
 
     return `

--- a/bookings-extension/panel.js
+++ b/bookings-extension/panel.js
@@ -164,17 +164,30 @@
     isSuggested = isSuggested || false;
     const status = (booking.status || '').toLowerCase();
     const statusClass = `ba-status-${escapeHtml(status)}`;
-    const start = booking.startDate
-      ? formatDate(new Date(booking.startDate), false)
-      : '';
-    const end = booking.endDate
-      ? formatDate(new Date(booking.endDate), true)
-      : '';
+
+    const startDate = booking.startDate ? new Date(booking.startDate) : null;
+    const endDate   = booking.endDate   ? new Date(booking.endDate)   : null;
+    const start = startDate ? formatDate(startDate, false) : '';
+    const end   = endDate   ? formatDate(endDate,   true)  : '';
+
+    // Build the date range text, then optionally wrap it in a holiday tooltip.
+    const dateText = start + (end ? ' \u2013 ' + end : '');
+    const holiday = startDate ? getHolidayForDate(startDate) : null;
+
+    let datesHtml;
+    if (holiday) {
+      const tipStart = holiday.start.toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' });
+      const tipEnd   = holiday.end.toLocaleDateString('en-GB',   { day: 'numeric', month: 'short', year: 'numeric' });
+      const tipText  = escapeHtml(`${holiday.name}: ${tipStart} \u2013 ${tipEnd}`);
+      datesHtml = `<span class="ba-date-tip" data-tip="${tipText}">${escapeHtml(dateText)} \u00b7 ${escapeHtml(holiday.shortName)}</span>`;
+    } else {
+      datesHtml = escapeHtml(dateText);
+    }
 
     return `
       <div class="ba-booking-card">
         <div><span class="ba-booking-ref">#${escapeHtml(booking.osmBookingId)}</span> \u00b7 <span class="ba-booking-name">${escapeHtml(booking.customerName)}</span></div>
-        <div class="ba-booking-dates">${escapeHtml(start)}${end ? ' \u2013 ' + escapeHtml(end) : ''}</div>
+        <div class="ba-booking-dates">${datesHtml}</div>
         <div><span class="ba-booking-status ${statusClass}">${escapeHtml(booking.status)}</span></div>
         ${isSuggested ? '<div style="font-size:11px;color:#666;margin-top:4px">Possible match</div>' : ''}
       </div>

--- a/bookings-extension/sidebar.css
+++ b/bookings-extension/sidebar.css
@@ -135,3 +135,27 @@
   font-weight: 600;
 }
 .ba-handle-btn:hover { background: #581c87; }
+
+/* Holiday tooltip — appears on hover over date line when start date is in a school holiday */
+.ba-date-tip {
+  position: relative;
+  cursor: default;
+}
+.ba-date-tip::after {
+  content: attr(data-tip);
+  display: none;
+  position: absolute;
+  left: 0;
+  top: calc(100% + 4px);
+  background: #333;
+  color: #fff;
+  font-size: 10px;
+  padding: 3px 6px;
+  border-radius: 3px;
+  white-space: nowrap;
+  z-index: 10;
+  pointer-events: none;
+}
+.ba-date-tip:hover::after {
+  display: block;
+}


### PR DESCRIPTION
Closes #3

## Summary
- Booking dates in the panel now show the day of week inline: "Sat 15 Mar – Mon 17 Mar 2026"
- Bookings whose start date falls within an Essex school holiday show a subtle inline marker (`· Easter hols`) with a CSS hover tooltip showing the full holiday name and date range
- No backend changes — date enrichment is entirely in the Chrome extension frontend

## Approach
Three helpers were added to `panel.js`: `formatDate()` wraps `toLocaleDateString` with `weekday: 'short'`; `ESSEX_HOLIDAYS` holds the 7 Essex 2025-2026 holiday periods; `getHolidayForDate()` checks a date against those ranges. In `renderBookingCard`, the start date is checked and — if a holiday matches — the date span gains a `.ba-date-tip[data-tip="..."]` attribute. A `::after` CSS tooltip rule in `sidebar.css` surfaces the full period name and dates on hover.

## Key decisions
- **Day of week inline, holiday as tooltip:** Day of week is essential (user's words) so it's always visible. Holiday info is supplementary so it lives behind a hover interaction, keeping the card compact.
- **Local-time Date constructor:** `ESSEX_HOLIDAYS` uses `new Date(year, month-1, day)` rather than `new Date('YYYY-MM-DD')` to avoid UTC-midnight boundary issues in UTC+ timezones (e.g. BST would otherwise miss the first calendar day of each holiday).
- **Hardcoded 2025-2026 data:** Simpler than scraping; the constant includes a source URL comment and a note to update annually.

## Testing strategy
No automated test framework exists for the extension JS. Manual verification:
- [ ] Booking dates show short day name: "Sat 15 Mar – Mon 17 Mar 2026"
- [ ] Holiday booking: `· Easter hols` marker visible inline on start date
- [ ] Hovering shows tooltip: "Easter holiday: 30 Mar – 10 Apr 2026"
- [ ] Non-holiday booking: no marker, date renders as normal
- [ ] OWA email context dates also show day of week

All 12 C# backend tests pass (run after each of the 4 commits).

## Review guidance
`ESSEX_HOLIDAYS` and `getHolidayForDate` in `panel.js` are the core of the change — worth verifying the date boundary logic. The UTC fix (local-time constructors) is the non-obvious correctness decision. `sidebar.css` additions are mechanical.

🤖 Generated with [Claude Code](https://claude.com/claude-code)