### PR TITLE
feat: surface HA addon web UI via webui field

### DIFF
--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,10 +1,11 @@
 name: Bookings Assistant
-version: 0.9.3
+version: 0.9.4
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper
 arch:
   - amd64
+webui: http://[HOST]:[PORT]/
 ports:
   5000/tcp: 8099
 ports_description:

--- a/docs/plans/2026-02-27-ha-addon-webview-design.md
+++ b/docs/plans/2026-02-27-ha-addon-webview-design.md
@@ -1,0 +1,46 @@
+# HA Addon Web View — Design
+
+**Issue:** #4
+**Date:** 2026-02-27
+**Status:** Approved
+
+## Problem
+
+The HA addon exposes port 5000 internally (mapped to host port 8099) and the backend already serves a full React SPA via `UseStaticFiles` + `MapFallbackToFile`. However, the `bookings-assistant/config.yaml` has no `webui` field, so Home Assistant never shows the "Go to webview" button on the addon info page. Users must manually type the URL.
+
+## Options Considered
+
+### Option A — `webui` only (chosen)
+
+Add a single line to `config.yaml`:
+
+```yaml
+webui: http://[HOST]:[PORT]/
+```
+
+HA substitutes `[HOST]` and `[PORT]` (using the first mapped port, 8099) at runtime and displays a "Go to webview" button on the addon info page. No code changes required.
+
+- Risk: zero
+- Files changed: 1 (`bookings-assistant/config.yaml`)
+
+### Option B — Ingress only
+
+Add `ingress: true`, `ingress_port: 5000`, `panel_icon`, `panel_title`. HA proxies requests through a dynamic base path (`/api/hassio_ingress/<token>/`) and shows the addon in the sidebar. Requires changes to `vite.config.ts` (`base: './'`), `main.tsx` (dynamic `BrowserRouter` basename from `X-Ingress-Path` header), and `Program.cs` (`UsePathBase`). Moderate complexity.
+
+### Option C — `webui` + ingress
+
+Both features together. Same complexity as Option B for the ingress side.
+
+## Decision
+
+**Option A.** The issue states sidebar support as "even better if" — a nice-to-have. The `webui` field directly satisfies the primary ask ("Go to webview" option) with zero risk. Ingress can be revisited as a separate issue if sidebar support is later desired.
+
+## Implementation
+
+Single change to `bookings-assistant/config.yaml` — add after the `ports_description` block:
+
+```yaml
+webui: http://[HOST]:[PORT]/
+```
+
+HA's `[HOST]` and `[PORT]` placeholders are resolved by the Supervisor using the first entry in the addon's `ports` map, which is `5000/tcp: 8099`, so the button will open `http://<ha-host>:8099/`.


### PR DESCRIPTION
## Summary

- Adds `webui: http://[HOST]:[PORT]/` to `bookings-assistant/config.yaml` so Home Assistant displays a **Go to webview** button on the addon info page
- The button links directly to the existing React web UI already served by the ASP.NET Core backend on port 8099
- Bumps addon version `0.9.3` → `0.9.4`
- Adds design doc recording the webui-vs-ingress decision for future reference

## Why this approach

The issue requested both "Go to webview" (primary) and sidebar display (nice-to-have). The `webui` field satisfies the primary ask with a single config line and zero risk. Ingress (which would add the sidebar entry) requires coordinated base-path changes in Vite, React Router, and ASP.NET Core to handle HA's dynamic proxy prefix — that complexity is deferred to a future issue if sidebar support is desired.

## Test plan

- [ ] Install/update the addon in a HA instance
- [ ] Navigate to Settings > Add-ons > Bookings Assistant
- [ ] Confirm the **Go to webview** button appears on the addon info page
- [ ] Click the button and confirm the React web UI loads at `http://<ha-host>:8099/`

Closes #4

🤖 Generated with [Claude Code](https://claude.com/claude-code)