### PR TITLE
Booking actions API: move activity, change site, shift booking dates

### DIFF
--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -1,0 +1,57 @@
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using Microsoft.AspNetCore.Mvc;
+
+namespace BookingsAssistant.Api.Controllers;
+
+[ApiController]
+[Route("api/bookings")]
+public class BookingActionsController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IOsmService _osmService;
+    private readonly ILogger<BookingActionsController> _logger;
+
+    public BookingActionsController(
+        ApplicationDbContext context,
+        IOsmService osmService,
+        ILogger<BookingActionsController> logger)
+    {
+        _context = context;
+        _osmService = osmService;
+        _logger = logger;
+    }
+
+    /// <summary>
+    /// Returns the line-items (sites and activities) for a booking.
+    /// Returns 501 while the OSM item parsing seam is not yet wired up.
+    /// </summary>
+    [HttpGet("{id}/items")]
+    public async Task<ActionResult<List<BookingItemDto>>> GetItems(int id)
+    {
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
+            return Ok(items);
+        }
+        catch (NotImplementedException ex)
+        {
+            _logger.LogInformation("OSM item retrieval not yet implemented for booking {Id}: {Message}", id, ex.Message);
+            return StatusCode(501, new { message = "OSM item retrieval not yet implemented" });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching items for booking {Id}", id);
+            return StatusCode(502, new { message = "Error fetching items from OSM", detail = ex.Message });
+        }
+    }
+}

--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -29,7 +29,6 @@ public class BookingActionsController : ControllerBase
 
     /// <summary>
     /// Returns the line-items (sites and activities) for a booking.
-    /// Returns 501 while the OSM item parsing seam is not yet wired up.
     /// </summary>
     [HttpGet("{id}/items")]
     public async Task<ActionResult<List<BookingItemDto>>> GetItems(int id)
@@ -42,11 +41,6 @@ public class BookingActionsController : ControllerBase
         {
             var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
             return Ok(items);
-        }
-        catch (NotImplementedException ex)
-        {
-            _logger.LogInformation("OSM item retrieval not yet implemented for booking {Id}: {Message}", id, ex.Message);
-            return StatusCode(501, new { message = "OSM item retrieval not yet implemented" });
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
         {
@@ -63,14 +57,13 @@ public class BookingActionsController : ControllerBase
     // - 400 Bad Request: missing/invalid request parameters (checked before OSM calls)
     // - 404 Not Found: booking not in DB, or item not in booking's current item list
     // - 401 Unauthorized: InvalidOperationException whose message contains "OSM" (auth)
-    // - 501 Not Implemented: NotImplementedException (OSM seam stubs not yet wired)
+    // - 502 Bad Gateway: other OSM failures (e.g. no available slot, OSM rejected the create)
     // - 200 OK for all engine outcomes (completed/completed_with_warnings/rolled_back/failed):
     //   the caller reads result.Status — using 200 keeps the response contract simple and
     //   avoids conflating HTTP transport errors with application-level partial failures.
 
     /// <summary>
     /// Moves an activity item within the booking (changes start/end date or start/end time).
-    /// Returns 501 while the OSM create/delete seam is not yet wired up.
     /// </summary>
     [HttpPost("{id}/actions/move-activity")]
     public async Task<ActionResult<BookingActionResult>> MoveActivity(int id, [FromBody] MoveActivityRequest request)
@@ -100,11 +93,6 @@ public class BookingActionsController : ControllerBase
             var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, new[] { replacement });
             return Ok(result);
         }
-        catch (NotImplementedException ex)
-        {
-            _logger.LogInformation("OSM move-activity not yet implemented for booking {Id}: {Message}", id, ex.Message);
-            return StatusCode(501, new { message = "OSM item mutation not yet implemented" });
-        }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
         {
             return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
@@ -118,7 +106,6 @@ public class BookingActionsController : ControllerBase
 
     /// <summary>
     /// Moves a site item to a different site within the booking.
-    /// Returns 501 while the OSM create/delete seam is not yet wired up.
     /// </summary>
     [HttpPost("{id}/actions/change-site")]
     public async Task<ActionResult<BookingActionResult>> ChangeSite(int id, [FromBody] ChangeSiteRequest request)
@@ -149,11 +136,6 @@ public class BookingActionsController : ControllerBase
             var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, new[] { replacement });
             return Ok(result);
         }
-        catch (NotImplementedException ex)
-        {
-            _logger.LogInformation("OSM change-site not yet implemented for booking {Id}: {Message}", id, ex.Message);
-            return StatusCode(501, new { message = "OSM item mutation not yet implemented" });
-        }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
         {
             return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
@@ -169,7 +151,6 @@ public class BookingActionsController : ControllerBase
     /// Shifts all items in the booking by the given number of days (positive = forward, negative = back).
     /// Each item with a StartDate gets a replacement with both StartDate and EndDate shifted.
     /// Items without a date are included unchanged.
-    /// Returns 501 while the OSM create/delete seam is not yet wired up.
     /// </summary>
     [HttpPost("{id}/actions/move-dates")]
     public async Task<ActionResult<BookingActionResult>> MoveDates(int id, [FromBody] MoveDatesRequest request)
@@ -199,11 +180,6 @@ public class BookingActionsController : ControllerBase
 
             var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, replacements);
             return Ok(result);
-        }
-        catch (NotImplementedException ex)
-        {
-            _logger.LogInformation("OSM move-dates not yet implemented for booking {Id}: {Message}", id, ex.Message);
-            return StatusCode(501, new { message = "OSM item mutation not yet implemented" });
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
         {

--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -10,16 +10,20 @@ namespace BookingsAssistant.Api.Controllers;
 public class BookingActionsController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
+    // Used to resolve booking items by id before delegating the mutation to the engine.
     private readonly IOsmService _osmService;
+    private readonly IBookingMutationService _mutationService;
     private readonly ILogger<BookingActionsController> _logger;
 
     public BookingActionsController(
         ApplicationDbContext context,
         IOsmService osmService,
+        IBookingMutationService mutationService,
         ILogger<BookingActionsController> logger)
     {
         _context = context;
         _osmService = osmService;
+        _mutationService = mutationService;
         _logger = logger;
     }
 
@@ -52,6 +56,163 @@ public class BookingActionsController : ControllerBase
         {
             _logger.LogError(ex, "Error fetching items for booking {Id}", id);
             return StatusCode(502, new { message = "Error fetching items from OSM", detail = ex.Message });
+        }
+    }
+
+    // ── Error mapping convention for mutation endpoints ───────────────────────
+    // - 400 Bad Request: missing/invalid request parameters (checked before OSM calls)
+    // - 404 Not Found: booking not in DB, or item not in booking's current item list
+    // - 401 Unauthorized: InvalidOperationException whose message contains "OSM" (auth)
+    // - 501 Not Implemented: NotImplementedException (OSM seam stubs not yet wired)
+    // - 200 OK for all engine outcomes (completed/completed_with_warnings/rolled_back/failed):
+    //   the caller reads result.Status — using 200 keeps the response contract simple and
+    //   avoids conflating HTTP transport errors with application-level partial failures.
+
+    /// <summary>
+    /// Moves an activity item within the booking (changes start/end date or start/end time).
+    /// Returns 501 while the OSM create/delete seam is not yet wired up.
+    /// </summary>
+    [HttpPost("{id}/actions/move-activity")]
+    public async Task<ActionResult<BookingActionResult>> MoveActivity(int id, [FromBody] MoveActivityRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ItemId))
+            return BadRequest(new { message = "ItemId is required" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
+            var item = items.FirstOrDefault(i => i.ItemId == request.ItemId);
+            if (item == null)
+                return NotFound(new { message = $"Item '{request.ItemId}' not found in booking {id}" });
+
+            var replacement = new ItemReplacement
+            {
+                Original = item,
+                NewStartDate = request.NewStartDate,
+                NewStartTime = request.NewStartTime,
+                NewEndTime = request.NewEndTime
+            };
+
+            var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, new[] { replacement });
+            return Ok(result);
+        }
+        catch (NotImplementedException ex)
+        {
+            _logger.LogInformation("OSM move-activity not yet implemented for booking {Id}: {Message}", id, ex.Message);
+            return StatusCode(501, new { message = "OSM item mutation not yet implemented" });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during move-activity for booking {Id}", id);
+            return StatusCode(502, new { message = "Error executing move-activity", detail = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Moves a site item to a different site within the booking.
+    /// Returns 501 while the OSM create/delete seam is not yet wired up.
+    /// </summary>
+    [HttpPost("{id}/actions/change-site")]
+    public async Task<ActionResult<BookingActionResult>> ChangeSite(int id, [FromBody] ChangeSiteRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ItemId))
+            return BadRequest(new { message = "ItemId is required" });
+
+        if (string.IsNullOrWhiteSpace(request.NewSiteId))
+            return BadRequest(new { message = "NewSiteId is required" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
+            var item = items.FirstOrDefault(i => i.ItemId == request.ItemId);
+            if (item == null)
+                return NotFound(new { message = $"Item '{request.ItemId}' not found in booking {id}" });
+
+            var replacement = new ItemReplacement
+            {
+                Original = item,
+                NewSiteId = request.NewSiteId
+            };
+
+            var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, new[] { replacement });
+            return Ok(result);
+        }
+        catch (NotImplementedException ex)
+        {
+            _logger.LogInformation("OSM change-site not yet implemented for booking {Id}: {Message}", id, ex.Message);
+            return StatusCode(501, new { message = "OSM item mutation not yet implemented" });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during change-site for booking {Id}", id);
+            return StatusCode(502, new { message = "Error executing change-site", detail = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Shifts all items in the booking by the given number of days (positive = forward, negative = back).
+    /// Each item with a StartDate gets a replacement with both StartDate and EndDate shifted.
+    /// Items without a date are included unchanged.
+    /// Returns 501 while the OSM create/delete seam is not yet wired up.
+    /// </summary>
+    [HttpPost("{id}/actions/move-dates")]
+    public async Task<ActionResult<BookingActionResult>> MoveDates(int id, [FromBody] MoveDatesRequest request)
+    {
+        if (request.DayShift == 0)
+            return BadRequest(new { message = "DayShift must be non-zero" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
+
+            var replacements = items.Select(item => new ItemReplacement
+            {
+                Original = item,
+                NewStartDate = item.StartDate.HasValue
+                    ? item.StartDate.Value.AddDays(request.DayShift)
+                    : null,
+                NewEndDate = item.EndDate.HasValue
+                    ? item.EndDate.Value.AddDays(request.DayShift)
+                    : null
+                // StartTime and EndTime are preserved (not overridden)
+            }).ToList();
+
+            var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, replacements);
+            return Ok(result);
+        }
+        catch (NotImplementedException ex)
+        {
+            _logger.LogInformation("OSM move-dates not yet implemented for booking {Id}: {Message}", id, ex.Message);
+            return StatusCode(501, new { message = "OSM item mutation not yet implemented" });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during move-dates for booking {Id}", id);
+            return StatusCode(502, new { message = "Error executing move-dates", detail = ex.Message });
         }
     }
 }

--- a/BookingsAssistant.Api/Models/BookingActionResult.cs
+++ b/BookingsAssistant.Api/Models/BookingActionResult.cs
@@ -1,0 +1,40 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// String constants for BookingActionResult.Status.
+/// Using plain string constants to match the project's style (OsmBooking.Status is a plain string).
+/// </summary>
+public static class BookingActionStatus
+{
+    public const string Completed = "completed";
+    public const string CompletedWithWarnings = "completed_with_warnings";
+    public const string RolledBack = "rolled_back";
+    public const string Failed = "failed";
+}
+
+/// <summary>
+/// The result of a booking mutation operation (e.g. item replacement).
+/// </summary>
+public class BookingActionResult
+{
+    /// <summary>Ids of items successfully created during this operation.</summary>
+    public List<string> Created { get; set; } = new();
+
+    /// <summary>Ids of items successfully deleted during this operation.</summary>
+    public List<string> Deleted { get; set; } = new();
+
+    /// <summary>
+    /// One of: "completed", "completed_with_warnings", "rolled_back", "failed".
+    /// See <see cref="BookingActionStatus"/> for the constants.
+    /// </summary>
+    public string Status { get; set; } = BookingActionStatus.Failed;
+
+    /// <summary>Human-readable explanation of the outcome.</summary>
+    public string Message { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The booking's items after the operation completes (best-effort; may reflect
+    /// the pre-rollback state if GetBookingItemsAsync itself fails).
+    /// </summary>
+    public List<BookingItemDto> Items { get; set; } = new();
+}

--- a/BookingsAssistant.Api/Models/BookingItemCreateSpec.cs
+++ b/BookingsAssistant.Api/Models/BookingItemCreateSpec.cs
@@ -1,0 +1,24 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// Everything OSM needs to create (clone) a booked item. Built by the mutation engine
+/// from an existing item plus any field overrides. The OSM adapter resolves the
+/// availability slot and posts the addItem form from these values.
+/// </summary>
+public class BookingItemCreateSpec
+{
+    /// <summary>The item-TYPE id (OSM campsite_item_id) used in the addItem URL.</summary>
+    public string CampsiteItemId { get; set; } = string.Empty;
+
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string? StartTime { get; set; }
+    public string? EndTime { get; set; }
+    public int? NumberPeople { get; set; }
+
+    /// <summary>
+    /// The original item's question answers, keyed by stable question-definition id
+    /// (OSM campsite_booking_question_id). Replayed onto the clone after creation.
+    /// </summary>
+    public Dictionary<int, string> QuestionAnswers { get; set; } = new();
+}

--- a/BookingsAssistant.Api/Models/BookingItemDto.cs
+++ b/BookingsAssistant.Api/Models/BookingItemDto.cs
@@ -15,5 +15,12 @@ public class BookingItemDto
     public DateTime? EndDate { get; set; }
     public string? StartTime { get; set; }
     public string? EndTime { get; set; }
+
+    /// <summary>
+    /// Number of people on the booked item. Needed to rebuild the create payload
+    /// when cloning (OSM's addItem requires number_people).
+    /// </summary>
+    public int? NumberPeople { get; set; }
+
     public string Label { get; set; } = string.Empty;
 }

--- a/BookingsAssistant.Api/Models/BookingItemDto.cs
+++ b/BookingsAssistant.Api/Models/BookingItemDto.cs
@@ -1,0 +1,19 @@
+namespace BookingsAssistant.Api.Models;
+
+public class BookingItemDto
+{
+    public string ItemId { get; set; } = string.Empty;
+
+    /// <summary>
+    /// "site" or "activity"
+    /// </summary>
+    public string Type { get; set; } = string.Empty;
+
+    public string? SiteId { get; set; }
+    public string? ActivityId { get; set; }
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string? StartTime { get; set; }
+    public string? EndTime { get; set; }
+    public string Label { get; set; } = string.Empty;
+}

--- a/BookingsAssistant.Api/Models/BookingItemDto.cs
+++ b/BookingsAssistant.Api/Models/BookingItemDto.cs
@@ -1,3 +1,5 @@
+using System.Text.Json.Serialization;
+
 namespace BookingsAssistant.Api.Models;
 
 public class BookingItemDto
@@ -23,4 +25,12 @@ public class BookingItemDto
     public int? NumberPeople { get; set; }
 
     public string Label { get; set; } = string.Empty;
+
+    /// <summary>
+    /// The item's question answers (from the booking-detail response). Carried so a
+    /// clone can replay them; not part of the public items contract (it could contain
+    /// free-text), so excluded from JSON serialisation.
+    /// </summary>
+    [JsonIgnore]
+    public List<BookingItemQuestion> Questions { get; set; } = new();
 }

--- a/BookingsAssistant.Api/Models/BookingItemQuestion.cs
+++ b/BookingsAssistant.Api/Models/BookingItemQuestion.cs
@@ -1,0 +1,12 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// A booked item's question answer, as carried on the booking-detail response.
+/// Keyed by the stable question-definition id so answers can be replayed onto a
+/// cloned item (whose per-item answer rows have different ids).
+/// </summary>
+public class BookingItemQuestion
+{
+    public int QuestionDefId { get; set; }
+    public string Answer { get; set; } = string.Empty;
+}

--- a/BookingsAssistant.Api/Models/ChangeSiteRequest.cs
+++ b/BookingsAssistant.Api/Models/ChangeSiteRequest.cs
@@ -1,0 +1,7 @@
+namespace BookingsAssistant.Api.Models;
+
+public class ChangeSiteRequest
+{
+    public string ItemId { get; set; } = string.Empty;
+    public string NewSiteId { get; set; } = string.Empty;
+}

--- a/BookingsAssistant.Api/Models/ItemReplacement.cs
+++ b/BookingsAssistant.Api/Models/ItemReplacement.cs
@@ -1,0 +1,27 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// Describes a single item to be replaced within a booking mutation operation.
+/// Carries the original item (to be deleted after successful creation) plus
+/// the field overrides to apply to the clone.
+/// </summary>
+public class ItemReplacement
+{
+    /// <summary>The original booking item that will be deleted after the clone is created.</summary>
+    public BookingItemDto Original { get; set; } = new();
+
+    /// <summary>If set, overrides the SiteId on the cloned item.</summary>
+    public string? NewSiteId { get; set; }
+
+    /// <summary>If set, overrides the StartDate on the cloned item.</summary>
+    public DateTime? NewStartDate { get; set; }
+
+    /// <summary>If set, overrides the EndDate on the cloned item.</summary>
+    public DateTime? NewEndDate { get; set; }
+
+    /// <summary>If set, overrides the StartTime on the cloned item.</summary>
+    public string? NewStartTime { get; set; }
+
+    /// <summary>If set, overrides the EndTime on the cloned item.</summary>
+    public string? NewEndTime { get; set; }
+}

--- a/BookingsAssistant.Api/Models/MoveActivityRequest.cs
+++ b/BookingsAssistant.Api/Models/MoveActivityRequest.cs
@@ -1,0 +1,9 @@
+namespace BookingsAssistant.Api.Models;
+
+public class MoveActivityRequest
+{
+    public string ItemId { get; set; } = string.Empty;
+    public DateTime? NewStartDate { get; set; }
+    public string? NewStartTime { get; set; }
+    public string? NewEndTime { get; set; }
+}

--- a/BookingsAssistant.Api/Models/MoveDatesRequest.cs
+++ b/BookingsAssistant.Api/Models/MoveDatesRequest.cs
@@ -1,0 +1,6 @@
+namespace BookingsAssistant.Api.Models;
+
+public class MoveDatesRequest
+{
+    public int DayShift { get; set; }
+}

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -28,6 +28,9 @@ builder.Services.AddHttpClient<IOsmService, OsmService>();
 // Add linking service
 builder.Services.AddScoped<ILinkingService, LinkingService>();
 
+// Add booking mutation service (scoped — depends on IOsmService which is per-request via HttpClient)
+builder.Services.AddScoped<IBookingMutationService, BookingMutationService>();
+
 // Add hashing service (singleton — loaded once at startup with the secret)
 builder.Services.AddSingleton<IHashingService, HashingService>();
 

--- a/BookingsAssistant.Api/Services/BookingMutationService.cs
+++ b/BookingsAssistant.Api/Services/BookingMutationService.cs
@@ -149,11 +149,11 @@ public class BookingMutationService : IBookingMutationService
     {
         var original = replacement.Original;
 
-        // The item-type id lives in SiteId (sites) or ActivityId (activities); change-site
-        // swaps it for the target site.
-        var campsiteItemId = replacement.NewSiteId
-            ?? (original.Type == "activity" ? original.ActivityId : original.SiteId)
-            ?? string.Empty;
+        // The clone's item-type id: change-site substitutes the target site's type id;
+        // otherwise reuse whichever type field the original item carries (sites store it
+        // in SiteId, activities in ActivityId).
+        var originalTypeId = original.Type == "activity" ? original.ActivityId : original.SiteId;
+        var campsiteItemId = replacement.NewSiteId ?? originalTypeId ?? string.Empty;
 
         return new BookingItemCreateSpec
         {

--- a/BookingsAssistant.Api/Services/BookingMutationService.cs
+++ b/BookingsAssistant.Api/Services/BookingMutationService.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using BookingsAssistant.Api.Models;
 
 namespace BookingsAssistant.Api.Services;
@@ -38,8 +37,8 @@ public class BookingMutationService : IBookingMutationService
         {
             try
             {
-                var cloneJson = BuildCloneJson(replacement);
-                var newId = await _osmService.CreateBookingItemAsync(osmBookingId, cloneJson);
+                var spec = BuildCreateSpec(replacement);
+                var newId = await _osmService.CreateBookingItemAsync(osmBookingId, spec);
                 created.Add(newId);
                 _logger.LogInformation(
                     "ReplaceItemsAsync: created item {NewId} for booking {BookingId}",
@@ -141,33 +140,31 @@ public class BookingMutationService : IBookingMutationService
     }
 
     /// <summary>
-    /// Builds the clone JSON for a replacement by copying the original item and
-    /// applying any provided overrides.
-    ///
-    /// INTERIM CLONE REPRESENTATION: this serialises BookingItemDto with overrides.
-    /// The real raw-JSON-preserving clone (preserving unmapped OSM fields) is deferred
-    /// to the osm-payload-mapping chunk pending example response data.
+    /// Builds the create spec for a replacement: the original item's fields with any
+    /// overrides applied. The "site/activity id" is the OSM item-type id used to re-add
+    /// the item; change-site overrides it with the target site. Original question answers
+    /// (keyed by question-definition id) are carried through for replay onto the clone.
     /// </summary>
-    private static string BuildCloneJson(ItemReplacement replacement)
+    private static BookingItemCreateSpec BuildCreateSpec(ItemReplacement replacement)
     {
         var original = replacement.Original;
 
-        // Copy the original item — note ItemId is intentionally excluded from
-        // the clone payload (OSM will assign a new one on creation).
-        var clone = new BookingItemDto
+        // The item-type id lives in SiteId (sites) or ActivityId (activities); change-site
+        // swaps it for the target site.
+        var campsiteItemId = replacement.NewSiteId
+            ?? (original.Type == "activity" ? original.ActivityId : original.SiteId)
+            ?? string.Empty;
+
+        return new BookingItemCreateSpec
         {
-            ItemId = string.Empty,   // excluded from payload; OSM assigns on create
-            Type = original.Type,
-            SiteId = replacement.NewSiteId ?? original.SiteId,
-            ActivityId = original.ActivityId,
-            Label = original.Label,
+            CampsiteItemId = campsiteItemId,
             StartDate = replacement.NewStartDate ?? original.StartDate,
             EndDate = replacement.NewEndDate ?? original.EndDate,
             StartTime = replacement.NewStartTime ?? original.StartTime,
-            EndTime = replacement.NewEndTime ?? original.EndTime
+            EndTime = replacement.NewEndTime ?? original.EndTime,
+            NumberPeople = original.NumberPeople,
+            QuestionAnswers = original.Questions.ToDictionary(q => q.QuestionDefId, q => q.Answer)
         };
-
-        return JsonSerializer.Serialize(clone);
     }
 
     private async Task<List<BookingItemDto>> GetItemsSafeAsync(string osmBookingId)

--- a/BookingsAssistant.Api/Services/BookingMutationService.cs
+++ b/BookingsAssistant.Api/Services/BookingMutationService.cs
@@ -1,0 +1,187 @@
+using System.Text.Json;
+using BookingsAssistant.Api.Models;
+
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Orchestrates booking item mutations: clone → create-all → delete-all with rollback.
+///
+/// NOTE — interim clone representation:
+/// The clone payload is built from BookingItemDto (with overrides applied) serialised to JSON.
+/// This works for the orchestration and override logic tests. The real raw-JSON-preserving
+/// clone (which would preserve OSM-specific fields not in our DTO) will be wired up in the
+/// osm-payload-mapping chunk once example response data is available.
+/// </summary>
+public class BookingMutationService : IBookingMutationService
+{
+    private readonly IOsmService _osmService;
+    private readonly ILogger<BookingMutationService> _logger;
+
+    public BookingMutationService(IOsmService osmService, ILogger<BookingMutationService> logger)
+    {
+        _osmService = osmService;
+        _logger = logger;
+    }
+
+    public async Task<BookingActionResult> ReplaceItemsAsync(
+        string osmBookingId,
+        IReadOnlyList<ItemReplacement> replacements)
+    {
+        _logger.LogInformation(
+            "ReplaceItemsAsync: booking {BookingId}, {Count} replacement(s)",
+            osmBookingId, replacements.Count);
+
+        var created = new List<string>();
+
+        // ── PHASE 1: Create all clones ──────────────────────────────────────
+        foreach (var replacement in replacements)
+        {
+            try
+            {
+                var cloneJson = BuildCloneJson(replacement);
+                var newId = await _osmService.CreateBookingItemAsync(osmBookingId, cloneJson);
+                created.Add(newId);
+                _logger.LogInformation(
+                    "ReplaceItemsAsync: created item {NewId} for booking {BookingId}",
+                    newId, osmBookingId);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogError(ex,
+                    "ReplaceItemsAsync: create failed for booking {BookingId}; rolling back {Count} created item(s)",
+                    osmBookingId, created.Count);
+
+                // ROLLBACK: best-effort delete everything created so far
+                foreach (var rollbackId in created)
+                {
+                    try
+                    {
+                        await _osmService.DeleteBookingItemAsync(osmBookingId, rollbackId);
+                        _logger.LogInformation(
+                            "ReplaceItemsAsync: rollback deleted {ItemId} from booking {BookingId}",
+                            rollbackId, osmBookingId);
+                    }
+                    catch (Exception rbEx)
+                    {
+                        // Swallow rollback errors — log only
+                        _logger.LogWarning(rbEx,
+                            "ReplaceItemsAsync: rollback delete failed for item {ItemId} on booking {BookingId}",
+                            rollbackId, osmBookingId);
+                    }
+                }
+
+                // Best-effort: fetch the current item list after rollback
+                var itemsAfterRollback = await GetItemsSafeAsync(osmBookingId);
+
+                return new BookingActionResult
+                {
+                    Status = BookingActionStatus.RolledBack,
+                    Created = new List<string>(),
+                    Deleted = new List<string>(),
+                    Message = $"Create failed during replacement: {ex.Message}. Rolled back {created.Count} created item(s).",
+                    Items = itemsAfterRollback
+                };
+            }
+        }
+
+        // ── PHASE 2: Delete originals (only reached when all creates succeeded) ──
+        var deleted = new List<string>();
+        foreach (var replacement in replacements)
+        {
+            var originalId = replacement.Original.ItemId;
+            try
+            {
+                var success = await _osmService.DeleteBookingItemAsync(osmBookingId, originalId);
+                if (success)
+                {
+                    deleted.Add(originalId);
+                    _logger.LogInformation(
+                        "ReplaceItemsAsync: deleted original {ItemId} from booking {BookingId}",
+                        originalId, osmBookingId);
+                }
+                else
+                {
+                    _logger.LogWarning(
+                        "ReplaceItemsAsync: delete returned false for original {ItemId} on booking {BookingId}",
+                        originalId, osmBookingId);
+                }
+            }
+            catch (Exception ex)
+            {
+                // Swallow delete failures in phase 2 — they degrade to a warning
+                _logger.LogWarning(ex,
+                    "ReplaceItemsAsync: delete threw for original {ItemId} on booking {BookingId}",
+                    originalId, osmBookingId);
+            }
+        }
+
+        var allDeleted = deleted.Count == replacements.Count;
+        var status = allDeleted
+            ? BookingActionStatus.Completed
+            : BookingActionStatus.CompletedWithWarnings;
+
+        var message = allDeleted
+            ? $"Replaced {replacements.Count} item(s) successfully."
+            : $"Created {created.Count} item(s) but only deleted {deleted.Count} of {replacements.Count} originals.";
+
+        var freshItems = await GetItemsSafeAsync(osmBookingId);
+
+        _logger.LogInformation(
+            "ReplaceItemsAsync: {Status} for booking {BookingId} — created {C}, deleted {D}",
+            status, osmBookingId, created.Count, deleted.Count);
+
+        return new BookingActionResult
+        {
+            Status = status,
+            Created = created,
+            Deleted = deleted,
+            Message = message,
+            Items = freshItems
+        };
+    }
+
+    /// <summary>
+    /// Builds the clone JSON for a replacement by copying the original item and
+    /// applying any provided overrides.
+    ///
+    /// INTERIM CLONE REPRESENTATION: this serialises BookingItemDto with overrides.
+    /// The real raw-JSON-preserving clone (preserving unmapped OSM fields) is deferred
+    /// to the osm-payload-mapping chunk pending example response data.
+    /// </summary>
+    private static string BuildCloneJson(ItemReplacement replacement)
+    {
+        var original = replacement.Original;
+
+        // Copy the original item — note ItemId is intentionally excluded from
+        // the clone payload (OSM will assign a new one on creation).
+        var clone = new BookingItemDto
+        {
+            ItemId = string.Empty,   // excluded from payload; OSM assigns on create
+            Type = original.Type,
+            SiteId = replacement.NewSiteId ?? original.SiteId,
+            ActivityId = original.ActivityId,
+            Label = original.Label,
+            StartDate = replacement.NewStartDate ?? original.StartDate,
+            EndDate = replacement.NewEndDate ?? original.EndDate,
+            StartTime = replacement.NewStartTime ?? original.StartTime,
+            EndTime = replacement.NewEndTime ?? original.EndTime
+        };
+
+        return JsonSerializer.Serialize(clone);
+    }
+
+    private async Task<List<BookingItemDto>> GetItemsSafeAsync(string osmBookingId)
+    {
+        try
+        {
+            return await _osmService.GetBookingItemsAsync(osmBookingId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "ReplaceItemsAsync: could not fetch items after operation for booking {BookingId}",
+                osmBookingId);
+            return new List<BookingItemDto>();
+        }
+    }
+}

--- a/BookingsAssistant.Api/Services/IBookingMutationService.cs
+++ b/BookingsAssistant.Api/Services/IBookingMutationService.cs
@@ -1,0 +1,14 @@
+using BookingsAssistant.Api.Models;
+
+namespace BookingsAssistant.Api.Services;
+
+public interface IBookingMutationService
+{
+    /// <summary>
+    /// Replaces a set of booking items using clone → create-all → delete-all with rollback.
+    /// Phase 1: creates all clones. If any create fails, rolls back by deleting the created items.
+    /// Phase 2 (only if all creates succeeded): deletes the originals.
+    /// Returns a BookingActionResult describing what happened.
+    /// </summary>
+    Task<BookingActionResult> ReplaceItemsAsync(string osmBookingId, IReadOnlyList<ItemReplacement> replacements);
+}

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -22,6 +22,14 @@ public interface IOsmService
     /// </summary>
     Task<string?> GetBookingContactEmailAsync(string osmBookingId);
 
+    // Items
+    /// <summary>
+    /// Fetches the line-items (sites and activities) for a booking.
+    /// NOTE: OSM item parsing is a deferred seam — the implementation throws
+    /// NotImplementedException until real response data is available to wire it up.
+    /// </summary>
+    Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId);
+
     // Auth
     string GetAuthorizationUrl(string redirectUri);
     Task<bool> HandleOAuthCallbackAsync(string code, int userId, string redirectUri);

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -30,6 +30,22 @@ public interface IOsmService
     /// </summary>
     Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId);
 
+    /// <summary>
+    /// Creates a new booking item by cloning the provided JSON payload.
+    /// Returns the new item id assigned by OSM.
+    /// NOTE: DEFERRED SEAM — real implementation pending example OSM request/response data.
+    /// The real OsmService throws NotImplementedException("... pending example data").
+    /// </summary>
+    Task<string> CreateBookingItemAsync(string osmBookingId, string cloneJson);
+
+    /// <summary>
+    /// Deletes the specified booking item.
+    /// Returns true on success, false on failure.
+    /// NOTE: DEFERRED SEAM — real implementation pending example OSM request/response data.
+    /// The real OsmService throws NotImplementedException("... pending example data").
+    /// </summary>
+    Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId);
+
     // Auth
     string GetAuthorizationUrl(string redirectUri);
     Task<bool> HandleOAuthCallbackAsync(string code, int userId, string redirectUri);

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -24,25 +24,20 @@ public interface IOsmService
 
     // Items
     /// <summary>
-    /// Fetches the line-items (sites and activities) for a booking.
-    /// NOTE: OSM item parsing is a deferred seam — the implementation throws
-    /// NotImplementedException until real response data is available to wire it up.
+    /// Fetches the line-items (sites and activities) for a booking from the OSM
+    /// booking-detail resource.
     /// </summary>
     Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId);
 
     /// <summary>
-    /// Creates a new booking item by cloning the provided JSON payload.
-    /// Returns the new item id assigned by OSM.
-    /// NOTE: DEFERRED SEAM — real implementation pending example OSM request/response data.
-    /// The real OsmService throws NotImplementedException("... pending example data").
+    /// Creates a new booking item from the given spec (an existing item with overrides
+    /// applied). The adapter resolves the OSM availability slot, posts the addItem form,
+    /// and replays the original item's question answers. Returns the new item id.
     /// </summary>
-    Task<string> CreateBookingItemAsync(string osmBookingId, string cloneJson);
+    Task<string> CreateBookingItemAsync(string osmBookingId, BookingItemCreateSpec spec);
 
     /// <summary>
-    /// Deletes the specified booking item.
-    /// Returns true on success, false on failure.
-    /// NOTE: DEFERRED SEAM — real implementation pending example OSM request/response data.
-    /// The real OsmService throws NotImplementedException("... pending example data").
+    /// Deletes the specified booking item. Returns true on success, false on failure.
     /// </summary>
     Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId);
 

--- a/BookingsAssistant.Api/Services/OsmItemQuestion.cs
+++ b/BookingsAssistant.Api/Services/OsmItemQuestion.cs
@@ -1,0 +1,9 @@
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// A question-answer row as returned by OSM's per-item questions endpoint
+/// (GET /v3/campsites/bookings/items/{itemId}/questions). <see cref="RowId"/> is the
+/// per-item answer row (used when POSTing answers back); <see cref="QuestionDefId"/> is
+/// the stable question definition (used to match answers across original ↔ clone).
+/// </summary>
+public record OsmItemQuestion(int RowId, int QuestionDefId, string Answer);

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -353,7 +353,10 @@ internal class OsmService : IOsmService
 
     public async Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
     {
-        var url = $"/v3/campsites/{_campsiteId}/items?booking_id={osmBookingId}&mode=booking&audience=venue";
+        // Booked items live on the booking-detail resource, NOT the /items catalogue
+        // endpoint (which lists bookable item-types). Confirmed from captured OSM data
+        // (see BookingsAssistant.Tests/Fixtures/OsmItems/README.md).
+        var url = $"/v3/campsites/bookings/{osmBookingId}";
 
         _logger.LogInformation("Fetching OSM items for booking {BookingId}", osmBookingId);
 
@@ -377,12 +380,100 @@ internal class OsmService : IOsmService
         }
 
         var content = await response.Content.ReadAsStringAsync();
-
-        // DEFERRED SEAM: parsing the real OSM items response into BookingItemDto is
-        // pending example data from a live response. Do not implement until the
-        // shape is confirmed. The controller maps this to HTTP 501.
-        throw new NotImplementedException("OSM item parsing not yet wired — pending example data");
+        return ParseBookingItems(content);
     }
+
+    /// <summary>
+    /// Parses an OSM booking-detail response (<c>GET /v3/campsites/bookings/{id}</c>)
+    /// into our booked-item DTOs. Pure/static so it can be unit-tested against captured
+    /// fixtures (see OsmServiceItemParsingTests). Returns an empty list for blank input,
+    /// a non-success status, or a missing/empty items array.
+    /// </summary>
+    internal static List<BookingItemDto> ParseBookingItems(string? json)
+    {
+        var items = new List<BookingItemDto>();
+        if (string.IsNullOrWhiteSpace(json))
+            return items;
+
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("status", out var status) &&
+            status.ValueKind == JsonValueKind.False)
+            return items;
+
+        if (!root.TryGetProperty("data", out var data) ||
+            data.ValueKind != JsonValueKind.Object ||
+            !data.TryGetProperty("items", out var itemsEl) ||
+            itemsEl.ValueKind != JsonValueKind.Array)
+            return items;
+
+        foreach (var item in itemsEl.EnumerateArray())
+            items.Add(MapBookingItem(item));
+
+        return items;
+    }
+
+    private static BookingItemDto MapBookingItem(JsonElement item)
+    {
+        var (startDate, startTime) = SplitTimestamp(GetString(item, "start_timestamp"));
+        var (endDate, endTime) = SplitTimestamp(GetString(item, "end_timestamp"));
+
+        // Site vs activity: activities carry an instructor type / required instructors;
+        // sites/pitches have neither. (The "ACTIVITY - " name prefix is cosmetic only.)
+        var isActivity = GetInt(item, "campsite_instructor_type_id") > 0 ||
+                         GetInt(item, "number_instructors_required") > 0;
+
+        // campsite_item_id is the item-TYPE id (e.g. 1387 Hayvern, 4961 Air Rifle) —
+        // the id used in the addItem URL when cloning.
+        var typeId = GetString(item, "campsite_item_id");
+
+        var label = item.TryGetProperty("item", out var nested) &&
+                    nested.ValueKind == JsonValueKind.Object
+            ? GetString(nested, "name") ?? string.Empty
+            : string.Empty;
+
+        return new BookingItemDto
+        {
+            ItemId = GetString(item, "id") ?? string.Empty,   // booked-item id (for delete)
+            Type = isActivity ? "activity" : "site",
+            SiteId = isActivity ? null : typeId,
+            ActivityId = isActivity ? typeId : null,
+            StartDate = startDate,
+            EndDate = endDate,
+            StartTime = startTime,
+            EndTime = endTime,
+            NumberPeople = item.TryGetProperty("number_people", out var np) &&
+                           np.TryGetInt32(out var npVal) ? npVal : null,
+            Label = label
+        };
+    }
+
+    /// <summary>Splits an OSM "yyyy-MM-dd HH:mm:ss" timestamp into a date and an "HH:mm" time.</summary>
+    private static (DateTime? Date, string? Time) SplitTimestamp(string? timestamp)
+    {
+        if (string.IsNullOrWhiteSpace(timestamp))
+            return (null, null);
+
+        var parts = timestamp.Split(' ', 2);
+        DateTime? date = DateTime.TryParse(parts[0], out var d) ? d.Date : null;
+        string? time = parts.Length > 1 && parts[1].Length >= 5 ? parts[1][..5] : null;
+        return (date, time);
+    }
+
+    private static string? GetString(JsonElement el, string name)
+    {
+        if (!el.TryGetProperty(name, out var prop)) return null;
+        return prop.ValueKind switch
+        {
+            JsonValueKind.String => prop.GetString(),
+            JsonValueKind.Number => prop.ToString(),
+            _ => null
+        };
+    }
+
+    private static int GetInt(JsonElement el, string name)
+        => el.TryGetProperty(name, out var prop) && prop.TryGetInt32(out var v) ? v : 0;
 
     private async Task<string?> GetBookingMemberIdAsync(string osmBookingId)
     {

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -337,6 +337,20 @@ internal class OsmService : IOsmService
         }
     }
 
+    public Task<string> CreateBookingItemAsync(string osmBookingId, string cloneJson)
+    {
+        // DEFERRED SEAM: creating an OSM booking item is pending example request/response
+        // data to confirm the endpoint URL and payload shape.
+        throw new NotImplementedException("OSM CreateBookingItem not yet wired — pending example data");
+    }
+
+    public Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId)
+    {
+        // DEFERRED SEAM: deleting an OSM booking item is pending example request/response
+        // data to confirm the endpoint URL and payload shape.
+        throw new NotImplementedException("OSM DeleteBookingItem not yet wired — pending example data");
+    }
+
     public async Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
     {
         var url = $"/v3/campsites/{_campsiteId}/items?booking_id={osmBookingId}&mode=booking&audience=venue";

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -337,6 +337,39 @@ internal class OsmService : IOsmService
         }
     }
 
+    public async Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
+    {
+        var url = $"/v3/campsites/{_campsiteId}/items?booking_id={osmBookingId}&mode=booking&audience=venue";
+
+        _logger.LogInformation("Fetching OSM items for booking {BookingId}", osmBookingId);
+
+        var response = await SendWithRateLimitAsync(async () =>
+        {
+            var token = await GetAccessTokenAsync();
+            var req = new HttpRequestMessage(HttpMethod.Get, url);
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            return req;
+        });
+
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogError("OSM items endpoint returned {StatusCode} for booking {BookingId}",
+                response.StatusCode, osmBookingId);
+
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                throw new InvalidOperationException($"OSM authentication failed fetching items for booking {osmBookingId}");
+
+            return new List<BookingItemDto>();
+        }
+
+        var content = await response.Content.ReadAsStringAsync();
+
+        // DEFERRED SEAM: parsing the real OSM items response into BookingItemDto is
+        // pending example data from a live response. Do not implement until the
+        // shape is confirmed. The controller maps this to HTTP 501.
+        throw new NotImplementedException("OSM item parsing not yet wired — pending example data");
+    }
+
     private async Task<string?> GetBookingMemberIdAsync(string osmBookingId)
     {
         var response = await SendWithRateLimitAsync(async () =>

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -349,7 +349,7 @@ internal class OsmService : IOsmService
         var availUrl = $"/v3/campsites/items/{Uri.EscapeDataString(spec.CampsiteItemId)}/availability?booking_id={Uri.EscapeDataString(osmBookingId)}";
         var availResponse = await SendAuthorizedAsync(HttpMethod.Get, availUrl, null);
         if (!availResponse.IsSuccessStatusCode)
-            throw await BuildOsmExceptionAsync(availResponse, $"fetching availability for item {spec.CampsiteItemId}");
+            throw await CreateOsmExceptionAsync(availResponse, $"fetching availability for item {spec.CampsiteItemId}");
 
         var availJson = await availResponse.Content.ReadAsStringAsync();
         var slotId = ResolveSlotId(availJson, spec.StartDate.Value, spec.EndDate.Value)
@@ -362,7 +362,7 @@ internal class OsmService : IOsmService
         var createResponse = await SendAuthorizedAsync(HttpMethod.Post, createUrl,
             () => new FormUrlEncodedContent(form));
         if (!createResponse.IsSuccessStatusCode)
-            throw await BuildOsmExceptionAsync(createResponse, $"creating item {spec.CampsiteItemId} for booking {osmBookingId}");
+            throw await CreateOsmExceptionAsync(createResponse, $"creating item {spec.CampsiteItemId} for booking {osmBookingId}");
 
         var createJson = await createResponse.Content.ReadAsStringAsync();
         var newItemId = ParseCreatedItemId(createJson);
@@ -430,7 +430,7 @@ internal class OsmService : IOsmService
             return req;
         });
 
-    private async Task<Exception> BuildOsmExceptionAsync(HttpResponseMessage response, string context)
+    private async Task<Exception> CreateOsmExceptionAsync(HttpResponseMessage response, string context)
     {
         if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
             return new InvalidOperationException($"OSM authentication failed {context}");
@@ -453,13 +453,17 @@ internal class OsmService : IOsmService
 
         foreach (var slot in data.EnumerateArray())
         {
+            // OSM marks booked-out slots with available:false; an absent flag counts as
+            // available. ("available_until" is a separate deadline field, not this flag.)
             if (slot.TryGetProperty("available", out var avail) && avail.ValueKind == JsonValueKind.False)
                 continue;
 
+            // Slots are matched on date span only; the exact times within the window are
+            // flexible and supplied separately in the create form.
             var (slotStart, _) = SplitTimestamp(GetString(slot, "start"));
             var (slotEnd, _) = SplitTimestamp(GetString(slot, "end"));
             if (slotStart == startDate.Date && slotEnd == endDate.Date)
-                return GetString(slot, "id");
+                return GetString(slot, "id");   // first slot matching the date span
         }
 
         return null;
@@ -543,7 +547,7 @@ internal class OsmService : IOsmService
         // Booked items live on the booking-detail resource, NOT the /items catalogue
         // endpoint (which lists bookable item-types). Confirmed from captured OSM data
         // (see BookingsAssistant.Tests/Fixtures/OsmItems/README.md).
-        var url = $"/v3/campsites/bookings/{osmBookingId}";
+        var url = $"/v3/campsites/bookings/{Uri.EscapeDataString(osmBookingId)}";
 
         _logger.LogInformation("Fetching OSM items for booking {BookingId}", osmBookingId);
 
@@ -650,7 +654,7 @@ internal class OsmService : IOsmService
         return list;
     }
 
-    /// <summary>Splits an OSM "yyyy-MM-dd HH:mm:ss" timestamp into a date and an "HH:mm" time.</summary>
+    /// <summary>Splits an OSM "yyyy-MM-dd HH:mm:ss" timestamp into a date and the "HH:mm" portion of the time.</summary>
     private static (DateTime? Date, string? Time) SplitTimestamp(string? timestamp)
     {
         if (string.IsNullOrWhiteSpace(timestamp))

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -337,18 +337,205 @@ internal class OsmService : IOsmService
         }
     }
 
-    public Task<string> CreateBookingItemAsync(string osmBookingId, string cloneJson)
+    public async Task<string> CreateBookingItemAsync(string osmBookingId, BookingItemCreateSpec spec)
     {
-        // DEFERRED SEAM: creating an OSM booking item is pending example request/response
-        // data to confirm the endpoint URL and payload shape.
-        throw new NotImplementedException("OSM CreateBookingItem not yet wired — pending example data");
+        if (spec.StartDate is null || spec.EndDate is null)
+            throw new InvalidOperationException(
+                $"Cannot create OSM item {spec.CampsiteItemId} for booking {osmBookingId} without start/end dates");
+
+        // 1. Resolve the availability slot for the requested date window. OSM's addItem
+        //    requires a slot_id, which is NOT a property of the item — it's looked up from
+        //    the item-type's availability for this booking.
+        var availUrl = $"/v3/campsites/items/{Uri.EscapeDataString(spec.CampsiteItemId)}/availability?booking_id={Uri.EscapeDataString(osmBookingId)}";
+        var availResponse = await SendAuthorizedAsync(HttpMethod.Get, availUrl, null);
+        if (!availResponse.IsSuccessStatusCode)
+            throw await BuildOsmExceptionAsync(availResponse, $"fetching availability for item {spec.CampsiteItemId}");
+
+        var availJson = await availResponse.Content.ReadAsStringAsync();
+        var slotId = ResolveSlotId(availJson, spec.StartDate.Value, spec.EndDate.Value)
+            ?? throw new InvalidOperationException(
+                $"No available OSM slot for item {spec.CampsiteItemId} on {spec.StartDate:yyyy-MM-dd}..{spec.EndDate:yyyy-MM-dd}");
+
+        // 2. Create (add) the item.
+        var createUrl = $"/v3/campsites/bookings/{Uri.EscapeDataString(osmBookingId)}/addItem/{Uri.EscapeDataString(spec.CampsiteItemId)}";
+        var form = BuildCreateForm(spec, slotId);
+        var createResponse = await SendAuthorizedAsync(HttpMethod.Post, createUrl,
+            () => new FormUrlEncodedContent(form));
+        if (!createResponse.IsSuccessStatusCode)
+            throw await BuildOsmExceptionAsync(createResponse, $"creating item {spec.CampsiteItemId} for booking {osmBookingId}");
+
+        var createJson = await createResponse.Content.ReadAsStringAsync();
+        var newItemId = ParseCreatedItemId(createJson);
+        _logger.LogInformation("Created OSM item {NewItemId} on booking {BookingId}", newItemId, osmBookingId);
+
+        // 3. Replay the original item's question answers onto the clone (best-effort —
+        //    OSM creates blank question rows on add, and the clone's row ids differ from
+        //    the original's, so we match on the stable question-definition id).
+        if (spec.QuestionAnswers.Count > 0)
+            await ReplayQuestionAnswersAsync(newItemId, spec.QuestionAnswers);
+
+        return newItemId;
     }
 
-    public Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId)
+    public async Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId)
     {
-        // DEFERRED SEAM: deleting an OSM booking item is pending example request/response
-        // data to confirm the endpoint URL and payload shape.
-        throw new NotImplementedException("OSM DeleteBookingItem not yet wired — pending example data");
+        var url = $"/v3/campsites/bookings/items/{Uri.EscapeDataString(itemId)}/delete";
+        var response = await SendAuthorizedAsync(HttpMethod.Post, url, null);
+        if (!response.IsSuccessStatusCode)
+        {
+            _logger.LogWarning("OSM delete returned {StatusCode} for item {ItemId}", response.StatusCode, itemId);
+            return false;
+        }
+
+        var json = await response.Content.ReadAsStringAsync();
+        return ParseDeleteSucceeded(json);
+    }
+
+    private async Task ReplayQuestionAnswersAsync(string itemId, IReadOnlyDictionary<int, string> answersByDefId)
+    {
+        try
+        {
+            var url = $"/v3/campsites/bookings/items/{Uri.EscapeDataString(itemId)}/questions";
+            var getResponse = await SendAuthorizedAsync(HttpMethod.Get, url, null);
+            if (!getResponse.IsSuccessStatusCode)
+            {
+                _logger.LogWarning("Could not fetch questions for cloned item {ItemId}; answers not replayed", itemId);
+                return;
+            }
+
+            var cloneQuestions = ParseItemQuestions(await getResponse.Content.ReadAsStringAsync());
+            var answersJson = BuildAnswersJson(answersByDefId, cloneQuestions);
+            if (answersJson == "[]") return;   // nothing to replay
+
+            var postResponse = await SendAuthorizedAsync(HttpMethod.Post, url,
+                () => new FormUrlEncodedContent(new Dictionary<string, string> { ["answers"] = answersJson }));
+            if (!postResponse.IsSuccessStatusCode)
+                _logger.LogWarning("Replaying answers to cloned item {ItemId} returned {StatusCode}", itemId, postResponse.StatusCode);
+        }
+        catch (Exception ex)
+        {
+            // Answer replay is best-effort: a failure here must not fail the whole mutation.
+            _logger.LogWarning(ex, "Failed to replay question answers to cloned item {ItemId}", itemId);
+        }
+    }
+
+    private Task<HttpResponseMessage> SendAuthorizedAsync(
+        HttpMethod method, string url, Func<HttpContent>? contentFactory)
+        => SendWithRateLimitAsync(async () =>
+        {
+            var token = await GetAccessTokenAsync();
+            var req = new HttpRequestMessage(method, url);
+            req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
+            if (contentFactory != null) req.Content = contentFactory();   // fresh content per attempt
+            return req;
+        });
+
+    private async Task<Exception> BuildOsmExceptionAsync(HttpResponseMessage response, string context)
+    {
+        if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+            return new InvalidOperationException($"OSM authentication failed {context}");
+        var body = await response.Content.ReadAsStringAsync();
+        return new InvalidOperationException($"OSM error {(int)response.StatusCode} {context}: {body}");
+    }
+
+    /// <summary>
+    /// Finds the availability slot id whose date window matches the requested start/end
+    /// dates (times within the slot are flexible and supplied separately). Returns null
+    /// when no available slot covers the window.
+    /// </summary>
+    internal static string? ResolveSlotId(string? availabilityJson, DateTime startDate, DateTime endDate)
+    {
+        if (string.IsNullOrWhiteSpace(availabilityJson)) return null;
+
+        using var doc = JsonDocument.Parse(availabilityJson);
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
+            return null;
+
+        foreach (var slot in data.EnumerateArray())
+        {
+            if (slot.TryGetProperty("available", out var avail) && avail.ValueKind == JsonValueKind.False)
+                continue;
+
+            var (slotStart, _) = SplitTimestamp(GetString(slot, "start"));
+            var (slotEnd, _) = SplitTimestamp(GetString(slot, "end"));
+            if (slotStart == startDate.Date && slotEnd == endDate.Date)
+                return GetString(slot, "id");
+        }
+
+        return null;
+    }
+
+    /// <summary>Builds the OSM addItem form fields from a create spec and resolved slot id.</summary>
+    internal static Dictionary<string, string> BuildCreateForm(BookingItemCreateSpec spec, string slotId)
+        => new()
+        {
+            ["slot_id"] = slotId,
+            ["start"] = spec.StartDate?.ToString("yyyy-MM-dd") ?? string.Empty,
+            ["end"] = spec.EndDate?.ToString("yyyy-MM-dd") ?? string.Empty,
+            ["number_people"] = spec.NumberPeople?.ToString() ?? string.Empty,
+            ["start_time"] = spec.StartTime ?? string.Empty,
+            ["end_time"] = spec.EndTime ?? string.Empty
+        };
+
+    /// <summary>Reads the new booked-item id from an addItem response; throws if OSM rejected the create.</summary>
+    internal static string ParseCreatedItemId(string json)
+    {
+        using var doc = JsonDocument.Parse(json);
+        var root = doc.RootElement;
+
+        if (root.TryGetProperty("status", out var status) && status.ValueKind == JsonValueKind.False)
+            throw new InvalidOperationException($"OSM rejected item creation: {GetString(root, "error") ?? "unknown error"}");
+
+        if (root.TryGetProperty("data", out var data) && data.ValueKind == JsonValueKind.Object &&
+            data.TryGetProperty("id", out var id))
+            return id.ValueKind == JsonValueKind.Number ? id.GetInt64().ToString() : id.GetString() ?? string.Empty;
+
+        throw new InvalidOperationException("OSM create response missing data.id");
+    }
+
+    /// <summary>True when an OSM delete response reports success.</summary>
+    internal static bool ParseDeleteSucceeded(string? json)
+    {
+        if (string.IsNullOrWhiteSpace(json)) return false;
+        using var doc = JsonDocument.Parse(json);
+        return doc.RootElement.TryGetProperty("status", out var status) &&
+               status.ValueKind == JsonValueKind.True;
+    }
+
+    /// <summary>Parses an OSM per-item questions response into row/definition/answer triples.</summary>
+    internal static List<OsmItemQuestion> ParseItemQuestions(string? json)
+    {
+        var result = new List<OsmItemQuestion>();
+        if (string.IsNullOrWhiteSpace(json)) return result;
+
+        using var doc = JsonDocument.Parse(json);
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Object)
+            return result;
+        if (!data.TryGetProperty("questions", out var questions) || questions.ValueKind != JsonValueKind.Array)
+            return result;
+
+        foreach (var q in questions.EnumerateArray())
+            result.Add(new OsmItemQuestion(
+                GetInt(q, "id"),
+                GetInt(q, "campsite_booking_question_id"),
+                GetString(q, "answer") ?? string.Empty));
+
+        return result;
+    }
+
+    /// <summary>
+    /// Builds the OSM questions-POST payload (a JSON array of {id, answer}) by mapping the
+    /// original answers (keyed by question-definition id) onto the clone's answer-row ids.
+    /// Only questions with a non-empty original answer are included.
+    /// </summary>
+    internal static string BuildAnswersJson(
+        IReadOnlyDictionary<int, string> answersByDefId, IEnumerable<OsmItemQuestion> cloneQuestions)
+    {
+        var payload = cloneQuestions
+            .Where(q => answersByDefId.TryGetValue(q.QuestionDefId, out var a) && !string.IsNullOrEmpty(a))
+            .Select(q => new { id = q.RowId, answer = answersByDefId[q.QuestionDefId] })
+            .ToList();
+        return JsonSerializer.Serialize(payload);
     }
 
     public async Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
@@ -445,8 +632,22 @@ internal class OsmService : IOsmService
             EndTime = endTime,
             NumberPeople = item.TryGetProperty("number_people", out var np) &&
                            np.TryGetInt32(out var npVal) ? npVal : null,
-            Label = label
+            Label = label,
+            Questions = ParseBookingQuestions(item)
         };
+    }
+
+    private static List<BookingItemQuestion> ParseBookingQuestions(JsonElement item)
+    {
+        var list = new List<BookingItemQuestion>();
+        if (item.TryGetProperty("booking_questions", out var bq) && bq.ValueKind == JsonValueKind.Array)
+            foreach (var q in bq.EnumerateArray())
+                list.Add(new BookingItemQuestion
+                {
+                    QuestionDefId = GetInt(q, "campsite_booking_question_id"),
+                    Answer = GetString(q, "answer") ?? string.Empty
+                });
+        return list;
     }
 
     /// <summary>Splits an OSM "yyyy-MM-dd HH:mm:ss" timestamp into a date and an "HH:mm" time.</summary>

--- a/BookingsAssistant.Tests/BookingsAssistant.Tests.csproj
+++ b/BookingsAssistant.Tests/BookingsAssistant.Tests.csproj
@@ -24,4 +24,9 @@
     <ProjectReference Include="..\BookingsAssistant.Api\BookingsAssistant.Api.csproj" />
   </ItemGroup>
 
+  <ItemGroup>
+    <!-- Captured OSM request/response samples used as parser fixtures (see Fixtures/OsmItems/README.md) -->
+    <Content Include="Fixtures\**\*.json" CopyToOutputDirectory="PreserveNewest" />
+  </ItemGroup>
+
 </Project>

--- a/BookingsAssistant.Tests/Controllers/BookingActionsItemsTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsItemsTests.cs
@@ -1,0 +1,144 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class BookingActionsItemsTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsItemsTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_BookingActionsItems_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GetItems_Returns200WithItemsList_WhenBookingExists()
+    {
+        int bookingId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var booking = new OsmBooking
+            {
+                OsmBookingId = "77001",
+                CustomerName = "Scout Group Items",
+                StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+                Status = "Provisional"
+            };
+            db.OsmBookings.Add(booking);
+            await db.SaveChangesAsync();
+            bookingId = booking.Id;
+        }
+
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>
+        {
+            new BookingItemDto
+            {
+                ItemId = "item-001",
+                Type = "site",
+                SiteId = "site-42",
+                Label = "Pitch A",
+                StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc)
+            },
+            new BookingItemDto
+            {
+                ItemId = "item-002",
+                Type = "activity",
+                ActivityId = "act-10",
+                Label = "Archery Session",
+                StartDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+                StartTime = "10:00",
+                EndTime = "12:00"
+            }
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/bookings/{bookingId}/items");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var items = await response.Content.ReadFromJsonAsync<List<BookingItemDto>>();
+        Assert.NotNull(items);
+        Assert.Equal(2, items.Count);
+        Assert.Equal("item-001", items[0].ItemId);
+        Assert.Equal("site", items[0].Type);
+        Assert.Equal("Pitch A", items[0].Label);
+        Assert.Equal("item-002", items[1].ItemId);
+        Assert.Equal("activity", items[1].Type);
+        Assert.Equal("Archery Session", items[1].Label);
+    }
+
+    [Fact]
+    public async Task GetItems_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/bookings/999999/items");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetItems_Returns501_WhenOsmParseNotImplemented()
+    {
+        int bookingId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var booking = new OsmBooking
+            {
+                OsmBookingId = "77002",
+                CustomerName = "Scout Group Unimplemented",
+                StartDate = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc),
+                Status = "Provisional"
+            };
+            db.OsmBookings.Add(booking);
+            await db.SaveChangesAsync();
+            bookingId = booking.Id;
+        }
+
+        _fakeOsm.ThrowNotImplementedForItems = true;
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/bookings/{bookingId}/items");
+
+        Assert.Equal(HttpStatusCode.NotImplemented, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/BookingActionsItemsTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsItemsTests.cs
@@ -114,7 +114,7 @@ public class BookingActionsItemsTests : IClassFixture<WebApplicationFactory<Prog
     }
 
     [Fact]
-    public async Task GetItems_Returns501_WhenOsmParseNotImplemented()
+    public async Task GetItems_Returns200WithEmptyList_WhenBookingHasNoItems()
     {
         int bookingId;
 
@@ -124,7 +124,7 @@ public class BookingActionsItemsTests : IClassFixture<WebApplicationFactory<Prog
             var booking = new OsmBooking
             {
                 OsmBookingId = "77002",
-                CustomerName = "Scout Group Unimplemented",
+                CustomerName = "Scout Group Empty",
                 StartDate = new DateTime(2026, 9, 1, 0, 0, 0, DateTimeKind.Utc),
                 EndDate = new DateTime(2026, 9, 3, 0, 0, 0, DateTimeKind.Utc),
                 Status = "Provisional"
@@ -134,11 +134,14 @@ public class BookingActionsItemsTests : IClassFixture<WebApplicationFactory<Prog
             bookingId = booking.Id;
         }
 
-        _fakeOsm.ThrowNotImplementedForItems = true;
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>();
 
         var client = _factory.CreateClient();
         var response = await client.GetAsync($"/api/bookings/{bookingId}/items");
 
-        Assert.Equal(HttpStatusCode.NotImplemented, response.StatusCode);
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var items = await response.Content.ReadFromJsonAsync<List<BookingItemDto>>();
+        Assert.NotNull(items);
+        Assert.Empty(items);
     }
 }

--- a/BookingsAssistant.Tests/Controllers/BookingActionsTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsTests.cs
@@ -115,7 +115,7 @@ public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
-    public async Task MoveActivity_OverridesReachEngine_ViaCloneJson()
+    public async Task MoveActivity_OverridesReachEngine_ViaSpec()
     {
         var bookingId = await SeedBookingAsync("99011");
         _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
@@ -131,12 +131,10 @@ public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
                 NewEndTime = "11:00"
             });
 
-        Assert.Single(_fakeOsm.CapturedCloneJsons);
-        var cloneJson = _fakeOsm.CapturedCloneJsons[0];
-        Assert.Contains("09:00", cloneJson);
-        Assert.Contains("11:00", cloneJson);
-        // The shifted start date should appear in the serialised clone
-        Assert.Contains("2026-08-03", cloneJson);
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
+        Assert.Equal("09:00", spec.StartTime);
+        Assert.Equal("11:00", spec.EndTime);
+        Assert.Equal(new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc), spec.StartDate);
     }
 
     [Fact]
@@ -204,9 +202,9 @@ public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Contains("site-item-new", result.Created);
         Assert.Contains("site-item-1", result.Deleted);
 
-        // Clone JSON should contain the new site id
-        Assert.Single(_fakeOsm.CapturedCloneJsons);
-        Assert.Contains("site-99", _fakeOsm.CapturedCloneJsons[0]);
+        // The new site id becomes the clone's item-type id
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
+        Assert.Equal("site-99", spec.CampsiteItemId);
     }
 
     [Fact]
@@ -311,10 +309,10 @@ public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal(BookingActionStatus.Completed, result.Status);
 
         // One create per item
-        Assert.Equal(3, _fakeOsm.CapturedCloneJsons.Count);
+        Assert.Equal(3, _fakeOsm.CapturedSpecs.Count);
 
         // Dates should be shifted by 7 days — site-item-1 starts 2026-08-01, shifted to 2026-08-08
-        Assert.Contains("2026-08-08", _fakeOsm.CapturedCloneJsons[0]);
+        Assert.Equal(new DateTime(2026, 8, 8, 0, 0, 0, DateTimeKind.Utc), _fakeOsm.CapturedSpecs[0].StartDate);
     }
 
     [Fact]
@@ -339,13 +337,12 @@ public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
             $"/api/bookings/{bookingId}/actions/move-dates",
             new MoveDatesRequest { DayShift = 3 });
 
-        Assert.Single(_fakeOsm.CapturedCloneJsons);
-        var cloneJson = _fakeOsm.CapturedCloneJsons[0];
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
         // Date shifted: 2026-08-02 + 3 days = 2026-08-05
-        Assert.Contains("2026-08-05", cloneJson);
+        Assert.Equal(new DateTime(2026, 8, 5, 0, 0, 0, DateTimeKind.Utc), spec.StartDate);
         // Times preserved
-        Assert.Contains("10:00", cloneJson);
-        Assert.Contains("12:00", cloneJson);
+        Assert.Equal("10:00", spec.StartTime);
+        Assert.Equal("12:00", spec.EndTime);
     }
 
     [Fact]
@@ -383,16 +380,14 @@ public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
 
         // Fan-out: one replacement per item regardless of whether it has dates
-        Assert.Equal(2, _fakeOsm.CapturedCloneJsons.Count);
+        Assert.Equal(2, _fakeOsm.CapturedSpecs.Count);
 
         // Dated item clone: start date shifted from 2026-08-01 by 7 days → 2026-08-08
-        var datedCloneJson = _fakeOsm.CapturedCloneJsons[0];
-        Assert.Contains("2026-08-08", datedCloneJson);
+        Assert.Equal(new DateTime(2026, 8, 8, 0, 0, 0, DateTimeKind.Utc), _fakeOsm.CapturedSpecs[0].StartDate);
 
-        // Dateless item clone: no date override — null dates are not shifted,
-        // so the clone JSON must NOT contain any date value
-        var datelessCloneJson = _fakeOsm.CapturedCloneJsons[1];
-        Assert.DoesNotContain("2026-08", datelessCloneJson);
+        // Dateless item clone: null dates are not shifted, so they remain null
+        Assert.Null(_fakeOsm.CapturedSpecs[1].StartDate);
+        Assert.Null(_fakeOsm.CapturedSpecs[1].EndDate);
     }
 
     // ── Status propagation ────────────────────────────────────────────────────

--- a/BookingsAssistant.Tests/Controllers/BookingActionsTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsTests.cs
@@ -1,0 +1,466 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class BookingActionsTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_BookingActions_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<int> SeedBookingAsync(string osmBookingId = "99001")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var booking = new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "Test Group",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Provisional"
+        };
+        db.OsmBookings.Add(booking);
+        await db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    private static BookingItemDto MakeActivityItem(string itemId = "act-item-1") => new()
+    {
+        ItemId = itemId,
+        Type = "activity",
+        ActivityId = "act-10",
+        Label = "Archery Session",
+        StartDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+        StartTime = "10:00",
+        EndTime = "12:00"
+    };
+
+    private static BookingItemDto MakeSiteItem(string itemId = "site-item-1") => new()
+    {
+        ItemId = itemId,
+        Type = "site",
+        SiteId = "site-42",
+        Label = "Pitch A",
+        StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    // ── move-activity ─────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MoveActivity_Returns200WithCompletedResult_WhenHappyPath()
+    {
+        var bookingId = await SeedBookingAsync("99010");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.CreatedItemIds = new List<string> { "act-item-new" };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-activity",
+            new MoveActivityRequest
+            {
+                ItemId = "act-item-1",
+                NewStartTime = "14:00",
+                NewEndTime = "16:00"
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Contains("act-item-new", result.Created);
+        Assert.Contains("act-item-1", result.Deleted);
+    }
+
+    [Fact]
+    public async Task MoveActivity_OverridesReachEngine_ViaCloneJson()
+    {
+        var bookingId = await SeedBookingAsync("99011");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-activity",
+            new MoveActivityRequest
+            {
+                ItemId = "act-item-1",
+                NewStartDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+                NewStartTime = "09:00",
+                NewEndTime = "11:00"
+            });
+
+        Assert.Single(_fakeOsm.CapturedCloneJsons);
+        var cloneJson = _fakeOsm.CapturedCloneJsons[0];
+        Assert.Contains("09:00", cloneJson);
+        Assert.Contains("11:00", cloneJson);
+        // The shifted start date should appear in the serialised clone
+        Assert.Contains("2026-08-03", cloneJson);
+    }
+
+    [Fact]
+    public async Task MoveActivity_Returns400_WhenItemIdMissing()
+    {
+        var bookingId = await SeedBookingAsync("99012");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-activity",
+            new MoveActivityRequest { ItemId = "" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MoveActivity_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/bookings/999999/actions/move-activity",
+            new MoveActivityRequest { ItemId = "some-item" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MoveActivity_Returns404_WhenItemNotInBooking()
+    {
+        var bookingId = await SeedBookingAsync("99013");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-activity",
+            new MoveActivityRequest { ItemId = "item-does-not-exist" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ── change-site ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChangeSite_Returns200WithCompletedResult_WhenHappyPath()
+    {
+        var bookingId = await SeedBookingAsync("99020");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeSiteItem("site-item-1") };
+        _fakeOsm.CreatedItemIds = new List<string> { "site-item-new" };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-site",
+            new ChangeSiteRequest
+            {
+                ItemId = "site-item-1",
+                NewSiteId = "site-99"
+            });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Contains("site-item-new", result.Created);
+        Assert.Contains("site-item-1", result.Deleted);
+
+        // Clone JSON should contain the new site id
+        Assert.Single(_fakeOsm.CapturedCloneJsons);
+        Assert.Contains("site-99", _fakeOsm.CapturedCloneJsons[0]);
+    }
+
+    [Fact]
+    public async Task ChangeSite_Returns400_WhenNewSiteIdMissing()
+    {
+        var bookingId = await SeedBookingAsync("99021");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-site",
+            new ChangeSiteRequest { ItemId = "site-item-1", NewSiteId = "" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeSite_Returns400_WhenItemIdMissing()
+    {
+        var bookingId = await SeedBookingAsync("99022");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-site",
+            new ChangeSiteRequest { ItemId = "", NewSiteId = "site-99" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeSite_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/bookings/999999/actions/change-site",
+            new ChangeSiteRequest { ItemId = "x", NewSiteId = "y" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeSite_Returns404_WhenItemNotInBooking()
+    {
+        var bookingId = await SeedBookingAsync("99023");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeSiteItem("site-item-1") };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-site",
+            new ChangeSiteRequest { ItemId = "item-does-not-exist", NewSiteId = "site-99" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ── move-dates ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MoveDates_Returns400_WhenDayShiftIsZero()
+    {
+        var bookingId = await SeedBookingAsync("99030");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-dates",
+            new MoveDatesRequest { DayShift = 0 });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MoveDates_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/bookings/999999/actions/move-dates",
+            new MoveDatesRequest { DayShift = 1 });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task MoveDates_Returns200AndFansOutOneReplacementPerItem()
+    {
+        var bookingId = await SeedBookingAsync("99031");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>
+        {
+            MakeSiteItem("site-item-1"),
+            MakeActivityItem("act-item-1"),
+            MakeSiteItem("site-item-2")
+        };
+        _fakeOsm.CreatedItemIds = new List<string> { "new-1", "new-2", "new-3" };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-dates",
+            new MoveDatesRequest { DayShift = 7 });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+
+        // One create per item
+        Assert.Equal(3, _fakeOsm.CapturedCloneJsons.Count);
+
+        // Dates should be shifted by 7 days — site-item-1 starts 2026-08-01, shifted to 2026-08-08
+        Assert.Contains("2026-08-08", _fakeOsm.CapturedCloneJsons[0]);
+    }
+
+    [Fact]
+    public async Task MoveDates_ShiftsDates_AndPreservesTimes()
+    {
+        var bookingId = await SeedBookingAsync("99032");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>
+        {
+            new BookingItemDto
+            {
+                ItemId = "act-item-1",
+                Type = "activity",
+                Label = "Archery",
+                StartDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+                StartTime = "10:00",
+                EndTime = "12:00"
+            }
+        };
+
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-dates",
+            new MoveDatesRequest { DayShift = 3 });
+
+        Assert.Single(_fakeOsm.CapturedCloneJsons);
+        var cloneJson = _fakeOsm.CapturedCloneJsons[0];
+        // Date shifted: 2026-08-02 + 3 days = 2026-08-05
+        Assert.Contains("2026-08-05", cloneJson);
+        // Times preserved
+        Assert.Contains("10:00", cloneJson);
+        Assert.Contains("12:00", cloneJson);
+    }
+
+    [Fact]
+    public async Task MoveDates_WithMixOfDatedAndDatelessItems_ShiftsDatedItemOnly_LeavesDatelessItemUntouched()
+    {
+        var bookingId = await SeedBookingAsync("99033");
+
+        // One item WITH a StartDate, one item WITHOUT a StartDate
+        var datedItem = new BookingItemDto
+        {
+            ItemId = "site-item-dated",
+            Type = "site",
+            SiteId = "site-10",
+            Label = "Pitch A",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc)
+        };
+        var datelessItem = new BookingItemDto
+        {
+            ItemId = "act-item-dateless",
+            Type = "activity",
+            ActivityId = "act-99",
+            Label = "Badge Award",
+            StartDate = null,
+            EndDate = null
+        };
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { datedItem, datelessItem };
+        _fakeOsm.CreatedItemIds = new List<string> { "new-dated", "new-dateless" };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-dates",
+            new MoveDatesRequest { DayShift = 7 });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        // Fan-out: one replacement per item regardless of whether it has dates
+        Assert.Equal(2, _fakeOsm.CapturedCloneJsons.Count);
+
+        // Dated item clone: start date shifted from 2026-08-01 by 7 days → 2026-08-08
+        var datedCloneJson = _fakeOsm.CapturedCloneJsons[0];
+        Assert.Contains("2026-08-08", datedCloneJson);
+
+        // Dateless item clone: no date override — null dates are not shifted,
+        // so the clone JSON must NOT contain any date value
+        var datelessCloneJson = _fakeOsm.CapturedCloneJsons[1];
+        Assert.DoesNotContain("2026-08", datelessCloneJson);
+    }
+
+    // ── Status propagation ────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task MoveActivity_ReturnsRolledBack_WhenCreateFails()
+    {
+        var bookingId = await SeedBookingAsync("99040");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("OSM create failed"));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-activity",
+            new MoveActivityRequest { ItemId = "act-item-1", NewStartTime = "14:00" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.RolledBack, result.Status);
+    }
+
+    [Fact]
+    public async Task MoveActivity_ReturnsCompletedWithWarnings_WhenDeleteFails()
+    {
+        var bookingId = await SeedBookingAsync("99041");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.CreatedItemIds = new List<string> { "act-item-new" };
+        _fakeOsm.DeleteReturnFalseForIds.Add("act-item-1");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-activity",
+            new MoveActivityRequest { ItemId = "act-item-1", NewStartTime = "14:00" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.CompletedWithWarnings, result.Status);
+    }
+
+    [Fact]
+    public async Task MoveDates_ReturnsRolledBack_WhenCreateFails()
+    {
+        var bookingId = await SeedBookingAsync("99042");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>
+        {
+            MakeSiteItem("site-item-1"),
+            MakeSiteItem("site-item-2")
+        };
+        // Fail on the 2nd create call
+        _fakeOsm.FailCreateOnCall = (2, new InvalidOperationException("OSM create failed on 2nd"));
+        _fakeOsm.CreatedItemIds = new List<string> { "new-1" };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/move-dates",
+            new MoveDatesRequest { DayShift = 1 });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.RolledBack, result.Status);
+    }
+}

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -63,6 +63,64 @@ public class FakeOsmService : IOsmService
         return Task.FromResult(ItemsToReturn);
     }
 
+    // Create / Delete — configurable for mutation service tests
+    public List<string> CreatedItemIds { get; set; } = new();
+    private int _createCallCount;
+
+    /// <summary>
+    /// Captures each cloneJson passed to CreateBookingItemAsync.
+    /// </summary>
+    public List<string> CapturedCloneJsons { get; } = new();
+
+    /// <summary>
+    /// List of (osmBookingId, itemId) calls to DeleteBookingItemAsync.
+    /// </summary>
+    public List<(string OsmBookingId, string ItemId)> DeletedItems { get; } = new();
+
+    /// <summary>
+    /// Combined ordered call log — entries are either ("create", newItemId) or ("delete", itemId).
+    /// Lets tests assert that all creates happen before any deletes.
+    /// </summary>
+    public List<(string Op, string ItemId)> CallLog { get; } = new();
+
+    /// <summary>
+    /// If set, the Nth create call (1-based) will throw this exception.
+    /// </summary>
+    public (int CallNumber, Exception Error)? FailCreateOnCall { get; set; }
+
+    /// <summary>
+    /// Item ids whose delete should return false instead of true.
+    /// </summary>
+    public HashSet<string> DeleteReturnFalseForIds { get; } = new();
+
+    /// <summary>
+    /// Item ids whose delete should throw.
+    /// </summary>
+    public HashSet<string> DeleteThrowForIds { get; } = new();
+
+    public Task<string> CreateBookingItemAsync(string osmBookingId, string cloneJson)
+    {
+        _createCallCount++;
+        if (FailCreateOnCall is { } fail && fail.CallNumber == _createCallCount)
+            throw fail.Error;
+
+        CapturedCloneJsons.Add(cloneJson);
+        var newId = _createCallCount <= CreatedItemIds.Count
+            ? CreatedItemIds[_createCallCount - 1]
+            : $"new-item-{_createCallCount}";
+        CallLog.Add(("create", newId));
+        return Task.FromResult(newId);
+    }
+
+    public Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId)
+    {
+        if (DeleteThrowForIds.Contains(itemId))
+            throw new InvalidOperationException($"Fake: delete forced to throw for item {itemId}");
+        CallLog.Add(("delete", itemId));
+        DeletedItems.Add((osmBookingId, itemId));
+        return Task.FromResult(!DeleteReturnFalseForIds.Contains(itemId));
+    }
+
     public string GetAuthorizationUrl(string redirectUri)
     {
         return string.Empty;

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -68,9 +68,9 @@ public class FakeOsmService : IOsmService
     private int _createCallCount;
 
     /// <summary>
-    /// Captures each cloneJson passed to CreateBookingItemAsync.
+    /// Captures each spec passed to CreateBookingItemAsync (in call order).
     /// </summary>
-    public List<string> CapturedCloneJsons { get; } = new();
+    public List<BookingItemCreateSpec> CapturedSpecs { get; } = new();
 
     /// <summary>
     /// List of (osmBookingId, itemId) calls to DeleteBookingItemAsync.
@@ -98,13 +98,13 @@ public class FakeOsmService : IOsmService
     /// </summary>
     public HashSet<string> DeleteThrowForIds { get; } = new();
 
-    public Task<string> CreateBookingItemAsync(string osmBookingId, string cloneJson)
+    public Task<string> CreateBookingItemAsync(string osmBookingId, BookingItemCreateSpec spec)
     {
         _createCallCount++;
         if (FailCreateOnCall is { } fail && fail.CallNumber == _createCallCount)
             throw fail.Error;
 
-        CapturedCloneJsons.Add(cloneJson);
+        CapturedSpecs.Add(spec);
         var newId = _createCallCount <= CreatedItemIds.Count
             ? CreatedItemIds[_createCallCount - 1]
             : $"new-item-{_createCallCount}";

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -52,6 +52,17 @@ public class FakeOsmService : IOsmService
     public Task<string?> GetBookingContactEmailAsync(string osmBookingId)
         => Task.FromResult(ContactEmailByBookingId.TryGetValue(osmBookingId, out var email) ? email : null);
 
+    // Items
+    public List<BookingItemDto> ItemsToReturn { get; set; } = new();
+    public bool ThrowNotImplementedForItems { get; set; }
+
+    public Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
+    {
+        if (ThrowNotImplementedForItems)
+            throw new NotImplementedException("OSM item parsing not yet wired — pending example data");
+        return Task.FromResult(ItemsToReturn);
+    }
+
     public string GetAuthorizationUrl(string redirectUri)
     {
         return string.Empty;

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -54,14 +54,9 @@ public class FakeOsmService : IOsmService
 
     // Items
     public List<BookingItemDto> ItemsToReturn { get; set; } = new();
-    public bool ThrowNotImplementedForItems { get; set; }
 
     public Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
-    {
-        if (ThrowNotImplementedForItems)
-            throw new NotImplementedException("OSM item parsing not yet wired — pending example data");
-        return Task.FromResult(ItemsToReturn);
-    }
+        => Task.FromResult(ItemsToReturn);
 
     // Create / Delete — configurable for mutation service tests
     public List<string> CreatedItemIds { get; set; } = new();

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/README.md
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/README.md
@@ -1,0 +1,96 @@
+# OSM Booking-Item Contract (captured fixtures)
+
+Captured from a live OSM web session (HAR, 2026-06-29) against test booking **179743**
+("Test - Piers", campsite 219 Thorrington). PII redacted (`group_name` → `REDACTED`); all
+IDs, dates, and field names preserved. These are the fixtures for wiring the deferred
+`OsmService` item seams (issue #27 / `osm-payload-mapping` chunk of PR #25).
+
+> **Auth caveat:** the HAR write calls used the browser **session cookie**, not our OAuth
+> Bearer token. URLs/methods/payloads are confirmed; the OAuth `section:campsite_bookings:write`
+> scope coverage for `addItem`/`delete` is **NOT** confirmed by this capture — verify with a
+> live token smoke test.
+
+## Endpoints
+
+### 1. List booked items
+**Booked items live in the booking-detail response, NOT the items catalogue.**
+- `GET /v3/campsites/bookings/{bookingId}` → `data.items[]`  ← parse this for `GetBookingItemsAsync`
+- `GET /v3/campsites/{campsiteId}/items?booking_id={id}&mode=booking&audience=venue` returns the
+  **catalogue tree** of bookable item-types (categories via `parent_id`), with empty `bookings[]`
+  for booked items in this capture. See `items-catalogue-list.json`. (PR #25 pointed
+  `GetBookingItemsAsync` at this URL — that returns the catalogue, not the booked items. Correction needed.)
+
+Fixture: `booking-detail-with-items.json` (one site item + one activity item).
+
+**Booked-item shape (`data.items[]`):**
+| Field | Example (site / activity) | Notes |
+|-------|---------------------------|-------|
+| `id` | 411467 / 411468 | **booked-item id** → used for delete |
+| `campsite_item_id` | 1387 / 4961 | **item-type id** → used in addItem URL |
+| `campsite_booking_id` | 179743 | parent booking |
+| `start_timestamp` / `end_timestamp` | "2027-12-04 00:01:00" | full datetime (date + time) |
+| `number_people` | 20 / 10 | |
+| `number_sessions` | 1 | |
+| `price_per_person`/`price_per_session` | "0.00" / "50.00" | strings |
+| `flexible_times` / `flexible_price_mode` | true / null·"hourly" | |
+| `number_instructors_required` | 0 / 1 | **>0 ⇒ activity** |
+| `campsite_instructor_type_id` | 0 / 422 | **≠0 ⇒ activity** |
+| `item` | nested catalogue node | `item.parent_id` chains to "Campsites"/"Indoor Accommodation" (site) vs "Activities" (activity); activity `name` is prefixed `ACTIVITY - ` |
+| `booking_questions[]` | 3 / 1 | per-item Q&A, added after create |
+
+**Site vs activity** = one item *type* with optional fields (not distinct schemas). Discriminate by
+`campsite_instructor_type_id != 0` / `number_instructors_required > 0`, or by `item.parent_id` lineage,
+or the `ACTIVITY - ` name prefix.
+
+### 2. Create (add) a booked item
+- `POST /v3/campsites/bookings/{bookingId}/addItem/{campsiteItemId}`
+- `Content-Type: application/x-www-form-urlencoded`
+- Body: `slot_id`, `start` (yyyy-MM-dd), `end` (yyyy-MM-dd), `number_people`, `start_time` (HH:mm), `end_time` (HH:mm)
+- Response: `{"status":true,"error":null,"data":{"id":<newBookedItemId>,"item_name":"...","questions":<n>},"meta":[]}`
+
+Fixtures: `create-item-1387.json` (site), `create-item-4961.json` (activity). Same payload shape for both.
+
+**`slot_id` dependency (important for clone/move):** `slot_id` is **not** a field on the booked item —
+it comes from the availability endpoint:
+- `GET /v3/campsites/items/{campsiteItemId}/availability?booking_id={bookingId}` → `data[]`, each with
+  `id` (= the slot_id), `start`, `end`, `start_time`, `end_time`, `multi_day`, `available`, `cost`.
+- To clone to a **new date/site**, call availability for the target item-type and select the slot whose
+  start/end match the desired window. A same-window clone can reuse the original's slot only if you
+  re-derive it from availability (the booked item doesn't store slot_id).
+
+Fixtures: `availability-1387.json` (site: slot 8279 = multi-day 12-04→12-05), `availability-4961.json`
+(activity: slot 9235 = 12-05 09:00–21:00).
+
+### 3. Delete a booked item
+- `POST /v3/campsites/bookings/items/{bookedItemId}/delete` (POST-with-action, not HTTP DELETE)
+- Empty body. Response: `{"status":true,"error":null,"data":[],"meta":[]}`
+
+Fixtures: `delete-item-411467.json`, `delete-item-411468.json`.
+
+### 4. Booking questions (in scope — answers ARE replayed on clone)
+`addItem` auto-creates blank question placeholders (`response.data.questions` = count).
+- `GET /v3/campsites/bookings/items/{bookedItemId}/questions` → `data.questions[]`, each with `id`
+  (answer-row id, **per-item — differs between original and clone**), `campsite_booking_question_id`
+  (**stable question-definition id — match on this**), `question`, `answer`.
+- `POST /v3/campsites/bookings/items/{bookedItemId}/questions`, form field
+  `answers=<JSON array>` of `[{"id":<answerRowId>,"answer":"..."}]` → `{"status":true,...}`.
+
+Fixtures: `questions-get-411467.json`, `questions-post-411467.json` (site, 3 Qs), `questions-get-411468.json`,
+`questions-post-411468.json` (activity, 1 Q). `raw_body` in the post fixtures shows the URL-encoded form;
+`decoded_answers` shows the parsed JSON array.
+
+**Replay algorithm (clone):**
+1. Read original answers from the booking-detail item's `booking_questions[]` (already fetched) — keyed by
+   `campsite_booking_question_id` → `answer`.
+2. After creating the clone, `GET` the clone's `/questions` to learn its NEW answer-row `id`s.
+3. For each clone question, look up the original answer by `campsite_booking_question_id`, build
+   `[{"id": cloneRowId, "answer": originalAnswer}]`, and `POST` to the clone's `/questions`.
+   (Row `id`s differ per item, so matching MUST be on `campsite_booking_question_id`, not `id`.)
+
+## Open questions from #26 — answered
+- ✅ Item field set — see table above.
+- ✅ Site vs activity — one type, discriminated by instructor fields / parent lineage / name prefix.
+- ✅ Create endpoint URL/method/payload — `POST addItem/{typeId}`, form-encoded, needs `slot_id` from availability.
+- ✅ Delete endpoint — `POST items/{bookedItemId}/delete`.
+- ⚠️ OAuth scope — **unconfirmed** (HAR used cookies). Needs live Bearer-token smoke test.
+- ➕ New finding: `slot_id` requires an availability lookup; cloning to a new window is not a pure field copy.

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/availability-1387.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/availability-1387.json
@@ -1,0 +1,97 @@
+{
+  "status": true,
+  "error": null,
+  "data": [
+    {
+      "start": "2027-12-04 00:01:00",
+      "start_time": "00:01:00",
+      "cost": {
+        "id": 11199,
+        "campsite_effective_from_id": 7160,
+        "campsite_organisation_id": 1502,
+        "price_per_person": 0,
+        "price_per_session": 0,
+        "free_people_per_session": 0,
+        "minimum_price": 0,
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "created_at": "2022-10-15 11:27:59",
+        "updated_at": "2022-10-15 11:27:59"
+      },
+      "end": "2027-12-04 23:59:00",
+      "end_time": "23:59:00",
+      "available": true,
+      "unavailable_reason": null,
+      "available_until": false,
+      "minimum_sessions": 1,
+      "multi_day": false,
+      "id": 6185,
+      "flexible_times": true,
+      "flexible_price_mode": "session",
+      "flexible_minimum_duration": 120,
+      "flexible_existing_bookings": []
+    },
+    {
+      "start": "2027-12-04 00:01:00",
+      "start_time": "00:01:00",
+      "cost": {
+        "id": 11199,
+        "campsite_effective_from_id": 7160,
+        "campsite_organisation_id": 1502,
+        "price_per_person": 0,
+        "price_per_session": 0,
+        "free_people_per_session": 0,
+        "minimum_price": 0,
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "created_at": "2022-10-15 11:27:59",
+        "updated_at": "2022-10-15 11:27:59"
+      },
+      "end": "2027-12-05 23:59:00",
+      "end_time": "23:59:00",
+      "available": true,
+      "unavailable_reason": null,
+      "available_until": "2027-12-05 23:59:00",
+      "minimum_sessions": 1,
+      "multi_day": true,
+      "id": 8279,
+      "flexible_times": true,
+      "flexible_price_mode": null,
+      "flexible_minimum_duration": null,
+      "flexible_existing_bookings": []
+    },
+    {
+      "start": "2027-12-05 00:01:00",
+      "start_time": "00:01:00",
+      "cost": {
+        "id": 11199,
+        "campsite_effective_from_id": 7160,
+        "campsite_organisation_id": 1502,
+        "price_per_person": 0,
+        "price_per_session": 0,
+        "free_people_per_session": 0,
+        "minimum_price": 0,
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "created_at": "2022-10-15 11:27:59",
+        "updated_at": "2022-10-15 11:27:59"
+      },
+      "end": "2027-12-05 23:59:00",
+      "end_time": "23:59:00",
+      "available": true,
+      "unavailable_reason": null,
+      "available_until": false,
+      "minimum_sessions": 1,
+      "multi_day": false,
+      "id": 6185,
+      "flexible_times": true,
+      "flexible_price_mode": "session",
+      "flexible_minimum_duration": 120,
+      "flexible_existing_bookings": []
+    }
+  ],
+  "meta": {
+    "min_people": 0,
+    "max_people": 38
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/availability-4961.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/availability-4961.json
@@ -1,0 +1,68 @@
+{
+  "status": true,
+  "error": null,
+  "data": [
+    {
+      "start": "2027-12-04 09:00:00",
+      "start_time": "09:00:00",
+      "cost": {
+        "id": 23920,
+        "campsite_effective_from_id": 14808,
+        "campsite_organisation_id": 1502,
+        "price_per_person": 0,
+        "price_per_session": 50,
+        "free_people_per_session": 0,
+        "minimum_price": 0,
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "created_at": "2026-05-09 18:48:33",
+        "updated_at": "2026-05-09 18:48:33"
+      },
+      "end": "2027-12-04 21:00:00",
+      "end_time": "21:00:00",
+      "available": true,
+      "unavailable_reason": null,
+      "available_until": false,
+      "minimum_sessions": 1,
+      "multi_day": false,
+      "id": 9235,
+      "flexible_times": true,
+      "flexible_price_mode": "hourly",
+      "flexible_minimum_duration": 60,
+      "flexible_existing_bookings": []
+    },
+    {
+      "start": "2027-12-05 09:00:00",
+      "start_time": "09:00:00",
+      "cost": {
+        "id": 23920,
+        "campsite_effective_from_id": 14808,
+        "campsite_organisation_id": 1502,
+        "price_per_person": 0,
+        "price_per_session": 50,
+        "free_people_per_session": 0,
+        "minimum_price": 0,
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "created_at": "2026-05-09 18:48:33",
+        "updated_at": "2026-05-09 18:48:33"
+      },
+      "end": "2027-12-05 21:00:00",
+      "end_time": "21:00:00",
+      "available": true,
+      "unavailable_reason": null,
+      "available_until": false,
+      "minimum_sessions": 1,
+      "multi_day": false,
+      "id": 9235,
+      "flexible_times": true,
+      "flexible_price_mode": "hourly",
+      "flexible_minimum_duration": 60,
+      "flexible_existing_bookings": []
+    }
+  ],
+  "meta": {
+    "min_people": 0,
+    "max_people": 12
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/booking-detail-with-items.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/booking-detail-with-items.json
@@ -1,0 +1,233 @@
+{
+  "status": true,
+  "error": null,
+  "data": {
+    "id": 179743,
+    "campsite_site_id": 219,
+    "campsite_organisation_id": 1502,
+    "member_id": null,
+    "group_name": "REDACTED",
+    "start_date": "2027-12-04",
+    "end_date": "2027-12-05",
+    "number_leaders": 0,
+    "number_participants": 0,
+    "status": "draft",
+    "deposit": 0,
+    "deposit_due": null,
+    "total_price": 50,
+    "total_paid": 0,
+    "card_payments_config": null,
+    "campsite_users_card_account_id": 0,
+    "remaining_deposit": 0,
+    "formatted_created_at": "29/06/2026",
+    "items": [
+      {
+        "id": 411467,
+        "campsite_item_id": 1387,
+        "campsite_booking_id": 179743,
+        "start_timestamp": "2027-12-04 00:01:00",
+        "end_timestamp": "2027-12-05 23:59:00",
+        "number_sessions": 1,
+        "price_per_person": "0.00",
+        "price_per_session": "0.00",
+        "free_people_per_session": 0,
+        "minimum_price": "0.00",
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "flexible_times": true,
+        "flexible_price_mode": null,
+        "min_people": 0,
+        "number_people": 20,
+        "calculated_deposit": "0.00",
+        "calculated_price": "0.00",
+        "number_instructors_required": 0,
+        "number_instructors_required_override": null,
+        "number_instructors": 0,
+        "campsite_instructor_type_id": 0,
+        "item": {
+          "id": 1387,
+          "parent_id": 3867,
+          "campsite_session_id": 728,
+          "campsite_price_type_id": 802,
+          "availability_rules": [
+            848
+          ],
+          "also_check": [],
+          "name": "Hayvern",
+          "description": "Hayvern is our medium-sized building and provides sleeping accommodation for up to 38 individuals within its 5 sleeping areas. There are 3 bedrooms with 2 bunk beds, 1 bedroom with a bunk bed, and then a large dormitory with 12 bunk beds.\n\n**PLEASE SEE ATTACHED FLOOR PLAN FOR SLEEPING ARRANGEMENTS**",
+          "terms_and_conditions": null,
+          "instructions": null,
+          "quantity": 1,
+          "min_people": 0,
+          "max_people": 38,
+          "hide_externally": false,
+          "staff_only": false,
+          "campsite_instructor_type_id": 0,
+          "number_instructors": 0,
+          "number_participants": 0,
+          "minimum_instructors": 0
+        },
+        "booking_questions": [
+          {
+            "id": 234758,
+            "campsite_item_booking_id": 411467,
+            "campsite_booking_question_group_id": 546,
+            "campsite_booking_question_id": 989,
+            "question": "Please confirm the following booking terms:",
+            "answer": "-",
+            "created_at": "2026-06-29 10:42:39",
+            "updated_at": "2026-06-29 10:42:42"
+          },
+          {
+            "id": 234759,
+            "campsite_item_booking_id": 411467,
+            "campsite_booking_question_group_id": 546,
+            "campsite_booking_question_id": 990,
+            "question": "I will not arrive before 7pm on Fridays",
+            "answer": "-",
+            "created_at": "2026-06-29 10:42:39",
+            "updated_at": "2026-06-29 10:42:42"
+          },
+          {
+            "id": 234760,
+            "campsite_item_booking_id": 411467,
+            "campsite_booking_question_group_id": 546,
+            "campsite_booking_question_id": 991,
+            "question": "Wardens stay no later than 4pm on Sundays",
+            "answer": "-",
+            "created_at": "2026-06-29 10:42:39",
+            "updated_at": "2026-06-29 10:42:42"
+          }
+        ]
+      },
+      {
+        "id": 411468,
+        "campsite_item_id": 4961,
+        "campsite_booking_id": 179743,
+        "start_timestamp": "2027-12-05 09:00:00",
+        "end_timestamp": "2027-12-05 10:00:00",
+        "number_sessions": 1,
+        "price_per_person": "0.00",
+        "price_per_session": "50.00",
+        "free_people_per_session": 0,
+        "minimum_price": "0.00",
+        "deposit_amount": 0,
+        "deposit_percent": 0,
+        "flexible_times": true,
+        "flexible_price_mode": "hourly",
+        "min_people": 0,
+        "number_people": 10,
+        "calculated_deposit": "0.00",
+        "calculated_price": "50.00",
+        "number_instructors_required": 1,
+        "number_instructors_required_override": null,
+        "number_instructors": 0,
+        "campsite_instructor_type_id": 422,
+        "item": {
+          "id": 4961,
+          "parent_id": 10290,
+          "campsite_session_id": 2103,
+          "campsite_price_type_id": 5315,
+          "availability_rules": null,
+          "also_check": [
+            1546
+          ],
+          "name": "ACTIVITY - Air Rifle Shooting",
+          "description": null,
+          "terms_and_conditions": "When booking rifle shooting, it is a legal requirement to complete a Section 21 form before undertaking the activity, this can be found on our website. If you do not have a completed form, you will not be able to participate in the activity. Please note this is legislation and, therefore, must be adhered to by all parties.",
+          "instructions": "Please ensure Section 21 form is completed prior to activities. If no form is present the individual is legally not allowed to participate.",
+          "quantity": 1,
+          "min_people": 0,
+          "max_people": 12,
+          "hide_externally": false,
+          "staff_only": true,
+          "campsite_instructor_type_id": 422,
+          "number_instructors": 1,
+          "number_participants": 5000,
+          "minimum_instructors": 1
+        },
+        "booking_questions": [
+          {
+            "id": 234761,
+            "campsite_item_booking_id": 411468,
+            "campsite_booking_question_group_id": 304,
+            "campsite_booking_question_id": 530,
+            "question": "I will complete the section 21 form.",
+            "answer": "",
+            "created_at": "2026-06-29 10:43:03",
+            "updated_at": "2026-06-29 10:43:03"
+          }
+        ]
+      }
+    ],
+    "campsite": {
+      "id": 219,
+      "name": "Thorrington Scout Camp",
+      "slug": "thorringtonscoutcamp",
+      "public": 1,
+      "currency": "GBP",
+      "latitude": 51.842701,
+      "longitude": 1.02162,
+      "externally_visible_until": "2026-11-07",
+      "billing_start_date": "2020-02-20",
+      "billing_total_topup": "5096.00",
+      "organisations": [
+        {
+          "id": 609,
+          "campsite_site_id": 219,
+          "name": "Colchester Scouts & Guides",
+          "description": "You must be a part of Colchester North or Estuary Districts Scouting or Colchester Guiding for this organisation type to apply.\n\nYour booking may be refused if you are not part of these.",
+          "created_at": "2020-02-18 02:20:07",
+          "updated_at": "2020-02-26 11:31:23",
+          "deleted_at": null
+        },
+        {
+          "id": 613,
+          "campsite_site_id": 219,
+          "name": "District & County Training",
+          "description": "You must be a part of Colchester North or Estuary Districts Scouting, Essex County Scouting or Colchester Guiding for this organisation type to apply.\n\nYour booking may be refused if you are not part of these.",
+          "created_at": "2020-02-18 02:20:58",
+          "updated_at": "2021-11-07 09:20:40",
+          "deleted_at": null
+        },
+        {
+          "id": 611,
+          "campsite_site_id": 219,
+          "name": "External Organisations",
+          "description": "This is for all youth groups not associated with Scouting or Guiding.",
+          "created_at": "2020-02-18 02:20:21",
+          "updated_at": "2021-11-17 08:00:57",
+          "deleted_at": null
+        },
+        {
+          "id": 1502,
+          "campsite_site_id": 219,
+          "name": "INTERNAL BOOKING",
+          "description": "**THIS IS FOR INTERNAL BOOKINGS** \n\nAny bookings made using this price type will be cancelled.",
+          "created_at": "2021-11-23 12:23:28",
+          "updated_at": "2021-11-23 12:23:28",
+          "deleted_at": null
+        },
+        {
+          "id": 610,
+          "campsite_site_id": 219,
+          "name": "Other Scouting & Guiding",
+          "description": "This is for all groups that are not part of Colchester North & Estuary Districts.",
+          "created_at": "2020-02-18 02:20:14",
+          "updated_at": "2020-02-26 11:29:31",
+          "deleted_at": null
+        }
+      ]
+    },
+    "payments": [],
+    "adjustments": []
+  },
+  "meta": {
+    "editable": true,
+    "campsite_edit_access": true,
+    "cards": [],
+    "has_stripe": false,
+    "has_contact_details": true,
+    "has_instructor_types": true
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/create-item-1387.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/create-item-1387.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "url_template": "/v3/campsites/bookings/{bookingId}/addItem/{campsiteItemId}",
+    "actual_url": "https://www.onlinescoutmanager.co.uk/v3/campsites/bookings/179743/addItem/1387",
+    "content_type": "application/x-www-form-urlencoded",
+    "body": "slot_id=8279&start=2027-12-04&end=2027-12-05&number_people=20&start_time=00%3A01&end_time=23%3A59"
+  },
+  "response": {
+    "status": true,
+    "error": null,
+    "data": {
+      "id": 411467,
+      "item_name": "Hayvern",
+      "questions": 3
+    },
+    "meta": []
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/create-item-4961.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/create-item-4961.json
@@ -1,0 +1,19 @@
+{
+  "request": {
+    "method": "POST",
+    "url_template": "/v3/campsites/bookings/{bookingId}/addItem/{campsiteItemId}",
+    "actual_url": "https://www.onlinescoutmanager.co.uk/v3/campsites/bookings/179743/addItem/4961",
+    "content_type": "application/x-www-form-urlencoded",
+    "body": "slot_id=9235&start=2027-12-05&end=2027-12-05&number_people=10&start_time=09%3A00&end_time=10%3A00"
+  },
+  "response": {
+    "status": true,
+    "error": null,
+    "data": {
+      "id": 411468,
+      "item_name": "ACTIVITY - Air Rifle Shooting",
+      "questions": 1
+    },
+    "meta": []
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/delete-item-411467.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/delete-item-411467.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "url_template": "/v3/campsites/bookings/items/{bookedItemId}/delete",
+    "actual_url": "https://www.onlinescoutmanager.co.uk/v3/campsites/bookings/items/411467/delete",
+    "body": ""
+  },
+  "response": {
+    "status": true,
+    "error": null,
+    "data": [],
+    "meta": []
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/delete-item-411468.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/delete-item-411468.json
@@ -1,0 +1,14 @@
+{
+  "request": {
+    "method": "POST",
+    "url_template": "/v3/campsites/bookings/items/{bookedItemId}/delete",
+    "actual_url": "https://www.onlinescoutmanager.co.uk/v3/campsites/bookings/items/411468/delete",
+    "body": ""
+  },
+  "response": {
+    "status": true,
+    "error": null,
+    "data": [],
+    "meta": []
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/items-catalogue-list.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/items-catalogue-list.json
@@ -258,7 +258,7 @@
       "pictures": [
         {
           "upload_id": 34134,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Rear%20View%20-%20Alpha%20House_edited.jpg",
@@ -273,7 +273,7 @@
         },
         {
           "upload_id": 34145,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Communal Area - Alpha House.jpg",
@@ -288,7 +288,7 @@
         },
         {
           "upload_id": 34146,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Ron Sibley Room - Alpha House.jpg",
@@ -303,7 +303,7 @@
         },
         {
           "upload_id": 34147,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Kitchen - Alpha House.jpg",
@@ -318,7 +318,7 @@
         },
         {
           "upload_id": 34148,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "AlphaHouseFP.png",
@@ -368,7 +368,7 @@
       "pictures": [
         {
           "upload_id": 34136,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "IMG_1824.jpg",
@@ -383,7 +383,7 @@
         },
         {
           "upload_id": 34142,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "HayvernFP.png",
@@ -433,7 +433,7 @@
       "pictures": [
         {
           "upload_id": 34140,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Hayvern.jpg",
@@ -448,7 +448,7 @@
         },
         {
           "upload_id": 34143,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Communal area .jpg",
@@ -463,7 +463,7 @@
         },
         {
           "upload_id": 34144,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "PapillonFP.png",
@@ -783,7 +783,7 @@
       "pictures": [
         {
           "upload_id": 34128,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "HQ.jpg",
@@ -833,7 +833,7 @@
       "pictures": [
         {
           "upload_id": 34127,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Hill.jpg",
@@ -883,7 +883,7 @@
       "pictures": [
         {
           "upload_id": 34130,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Hurricane.jpg",
@@ -1035,7 +1035,7 @@
       "pictures": [
         {
           "upload_id": 34126,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Spring.jpg",
@@ -1085,7 +1085,7 @@
       "pictures": [
         {
           "upload_id": 34131,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "BottomFieldMOWN_edited.jpg",
@@ -1135,7 +1135,7 @@
       "pictures": [
         {
           "upload_id": 34129,
-          "uploader_id": "scouts:417898",
+          "uploader_id": "scouts:REDACTED",
           "section_id": 56710,
           "public_directory": "/",
           "public_name": "Top Field.jpg",

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/items-catalogue-list.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/items-catalogue-list.json
@@ -1,0 +1,2292 @@
+{
+  "status": true,
+  "error": null,
+  "data": [
+    {
+      "id": 10290,
+      "parent_id": 10288,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Activities",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10289,
+      "parent_id": 10288,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Add-ons",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 3868,
+      "parent_id": 1384,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": [
+        998
+      ],
+      "also_check": null,
+      "name": "Campsites",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 3867,
+      "parent_id": 1384,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": [
+        998
+      ],
+      "also_check": null,
+      "name": "Indoor Accommodation",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10374,
+      "parent_id": 10290,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Pond",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10377,
+      "parent_id": 10290,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Throwing Range",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10376,
+      "parent_id": 10290,
+      "campsite_session_id": 0,
+      "campsite_price_type_id": 0,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Tower",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": null,
+      "price": null,
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1384,
+      "parent_id": 10288,
+      "campsite_session_id": 733,
+      "campsite_price_type_id": 807,
+      "availability_rules": [
+        848,
+        998
+      ],
+      "also_check": [
+        1385
+      ],
+      "name": "Whole Site Booking",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": {
+        "id": 733,
+        "name": "AA - Whole Site Booking"
+      },
+      "price": {
+        "id": 807,
+        "name": "Whole Site Booking"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1386,
+      "parent_id": 3867,
+      "campsite_session_id": 728,
+      "campsite_price_type_id": 800,
+      "availability_rules": [],
+      "also_check": [],
+      "name": "Alpha House",
+      "description": "Alpha House is our largest building that can provide sleeping accommodation for 48 individuals in its upstairs dormitories, as well as providing a spacious area for indoor activities and dining.\n\n**PLEASE SEE ATTACHED FLOOR PLAN FOR SLEEPING ARRANGEMENTS**",
+      "terms_and_conditions": "",
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 48,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 728,
+        "name": "Accommodation"
+      },
+      "price": {
+        "id": 800,
+        "name": "Alpha House"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34134,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Rear%20View%20-%20Alpha%20House_edited.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 1467198,
+          "date_uploaded": "2021-10-28 12:01:48",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FRear%2520View%2520-%2520Alpha%2520House_edited.jpg&id=1386&fm=png&fit=crop&w=100&h=75&cb=b146b2a501dc8a0a611a231bbd54c845&s=8baea97d769fffe7cb5f741ad42c31f5",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FRear%2520View%2520-%2520Alpha%2520House_edited.jpg&id=1386&fm=png&fit=contain&w=565&h=424&cb=b146b2a501dc8a0a611a231bbd54c845&s=eea6a8cc49f8d488ca8ed80c15d9a4cf"
+        },
+        {
+          "upload_id": 34145,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Communal Area - Alpha House.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 2210468,
+          "date_uploaded": "2021-10-28 12:11:16",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FCommunal+Area+-+Alpha+House.jpg&id=1386&fm=png&fit=crop&w=100&h=75&cb=b7f20edaeddf2c4fd6adc999c037f959&s=0131da8ec738f2c63c4510fbfb314f24",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FCommunal+Area+-+Alpha+House.jpg&id=1386&fm=png&fit=contain&w=565&h=424&cb=b7f20edaeddf2c4fd6adc999c037f959&s=6e7e932f5b94e84f0c26526b24129394"
+        },
+        {
+          "upload_id": 34146,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Ron Sibley Room - Alpha House.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 2209939,
+          "date_uploaded": "2021-10-28 12:11:16",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FRon+Sibley+Room+-+Alpha+House.jpg&id=1386&fm=png&fit=crop&w=100&h=75&cb=e04247f27a3366aee72fd5932b9308df&s=f14d98dd628e7b8408cef83bc2f278fb",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FRon+Sibley+Room+-+Alpha+House.jpg&id=1386&fm=png&fit=contain&w=565&h=424&cb=e04247f27a3366aee72fd5932b9308df&s=01720e1004cc82449a51b26a5cf7cdc8"
+        },
+        {
+          "upload_id": 34147,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Kitchen - Alpha House.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 2523034,
+          "date_uploaded": "2021-10-28 12:11:16",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FKitchen+-+Alpha+House.jpg&id=1386&fm=png&fit=crop&w=100&h=75&cb=a8c0307fa6e6a63d4991f5bdd1da5fa9&s=cb00c5734909b57fea6ae420b93561b9",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FKitchen+-+Alpha+House.jpg&id=1386&fm=png&fit=contain&w=565&h=424&cb=a8c0307fa6e6a63d4991f5bdd1da5fa9&s=0099ab551ed942e1baac217f1f5aafbf"
+        },
+        {
+          "upload_id": 34148,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "AlphaHouseFP.png",
+          "temp": "no",
+          "mime": "image/png",
+          "extension": "png",
+          "size": 702987,
+          "date_uploaded": "2021-10-28 12:11:22",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FAlphaHouseFP.png&id=1386&fm=png&fit=crop&w=100&h=75&cb=b9d06380dcde0eff5efe11f29251a43e&s=09785c0eff112508a1b0e42e6899c5c4",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FAlphaHouseFP.png&id=1386&fm=png&fit=contain&w=565&h=424&cb=b9d06380dcde0eff5efe11f29251a43e&s=62a16268c826361c7d564a59dbf2df42"
+        }
+      ]
+    },
+    {
+      "id": 1387,
+      "parent_id": 3867,
+      "campsite_session_id": 728,
+      "campsite_price_type_id": 802,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Hayvern",
+      "description": "Hayvern is our medium-sized building and provides sleeping accommodation for up to 38 individuals within its 5 sleeping areas. There are 3 bedrooms with 2 bunk beds, 1 bedroom with a bunk bed, and then a large dormitory with 12 bunk beds.\n\n**PLEASE SEE ATTACHED FLOOR PLAN FOR SLEEPING ARRANGEMENTS**",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 38,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": {
+        "id": 728,
+        "name": "Accommodation"
+      },
+      "price": {
+        "id": 802,
+        "name": "Hayvern"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34136,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "IMG_1824.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 4751004,
+          "date_uploaded": "2021-10-28 12:02:18",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FIMG_1824.jpg&id=1387&fm=png&fit=crop&w=100&h=75&cb=e46d6cc620ce2a21962e516f5eb6b193&s=6c972dfa48a43f38b7386e49e6ebd3b4",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FIMG_1824.jpg&id=1387&fm=png&fit=contain&w=565&h=424&cb=e46d6cc620ce2a21962e516f5eb6b193&s=bfebc2f24d8454334739fd0e8bf06d42"
+        },
+        {
+          "upload_id": 34142,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "HayvernFP.png",
+          "temp": "no",
+          "mime": "image/png",
+          "extension": "png",
+          "size": 428206,
+          "date_uploaded": "2021-10-28 12:09:41",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHayvernFP.png&id=1387&fm=png&fit=crop&w=100&h=75&cb=f0b3a0e6b61d46271e610b3a9b825b83&s=14181e0de674caf68d975b7f562a895a",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHayvernFP.png&id=1387&fm=png&fit=contain&w=565&h=424&cb=f0b3a0e6b61d46271e610b3a9b825b83&s=3d1f1d39cced9c5128f2a1352f4a7442"
+        }
+      ]
+    },
+    {
+      "id": 1388,
+      "parent_id": 3867,
+      "campsite_session_id": 728,
+      "campsite_price_type_id": 803,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Papillon",
+      "description": "Despite being our smallest building, Papillon provides sleeping accommodation for 14 individuals, it consists of 2 bedrooms with a bunk bed, 1 bedroom with 3 bunk beds and a fourth bedroom containing 2 bunk beds.\n\n**PLEASE SEE ATTACHED FLOOR PLAN FOR SLEEPING ARRANGEMENTS**",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 14,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 728,
+        "name": "Accommodation"
+      },
+      "price": {
+        "id": 803,
+        "name": "Papillon"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34140,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Hayvern.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 5427623,
+          "date_uploaded": "2021-10-28 12:03:10",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHayvern.jpg&id=1388&fm=png&fit=crop&w=100&h=75&cb=a8511dbf0801d5d8719fc6090a25e29d&s=39196b78e14f41792791d0e907084d55",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHayvern.jpg&id=1388&fm=png&fit=contain&w=565&h=424&cb=a8511dbf0801d5d8719fc6090a25e29d&s=c7faecdf50223dc3fe19c3a154fdaf03"
+        },
+        {
+          "upload_id": 34143,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Communal area .jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 2531870,
+          "date_uploaded": "2021-10-28 12:10:13",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FCommunal+area+.jpg&id=1388&fm=png&fit=crop&w=100&h=75&cb=297737c30ff2dac6d97d7d83edd10483&s=d2eba3296036831ffcb58141cdc8d6ac",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FCommunal+area+.jpg&id=1388&fm=png&fit=contain&w=565&h=424&cb=297737c30ff2dac6d97d7d83edd10483&s=1857d2666eae3bb6a888e7e865cd4367"
+        },
+        {
+          "upload_id": 34144,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "PapillonFP.png",
+          "temp": "no",
+          "mime": "image/png",
+          "extension": "png",
+          "size": 381837,
+          "date_uploaded": "2021-10-28 12:10:27",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FPapillonFP.png&id=1388&fm=png&fit=crop&w=100&h=75&cb=ecc6da4652f16b7271ef14cf858e76a8&s=157785183dc951929fe5b2996f6a562d",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FPapillonFP.png&id=1388&fm=png&fit=contain&w=565&h=424&cb=ecc6da4652f16b7271ef14cf858e76a8&s=95454bf2ceda5c24627e126f5beab601"
+        }
+      ]
+    },
+    {
+      "id": 3864,
+      "parent_id": 3867,
+      "campsite_session_id": 728,
+      "campsite_price_type_id": 1976,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Winter Fuel Surcharge",
+      "description": "Mandatory charge during winter months due to increased utilities use.",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 10,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": {
+        "id": 728,
+        "name": "Accommodation"
+      },
+      "price": {
+        "id": 1976,
+        "name": "Winter Fuel Surcharge"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 5174,
+      "parent_id": 3868,
+      "campsite_session_id": 2167,
+      "campsite_price_type_id": 805,
+      "availability_rules": null,
+      "also_check": [
+        1384
+      ],
+      "name": "Campfire Circle",
+      "description": null,
+      "terms_and_conditions": "",
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2167,
+        "name": "CampfireCircle"
+      },
+      "price": {
+        "id": 805,
+        "name": "Campsites (Evening Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1404,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Birch",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1412,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 805,
+      "availability_rules": [
+        848
+      ],
+      "also_check": null,
+      "name": "Evening Visit",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 10,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 805,
+        "name": "Campsites (Evening Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1403,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 806,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Fallen Log",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 80,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 806,
+        "name": "Campsites (Overnight Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1407,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        933
+      ],
+      "also_check": [],
+      "name": "Fir & Elm",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 80,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1402,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Greens",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1405,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Gum",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1406,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Headquarters (HQ)",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 80,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34128,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "HQ.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 5627876,
+          "date_uploaded": "2021-10-28 11:58:49",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHQ.jpg&id=1406&fm=png&fit=crop&w=100&h=75&cb=177b6e479cd1640a996743964d88bf97&s=ed9f4f2a044e1da500857d74cc4a4764",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHQ.jpg&id=1406&fm=png&fit=contain&w=565&h=424&cb=177b6e479cd1640a996743964d88bf97&s=15f7b97ff0a1c4193d5014b87e5a21eb"
+        }
+      ]
+    },
+    {
+      "id": 1401,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Hill",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34127,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Hill.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 6061459,
+          "date_uploaded": "2021-10-28 11:57:30",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHill.jpg&id=1401&fm=png&fit=crop&w=100&h=75&cb=36bc07e2ee39f90f0e9b7159deb0f767&s=e89a2dc642ece0cb9ef94f9623bd264b",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHill.jpg&id=1401&fm=png&fit=contain&w=565&h=424&cb=36bc07e2ee39f90f0e9b7159deb0f767&s=d3ee79bc8dfcf60db46838ea161d30ca"
+        }
+      ]
+    },
+    {
+      "id": 1399,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Hurricane",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34130,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Hurricane.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 5873494,
+          "date_uploaded": "2021-10-28 11:59:22",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHurricane.jpg&id=1399&fm=png&fit=crop&w=100&h=75&cb=396f6bff643664ec08b66643e0fcee36&s=16286655a3f3abe156074996d6677333",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FHurricane.jpg&id=1399&fm=png&fit=contain&w=565&h=424&cb=396f6bff643664ec08b66643e0fcee36&s=286fe30beffdca63ab816c88bc6c128e"
+        }
+      ]
+    },
+    {
+      "id": 1396,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Moules",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1398,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Oak",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 15,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10288,
+      "parent_id": 0,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 805,
+      "availability_rules": [
+        535
+      ],
+      "also_check": [],
+      "name": "Site Reserved",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 805,
+        "name": "Campsites (Evening Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1400,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Spring",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 36,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34126,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Spring.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 6243350,
+          "date_uploaded": "2021-10-28 11:57:16",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FSpring.jpg&id=1400&fm=png&fit=crop&w=100&h=75&cb=e6b9fa43b6e228f6a72b5e529c7ef59d&s=7920e584fb4db6e10f5d7e8b5e6523d5",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FSpring.jpg&id=1400&fm=png&fit=contain&w=565&h=424&cb=e6b9fa43b6e228f6a72b5e529c7ef59d&s=c39e705bfae0f7c5b6f064d0827e8fbf"
+        }
+      ]
+    },
+    {
+      "id": 1408,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Tim's Field",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 50,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34131,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "BottomFieldMOWN_edited.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 2890834,
+          "date_uploaded": "2021-10-28 11:59:33",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FBottomFieldMOWN_edited.jpg&id=1408&fm=png&fit=crop&w=100&h=75&cb=54a8b6640e7fc78ff18b9db390c09cbc&s=a27f57bf906c7bed116fa9dd9e28b897",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FBottomFieldMOWN_edited.jpg&id=1408&fm=png&fit=contain&w=565&h=424&cb=54a8b6640e7fc78ff18b9db390c09cbc&s=26d5dcacbc97cff877f81d25475c45c5"
+        }
+      ]
+    },
+    {
+      "id": 1397,
+      "parent_id": 3868,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [],
+      "name": "Top Field",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 80,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": [
+        {
+          "upload_id": 34129,
+          "uploader_id": "scouts:417898",
+          "section_id": 56710,
+          "public_directory": "/",
+          "public_name": "Top Field.jpg",
+          "temp": "no",
+          "mime": "image/jpeg",
+          "extension": "jpg",
+          "size": 5939402,
+          "date_uploaded": "2021-10-28 11:59:09",
+          "deleted_at": null,
+          "thumbnail_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FTop+Field.jpg&id=1397&fm=png&fit=crop&w=100&h=75&cb=cd5234ffede166e466dbc0d136b52c23&s=fe7db93cdecfb215a901e358ec4e6666",
+          "preview_url": "/ext/campsites/items/pictures/index.php?section_id=56710&action=preview&file=%2FTop+Field.jpg&id=1397&fm=png&fit=contain&w=565&h=424&cb=cd5234ffede166e466dbc0d136b52c23&s=61939acbecc2456f23fdb81cfa959105"
+        }
+      ]
+    },
+    {
+      "id": 1544,
+      "parent_id": 10288,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 804,
+      "availability_rules": [
+        848
+      ],
+      "also_check": null,
+      "name": "ZZ - Day Visit (FOR CAMPSITE ONLY WHEN WSB IN-SITU).",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 2,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 804,
+        "name": "Campsites (Day Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1545,
+      "parent_id": 10288,
+      "campsite_session_id": 729,
+      "campsite_price_type_id": 806,
+      "availability_rules": [
+        848
+      ],
+      "also_check": null,
+      "name": "ZZ - Overnight Visit (FOR CAMPSITE ONLY WHEN WSB IN-SITU).",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 2,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 729,
+        "name": "Camping"
+      },
+      "price": {
+        "id": 806,
+        "name": "Campsites (Overnight Visit)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 3824,
+      "parent_id": 1386,
+      "campsite_session_id": 1685,
+      "campsite_price_type_id": 1958,
+      "availability_rules": [
+        859,
+        860
+      ],
+      "also_check": null,
+      "name": "ZZ - Midweek Training",
+      "description": "Please note this is only available during term-time and is for external organisations holding training. This will be unavailable if Alpha House is booked and vice versa.",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 48,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": false,
+      "session": {
+        "id": 1685,
+        "name": "Midweek Training"
+      },
+      "price": {
+        "id": 1958,
+        "name": "Midweek Training"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10466,
+      "parent_id": 10289,
+      "campsite_session_id": 4599,
+      "campsite_price_type_id": 5347,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ADD-ON - Table",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 6,
+      "min_people": 1,
+      "max_people": 1,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 4599,
+        "name": "Table hire"
+      },
+      "price": {
+        "id": 5347,
+        "name": "Table hire"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 1546,
+      "parent_id": 10288,
+      "campsite_session_id": 1678,
+      "campsite_price_type_id": 1943,
+      "availability_rules": [
+        848
+      ],
+      "also_check": [
+        4961
+      ],
+      "name": "ZZ - Wet Weather",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 25,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 1678,
+        "name": "Wet Weather"
+      },
+      "price": {
+        "id": 1943,
+        "name": "Wet Weather (Half Day)"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 6869,
+      "parent_id": 10289,
+      "campsite_session_id": 4020,
+      "campsite_price_type_id": 3561,
+      "availability_rules": [],
+      "also_check": null,
+      "name": "ADD-ON - Fridge No. 1",
+      "description": "This is an additional fridge for hire that is located to the rear of the site providore.",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 4020,
+        "name": "XX Accommodation ADD-ON"
+      },
+      "price": {
+        "id": 3561,
+        "name": "\u00a34 Fridges"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 6870,
+      "parent_id": 10289,
+      "campsite_session_id": 4020,
+      "campsite_price_type_id": 3561,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ADD-ON - Fridge No. 2",
+      "description": "This is an additional fridge for hire that is located to the rear of the site providore.",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 4020,
+        "name": "XX Accommodation ADD-ON"
+      },
+      "price": {
+        "id": 3561,
+        "name": "\u00a34 Fridges"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 6879,
+      "parent_id": 10289,
+      "campsite_session_id": 4020,
+      "campsite_price_type_id": 2487,
+      "availability_rules": [
+        933,
+        535
+      ],
+      "also_check": null,
+      "name": "ADD-ON - Hammock Hire",
+      "description": "Hire includes 12 hammocks and 1 tent, giving your group the chance to experience a unique style of camping under the trees. Perfect for backwoods skills, patrol camps, or lightweight expeditions.",
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 12,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 4020,
+        "name": "XX Accommodation ADD-ON"
+      },
+      "price": {
+        "id": 2487,
+        "name": "\u00a325 Activities"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 7798,
+      "parent_id": 10289,
+      "campsite_session_id": 4020,
+      "campsite_price_type_id": 4042,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ADD-ON - Midweek Check In",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 461,
+      "number_instructors": 1,
+      "number_participants": 0,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 4020,
+        "name": "XX Accommodation ADD-ON"
+      },
+      "price": {
+        "id": 4042,
+        "name": "\u00a30 Add On"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10056,
+      "parent_id": 10289,
+      "campsite_session_id": 4020,
+      "campsite_price_type_id": 4042,
+      "availability_rules": null,
+      "also_check": [
+        4968
+      ],
+      "name": "ADD-ON - Sandy Patch Parking",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 4020,
+        "name": "XX Accommodation ADD-ON"
+      },
+      "price": {
+        "id": 4042,
+        "name": "\u00a30 Add On"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 5401,
+      "parent_id": 10290,
+      "campsite_session_id": 2101,
+      "campsite_price_type_id": 2769,
+      "availability_rules": null,
+      "also_check": [
+        4963
+      ],
+      "name": "ACTIVITY - Crystal Maze",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2101,
+        "name": "XX Activity - 2HR Blocks CJ"
+      },
+      "price": {
+        "id": 2769,
+        "name": "\u00a325 Activities - 2HRS"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4972,
+      "parent_id": 10290,
+      "campsite_session_id": 2101,
+      "campsite_price_type_id": 2492,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Pond Dipping",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2101,
+        "name": "XX Activity - 2HR Blocks CJ"
+      },
+      "price": {
+        "id": 2492,
+        "name": "\u00a315 Activities - 2HRS"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 8054,
+      "parent_id": 10376,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5317,
+      "availability_rules": null,
+      "also_check": [
+        7693,
+        10380
+      ],
+      "name": "ACTIVITY - Abseiling",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 15,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 421,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5317,
+        "name": "Activity - Tower - Half"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10380,
+      "parent_id": 10376,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5316,
+      "availability_rules": null,
+      "also_check": [
+        8054,
+        7693
+      ],
+      "name": "ACTIVITY - Abseiling and Climbing",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 0,
+      "min_people": 0,
+      "max_people": 15,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 421,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 2,
+      "available": false,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5316,
+        "name": "Activity - Tower - Whole"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4961,
+      "parent_id": 10290,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5315,
+      "availability_rules": null,
+      "also_check": [
+        1546
+      ],
+      "name": "ACTIVITY - Air Rifle Shooting",
+      "description": null,
+      "terms_and_conditions": "When booking rifle shooting, it is a legal requirement to complete a Section 21 form before undertaking the activity, this can be found on our website. If you do not have a completed form, you will not be able to participate in the activity. Please note this is legislation and, therefore, must be adhered to by all parties.",
+      "instructions": "Please ensure Section 21 form is completed prior to activities. If no form is present the individual is legally not allowed to participate.",
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 12,
+      "hide_externally": false,
+      "staff_only": true,
+      "campsite_instructor_type_id": 422,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5315,
+        "name": "Activity - Instructed"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 5403,
+      "parent_id": 10377,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5315,
+      "availability_rules": null,
+      "also_check": [
+        4967,
+        4964
+      ],
+      "name": "ACTIVITY - Angel Throwing",
+      "description": null,
+      "terms_and_conditions": "Please note this activity is only suitable for ages 8 and above.",
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 15,
+      "hide_externally": false,
+      "staff_only": true,
+      "campsite_instructor_type_id": 420,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5315,
+        "name": "Activity - Instructed"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4962,
+      "parent_id": 10290,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5315,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Archery",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 12,
+      "hide_externally": false,
+      "staff_only": true,
+      "campsite_instructor_type_id": 419,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5315,
+        "name": "Activity - Instructed"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 7693,
+      "parent_id": 10376,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5317,
+      "availability_rules": null,
+      "also_check": [
+        8054,
+        10380
+      ],
+      "name": "ACTIVITY - Climbing",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 15,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 421,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5317,
+        "name": "Activity - Tower - Half"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4967,
+      "parent_id": 10377,
+      "campsite_session_id": 2103,
+      "campsite_price_type_id": 5315,
+      "availability_rules": null,
+      "also_check": [
+        4964,
+        5403
+      ],
+      "name": "ACTIVITY - Tomahawk Throwing",
+      "description": null,
+      "terms_and_conditions": "Please note this activity is only suitable for ages 10 and above.",
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 15,
+      "hide_externally": false,
+      "staff_only": true,
+      "campsite_instructor_type_id": 420,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2103,
+        "name": "XX Activity - Instructor Led CJ"
+      },
+      "price": {
+        "id": 5315,
+        "name": "Activity - Instructed"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4971,
+      "parent_id": 10290,
+      "campsite_session_id": 2105,
+      "campsite_price_type_id": 5322,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Pioneering",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 40,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2105,
+        "name": "XX Activity - Pioneering CJ"
+      },
+      "price": {
+        "id": 5322,
+        "name": "Activity - Budget"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4970,
+      "parent_id": 10374,
+      "campsite_session_id": 2102,
+      "campsite_price_type_id": 5320,
+      "availability_rules": null,
+      "also_check": [
+        4969
+      ],
+      "name": "ACTIVITY - Rafting",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2102,
+        "name": "XX Activity - Rafting CJ"
+      },
+      "price": {
+        "id": 5320,
+        "name": "Activity - Premium"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4963,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5320,
+      "availability_rules": null,
+      "also_check": [
+        5401
+      ],
+      "name": "ACTIVITY - 3D Maze",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5320,
+        "name": "Activity - Premium"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4965,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 2491,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Adventure Run",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 12,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 2491,
+        "name": "Activity - Free"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4944,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5320,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Bouldering Hut",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5320,
+        "name": "Activity - Premium"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4975,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5321,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Human Table Football",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5321,
+        "name": "Activity - Mid"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4969,
+      "parent_id": 10374,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5319,
+      "availability_rules": null,
+      "also_check": [
+        4970
+      ],
+      "name": "ACTIVITY - Kayaking",
+      "description": null,
+      "terms_and_conditions": "Please note to undertake this activity you must provide your own instructor.",
+      "instructions": "An qualified instructor must be provided for this activity. Thorrington is unable to provide such an instructor.",
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 12,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5319,
+        "name": "Activity - Kayaks"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 10482,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5321,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Mini Axe Throwing",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 12,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5321,
+        "name": "Activity - Mid"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4966,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5321,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Mini Crossbows",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5321,
+        "name": "Activity - Mid"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4977,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 2491,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Orienteering Trail",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 2491,
+        "name": "Activity - Free"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4968,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5320,
+      "availability_rules": null,
+      "also_check": [
+        10056
+      ],
+      "name": "ACTIVITY - Pedal Karts",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5320,
+        "name": "Activity - Premium"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4976,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 2491,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Photo Quiz",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 2491,
+        "name": "Activity - Free"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4964,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5321,
+      "availability_rules": null,
+      "also_check": [
+        4967
+      ],
+      "name": "ACTIVITY - Slacklining",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5321,
+        "name": "Activity - Mid"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 4973,
+      "parent_id": 10290,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 5320,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "ACTIVITY - Slingshots",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 1,
+      "min_people": 0,
+      "max_people": 20,
+      "hide_externally": false,
+      "staff_only": false,
+      "campsite_instructor_type_id": 0,
+      "number_instructors": 0,
+      "number_participants": 0,
+      "minimum_instructors": 0,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 5320,
+        "name": "Activity - Premium"
+      },
+      "bookings": [],
+      "pictures": []
+    },
+    {
+      "id": 8722,
+      "parent_id": 10288,
+      "campsite_session_id": 2104,
+      "campsite_price_type_id": 4042,
+      "availability_rules": null,
+      "also_check": null,
+      "name": "Midweek Opening",
+      "description": null,
+      "terms_and_conditions": null,
+      "instructions": null,
+      "quantity": 10,
+      "min_people": 0,
+      "max_people": 0,
+      "hide_externally": true,
+      "staff_only": true,
+      "campsite_instructor_type_id": 461,
+      "number_instructors": 1,
+      "number_participants": 5000,
+      "minimum_instructors": 1,
+      "available": true,
+      "session": {
+        "id": 2104,
+        "name": "XX Activity - Self Led CJ"
+      },
+      "price": {
+        "id": 4042,
+        "name": "\u00a30 Add On"
+      },
+      "bookings": [],
+      "pictures": []
+    }
+  ],
+  "meta": {
+    "venue_name": "Thorrington Scout Camp",
+    "has_credit": true,
+    "has_contact_details": true
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/questions-get-411467.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/questions-get-411467.json
@@ -1,0 +1,40 @@
+{
+  "status": true,
+  "error": null,
+  "data": {
+    "item": "Hayvern",
+    "questions": [
+      {
+        "id": 234758,
+        "campsite_item_booking_id": 411467,
+        "campsite_booking_question_group_id": 546,
+        "campsite_booking_question_id": 989,
+        "question": "Please confirm the following booking terms:",
+        "answer": "",
+        "created_at": "2026-06-29 10:42:39",
+        "updated_at": "2026-06-29 10:42:39"
+      },
+      {
+        "id": 234759,
+        "campsite_item_booking_id": 411467,
+        "campsite_booking_question_group_id": 546,
+        "campsite_booking_question_id": 990,
+        "question": "I will not arrive before 7pm on Fridays",
+        "answer": "",
+        "created_at": "2026-06-29 10:42:39",
+        "updated_at": "2026-06-29 10:42:39"
+      },
+      {
+        "id": 234760,
+        "campsite_item_booking_id": 411467,
+        "campsite_booking_question_group_id": 546,
+        "campsite_booking_question_id": 991,
+        "question": "Wardens stay no later than 4pm on Sundays",
+        "answer": "",
+        "created_at": "2026-06-29 10:42:39",
+        "updated_at": "2026-06-29 10:42:39"
+      }
+    ]
+  },
+  "meta": []
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/questions-get-411468.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/questions-get-411468.json
@@ -1,0 +1,20 @@
+{
+  "status": true,
+  "error": null,
+  "data": {
+    "item": "ACTIVITY - Air Rifle Shooting",
+    "questions": [
+      {
+        "id": 234761,
+        "campsite_item_booking_id": 411468,
+        "campsite_booking_question_group_id": 304,
+        "campsite_booking_question_id": 530,
+        "question": "I will complete the section 21 form.",
+        "answer": "",
+        "created_at": "2026-06-29 10:43:03",
+        "updated_at": "2026-06-29 10:43:03"
+      }
+    ]
+  },
+  "meta": []
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/questions-post-411467.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/questions-post-411467.json
@@ -1,0 +1,29 @@
+{
+  "request": {
+    "method": "POST",
+    "url_template": "/v3/campsites/bookings/items/{itemId}/questions",
+    "content_type": "application/x-www-form-urlencoded",
+    "form_field": "answers",
+    "raw_body": "answers=%5B%7B%22id%22%3A234758%2C%22answer%22%3A%22-%22%7D%2C%7B%22id%22%3A234759%2C%22answer%22%3A%22-%22%7D%2C%7B%22id%22%3A234760%2C%22answer%22%3A%22-%22%7D%5D",
+    "decoded_answers": [
+      {
+        "id": 234758,
+        "answer": "-"
+      },
+      {
+        "id": 234759,
+        "answer": "-"
+      },
+      {
+        "id": 234760,
+        "answer": "-"
+      }
+    ]
+  },
+  "response": {
+    "status": true,
+    "error": null,
+    "data": [],
+    "meta": []
+  }
+}

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/questions-post-411468.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/questions-post-411468.json
@@ -1,0 +1,21 @@
+{
+  "request": {
+    "method": "POST",
+    "url_template": "/v3/campsites/bookings/items/{itemId}/questions",
+    "content_type": "application/x-www-form-urlencoded",
+    "form_field": "answers",
+    "raw_body": "answers=%5B%7B%22id%22%3A234761%2C%22answer%22%3A%22-%22%7D%5D",
+    "decoded_answers": [
+      {
+        "id": 234761,
+        "answer": "-"
+      }
+    ]
+  },
+  "response": {
+    "status": true,
+    "error": null,
+    "data": [],
+    "meta": []
+  }
+}

--- a/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
@@ -241,4 +241,24 @@ public class BookingMutationServiceTests
         Assert.Equal("15:00", spec.EndTime);
         Assert.Equal(12, spec.NumberPeople);
     }
+
+    [Fact]
+    public async Task BuildSpec_CarriesOriginalQuestionAnswers_KeyedByQuestionDefId()
+    {
+        var fake = new FakeOsmService { ItemsToReturn = new List<BookingItemDto>() };
+
+        var original = MakeItem("orig-1");
+        original.Questions = new List<BookingItemQuestion>
+        {
+            new() { QuestionDefId = 989, Answer = "-" },
+            new() { QuestionDefId = 991, Answer = "yes" }
+        };
+
+        var svc = CreateService(fake);
+        await svc.ReplaceItemsAsync("booking-99", new List<ItemReplacement> { new() { Original = original } });
+
+        var spec = Assert.Single(fake.CapturedSpecs);
+        Assert.Equal("-", spec.QuestionAnswers[989]);
+        Assert.Equal("yes", spec.QuestionAnswers[991]);
+    }
 }

--- a/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
@@ -1,0 +1,256 @@
+using System.Text.Json;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.Extensions.Logging;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Unit tests for BookingMutationService — all run against FakeOsmService.
+/// No WebApplicationFactory needed; the service is instantiated directly.
+/// </summary>
+public class BookingMutationServiceTests
+{
+    private static BookingMutationService CreateService(FakeOsmService fake)
+    {
+        var logger = new LoggerFactory().CreateLogger<BookingMutationService>();
+        return new BookingMutationService(fake, logger);
+    }
+
+    private static BookingItemDto MakeItem(string itemId, string siteId = "site-1",
+        string startTime = "09:00", string endTime = "17:00") => new()
+    {
+        ItemId = itemId,
+        Type = "site",
+        SiteId = siteId,
+        Label = "Test Pitch",
+        StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+        StartTime = startTime,
+        EndTime = endTime
+    };
+
+    // ── Happy path ────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task HappyPath_TwoReplacements_AllCreatedBeforeAnyDeleted_StatusCompleted()
+    {
+        var fake = new FakeOsmService
+        {
+            CreatedItemIds = new List<string> { "new-1", "new-2" },
+            ItemsToReturn = new List<BookingItemDto> { MakeItem("new-1"), MakeItem("new-2") }
+        };
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = MakeItem("orig-1") },
+            new() { Original = MakeItem("orig-2") }
+        };
+
+        var result = await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Equal(new[] { "new-1", "new-2" }, result.Created);
+        Assert.Equal(new[] { "orig-1", "orig-2" }, result.Deleted);
+        Assert.Equal(2, result.Items.Count);
+
+        // Assert ordering: all creates happened before any deletes
+        var createIndices = fake.CallLog.Select((entry, i) => (entry, i))
+            .Where(x => x.entry.Op == "create")
+            .Select(x => x.i)
+            .ToList();
+        var deleteIndices = fake.CallLog.Select((entry, i) => (entry, i))
+            .Where(x => x.entry.Op == "delete")
+            .Select(x => x.i)
+            .ToList();
+
+        Assert.NotEmpty(createIndices);
+        Assert.NotEmpty(deleteIndices);
+        Assert.True(createIndices.Max() < deleteIndices.Min(),
+            "All creates must complete before any deletes begin");
+    }
+
+    [Fact]
+    public async Task HappyPath_SingleReplacement_Works()
+    {
+        var fake = new FakeOsmService
+        {
+            CreatedItemIds = new List<string> { "new-single" },
+            ItemsToReturn = new List<BookingItemDto> { MakeItem("new-single") }
+        };
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = MakeItem("orig-single") }
+        };
+
+        var result = await svc.ReplaceItemsAsync("booking-100", replacements);
+
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Equal(new[] { "new-single" }, result.Created);
+        Assert.Equal(new[] { "orig-single" }, result.Deleted);
+    }
+
+    // ── Rollback ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task CreatePhaseFails_RollsBackCreatedItems_NoOriginalsDeleted_StatusRolledBack()
+    {
+        var fake = new FakeOsmService
+        {
+            CreatedItemIds = new List<string> { "new-1" },
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+        // 2nd create call throws
+        fake.FailCreateOnCall = (2, new InvalidOperationException("OSM create failed"));
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = MakeItem("orig-1") },
+            new() { Original = MakeItem("orig-2") }
+        };
+
+        var result = await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        Assert.Equal(BookingActionStatus.RolledBack, result.Status);
+
+        // The first create succeeded and must be rolled back
+        Assert.Empty(result.Created);
+        Assert.Contains(("booking-99", "new-1"), fake.DeletedItems);
+
+        // Original items must NOT have been deleted
+        Assert.DoesNotContain("orig-1", fake.DeletedItems.Select(d => d.ItemId));
+        Assert.DoesNotContain("orig-2", fake.DeletedItems.Select(d => d.ItemId));
+
+        Assert.NotEmpty(result.Message);
+    }
+
+    // ── completed_with_warnings ───────────────────────────────────────────────
+
+    [Fact]
+    public async Task DeletePhasePartialFailure_StatusCompletedWithWarnings()
+    {
+        var fake = new FakeOsmService
+        {
+            CreatedItemIds = new List<string> { "new-1", "new-2" },
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+        // orig-2 delete returns false
+        fake.DeleteReturnFalseForIds.Add("orig-2");
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = MakeItem("orig-1") },
+            new() { Original = MakeItem("orig-2") }
+        };
+
+        var result = await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        Assert.Equal(BookingActionStatus.CompletedWithWarnings, result.Status);
+        Assert.Equal(new[] { "new-1", "new-2" }, result.Created);
+
+        // Only orig-1 succeeded
+        Assert.Equal(new[] { "orig-1" }, result.Deleted);
+    }
+
+    // ── Override fidelity ─────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Override_NewSiteId_ReflectedInCloneJson_OtherFieldsUnchanged()
+    {
+        var fake = new FakeOsmService
+        {
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+
+        var original = MakeItem("orig-1", siteId: "site-OLD", startTime: "08:00", endTime: "16:00");
+        original.StartDate = new DateTime(2026, 8, 5, 0, 0, 0, DateTimeKind.Utc);
+        original.EndDate = new DateTime(2026, 8, 7, 0, 0, 0, DateTimeKind.Utc);
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = original, NewSiteId = "site-NEW" }
+        };
+
+        await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        Assert.Single(fake.CapturedCloneJsons);
+        var cloneJson = fake.CapturedCloneJsons[0];
+
+        // Parse the clone JSON and verify override was applied
+        var cloned = JsonSerializer.Deserialize<BookingItemDto>(cloneJson,
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(cloned);
+        Assert.Equal("site-NEW", cloned!.SiteId);          // overridden
+        Assert.Equal("08:00", cloned.StartTime);           // unchanged
+        Assert.Equal("16:00", cloned.EndTime);             // unchanged
+        Assert.Equal(original.StartDate, cloned.StartDate); // unchanged
+        Assert.Equal(original.EndDate, cloned.EndDate);     // unchanged
+    }
+
+    [Fact]
+    public async Task Override_NewStartTime_ReflectedInCloneJson_OtherFieldsUnchanged()
+    {
+        var fake = new FakeOsmService
+        {
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+
+        var original = MakeItem("orig-1", siteId: "site-42", startTime: "09:00", endTime: "17:00");
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = original, NewStartTime = "14:00", NewEndTime = "18:00" }
+        };
+
+        await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        Assert.Single(fake.CapturedCloneJsons);
+        var cloned = JsonSerializer.Deserialize<BookingItemDto>(fake.CapturedCloneJsons[0],
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(cloned);
+        Assert.Equal("14:00", cloned!.StartTime);  // overridden
+        Assert.Equal("18:00", cloned.EndTime);      // overridden
+        Assert.Equal("site-42", cloned.SiteId);     // unchanged
+    }
+
+    [Fact]
+    public async Task NoOverrides_CloneJsonMatchesOriginalFields()
+    {
+        var fake = new FakeOsmService
+        {
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+
+        var original = MakeItem("orig-1", siteId: "site-77", startTime: "10:00", endTime: "15:00");
+        original.Label = "Camping Pitch";
+        original.Type = "site";
+        original.ActivityId = null;
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = original }
+            // No overrides
+        };
+
+        await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        Assert.Single(fake.CapturedCloneJsons);
+        var cloned = JsonSerializer.Deserialize<BookingItemDto>(fake.CapturedCloneJsons[0],
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(cloned);
+        Assert.Equal("site-77", cloned!.SiteId);
+        Assert.Equal("10:00", cloned.StartTime);
+        Assert.Equal("15:00", cloned.EndTime);
+        Assert.Equal("Camping Pitch", cloned.Label);
+        Assert.Equal("site", cloned.Type);
+    }
+}

--- a/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
@@ -1,4 +1,3 @@
-using System.Text.Json;
 using BookingsAssistant.Api.Models;
 using BookingsAssistant.Api.Services;
 using BookingsAssistant.Tests.Fakes;
@@ -162,7 +161,7 @@ public class BookingMutationServiceTests
     // ── Override fidelity ─────────────────────────────────────────────────────
 
     [Fact]
-    public async Task Override_NewSiteId_ReflectedInCloneJson_OtherFieldsUnchanged()
+    public async Task Override_NewSiteId_ReflectedInSpec_OtherFieldsUnchanged()
     {
         var fake = new FakeOsmService
         {
@@ -181,22 +180,16 @@ public class BookingMutationServiceTests
 
         await svc.ReplaceItemsAsync("booking-99", replacements);
 
-        Assert.Single(fake.CapturedCloneJsons);
-        var cloneJson = fake.CapturedCloneJsons[0];
-
-        // Parse the clone JSON and verify override was applied
-        var cloned = JsonSerializer.Deserialize<BookingItemDto>(cloneJson,
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        Assert.NotNull(cloned);
-        Assert.Equal("site-NEW", cloned!.SiteId);          // overridden
-        Assert.Equal("08:00", cloned.StartTime);           // unchanged
-        Assert.Equal("16:00", cloned.EndTime);             // unchanged
-        Assert.Equal(original.StartDate, cloned.StartDate); // unchanged
-        Assert.Equal(original.EndDate, cloned.EndDate);     // unchanged
+        var spec = Assert.Single(fake.CapturedSpecs);
+        Assert.Equal("site-NEW", spec.CampsiteItemId);     // overridden (site → new item-type id)
+        Assert.Equal("08:00", spec.StartTime);             // unchanged
+        Assert.Equal("16:00", spec.EndTime);               // unchanged
+        Assert.Equal(original.StartDate, spec.StartDate);  // unchanged
+        Assert.Equal(original.EndDate, spec.EndDate);      // unchanged
     }
 
     [Fact]
-    public async Task Override_NewStartTime_ReflectedInCloneJson_OtherFieldsUnchanged()
+    public async Task Override_NewStartTime_ReflectedInSpec_OtherFieldsUnchanged()
     {
         var fake = new FakeOsmService
         {
@@ -213,17 +206,14 @@ public class BookingMutationServiceTests
 
         await svc.ReplaceItemsAsync("booking-99", replacements);
 
-        Assert.Single(fake.CapturedCloneJsons);
-        var cloned = JsonSerializer.Deserialize<BookingItemDto>(fake.CapturedCloneJsons[0],
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        Assert.NotNull(cloned);
-        Assert.Equal("14:00", cloned!.StartTime);  // overridden
-        Assert.Equal("18:00", cloned.EndTime);      // overridden
-        Assert.Equal("site-42", cloned.SiteId);     // unchanged
+        var spec = Assert.Single(fake.CapturedSpecs);
+        Assert.Equal("14:00", spec.StartTime);       // overridden
+        Assert.Equal("18:00", spec.EndTime);         // overridden
+        Assert.Equal("site-42", spec.CampsiteItemId); // unchanged
     }
 
     [Fact]
-    public async Task NoOverrides_CloneJsonMatchesOriginalFields()
+    public async Task NoOverrides_SpecMatchesOriginalFields()
     {
         var fake = new FakeOsmService
         {
@@ -234,6 +224,7 @@ public class BookingMutationServiceTests
         original.Label = "Camping Pitch";
         original.Type = "site";
         original.ActivityId = null;
+        original.NumberPeople = 12;
 
         var svc = CreateService(fake);
         var replacements = new List<ItemReplacement>
@@ -244,14 +235,10 @@ public class BookingMutationServiceTests
 
         await svc.ReplaceItemsAsync("booking-99", replacements);
 
-        Assert.Single(fake.CapturedCloneJsons);
-        var cloned = JsonSerializer.Deserialize<BookingItemDto>(fake.CapturedCloneJsons[0],
-            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
-        Assert.NotNull(cloned);
-        Assert.Equal("site-77", cloned!.SiteId);
-        Assert.Equal("10:00", cloned.StartTime);
-        Assert.Equal("15:00", cloned.EndTime);
-        Assert.Equal("Camping Pitch", cloned.Label);
-        Assert.Equal("site", cloned.Type);
+        var spec = Assert.Single(fake.CapturedSpecs);
+        Assert.Equal("site-77", spec.CampsiteItemId);
+        Assert.Equal("10:00", spec.StartTime);
+        Assert.Equal("15:00", spec.EndTime);
+        Assert.Equal(12, spec.NumberPeople);
     }
 }

--- a/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
@@ -120,6 +120,7 @@ public class BookingMutationServiceTests
 
         // The first create succeeded and must be rolled back
         Assert.Empty(result.Created);
+        Assert.Empty(result.Deleted);
         Assert.Contains(("booking-99", "new-1"), fake.DeletedItems);
 
         // Original items must NOT have been deleted

--- a/BookingsAssistant.Tests/Services/OsmServiceItemMutationTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceItemMutationTests.cs
@@ -33,6 +33,21 @@ public class OsmServiceItemMutationTests
             Fixture("availability-1387.json"),
             new DateTime(2030, 1, 1), new DateTime(2030, 1, 2)));
 
+    [Fact]
+    public void ResolveSlotId_SkipsUnavailableSlot_AndPicksAvailableMatch()
+    {
+        // Two slots share the same date span; the first is unavailable and must be skipped.
+        const string json = """
+        {"status":true,"data":[
+            {"start":"2027-12-04 00:01:00","end":"2027-12-05 23:59:00","available":false,"id":111},
+            {"start":"2027-12-04 00:01:00","end":"2027-12-05 23:59:00","available":true,"id":222}
+        ]}
+        """;
+
+        Assert.Equal("222", OsmService.ResolveSlotId(json,
+            new DateTime(2027, 12, 4), new DateTime(2027, 12, 5)));
+    }
+
     // ── BuildCreateForm ────────────────────────────────────────────────────────
 
     [Fact]
@@ -70,6 +85,11 @@ public class OsmServiceItemMutationTests
         => Assert.Throws<InvalidOperationException>(() => OsmService.ParseCreatedItemId(
             """{"status":false,"error":"insufficient scope","data":null,"meta":[]}"""));
 
+    [Fact]
+    public void ParseCreatedItemId_Throws_WhenDataIdMissing()
+        => Assert.Throws<InvalidOperationException>(() => OsmService.ParseCreatedItemId(
+            """{"status":true,"error":null,"data":{},"meta":[]}"""));
+
     // ── ParseDeleteSucceeded ───────────────────────────────────────────────────
 
     [Fact]
@@ -79,6 +99,13 @@ public class OsmServiceItemMutationTests
     [Fact]
     public void ParseDeleteSucceeded_FalseOnStatusFalse()
         => Assert.False(OsmService.ParseDeleteSucceeded("""{"status":false,"error":"nope","data":[],"meta":[]}"""));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseDeleteSucceeded_FalseOnBlankInput(string? input)
+        => Assert.False(OsmService.ParseDeleteSucceeded(input));
 
     // ── ParseItemQuestions ─────────────────────────────────────────────────────
 
@@ -134,5 +161,16 @@ public class OsmServiceItemMutationTests
 
         Assert.Contains("\"id\":555001", json);
         Assert.DoesNotContain("555002", json);
+    }
+
+    [Fact]
+    public void BuildAnswersJson_SkipsQuestion_WhenOriginalAnswerIsEmptyString()
+    {
+        // An original answer that is present but blank should not be replayed (the
+        // clone's row is already blank).
+        var originalByDefId = new Dictionary<int, string> { [989] = "" };
+        var cloneQuestions = new List<OsmItemQuestion> { new(555001, 989, "") };
+
+        Assert.Equal("[]", OsmService.BuildAnswersJson(originalByDefId, cloneQuestions));
     }
 }

--- a/BookingsAssistant.Tests/Services/OsmServiceItemMutationTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceItemMutationTests.cs
@@ -1,0 +1,138 @@
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Unit tests for the OSM item create/delete mapping helpers, against captured fixtures
+/// (BookingsAssistant.Tests/Fixtures/OsmItems/, see README.md). These pin the slot-resolution,
+/// create-payload, response-parsing, and question-replay logic that the live HTTP methods rely on.
+/// </summary>
+public class OsmServiceItemMutationTests
+{
+    private static string Fixture(string name) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "OsmItems", name));
+
+    // ── ResolveSlotId ──────────────────────────────────────────────────────────
+
+    [Fact]
+    public void ResolveSlotId_MatchesMultiDaySiteSlot_ByDateSpan()
+        => Assert.Equal("8279", OsmService.ResolveSlotId(
+            Fixture("availability-1387.json"),
+            new DateTime(2027, 12, 4), new DateTime(2027, 12, 5)));
+
+    [Fact]
+    public void ResolveSlotId_MatchesActivitySlot_OnTargetDay()
+        => Assert.Equal("9235", OsmService.ResolveSlotId(
+            Fixture("availability-4961.json"),
+            new DateTime(2027, 12, 5), new DateTime(2027, 12, 5)));
+
+    [Fact]
+    public void ResolveSlotId_ReturnsNull_WhenNoSlotMatchesDateSpan()
+        => Assert.Null(OsmService.ResolveSlotId(
+            Fixture("availability-1387.json"),
+            new DateTime(2030, 1, 1), new DateTime(2030, 1, 2)));
+
+    // ── BuildCreateForm ────────────────────────────────────────────────────────
+
+    [Fact]
+    public void BuildCreateForm_ProducesOsmAddItemFields()
+    {
+        var spec = new BookingItemCreateSpec
+        {
+            CampsiteItemId = "1387",
+            StartDate = new DateTime(2027, 12, 4),
+            EndDate = new DateTime(2027, 12, 5),
+            StartTime = "00:01",
+            EndTime = "23:59",
+            NumberPeople = 20
+        };
+
+        var form = OsmService.BuildCreateForm(spec, "8279");
+
+        Assert.Equal("8279", form["slot_id"]);
+        Assert.Equal("2027-12-04", form["start"]);
+        Assert.Equal("2027-12-05", form["end"]);
+        Assert.Equal("20", form["number_people"]);
+        Assert.Equal("00:01", form["start_time"]);
+        Assert.Equal("23:59", form["end_time"]);
+    }
+
+    // ── ParseCreatedItemId ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseCreatedItemId_ReturnsNewItemId()
+        => Assert.Equal("411467", OsmService.ParseCreatedItemId(
+            """{"status":true,"error":null,"data":{"id":411467,"item_name":"Hayvern","questions":3},"meta":[]}"""));
+
+    [Fact]
+    public void ParseCreatedItemId_Throws_WhenStatusFalse()
+        => Assert.Throws<InvalidOperationException>(() => OsmService.ParseCreatedItemId(
+            """{"status":false,"error":"insufficient scope","data":null,"meta":[]}"""));
+
+    // ── ParseDeleteSucceeded ───────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseDeleteSucceeded_TrueOnStatusTrue()
+        => Assert.True(OsmService.ParseDeleteSucceeded("""{"status":true,"error":null,"data":[],"meta":[]}"""));
+
+    [Fact]
+    public void ParseDeleteSucceeded_FalseOnStatusFalse()
+        => Assert.False(OsmService.ParseDeleteSucceeded("""{"status":false,"error":"nope","data":[],"meta":[]}"""));
+
+    // ── ParseItemQuestions ─────────────────────────────────────────────────────
+
+    [Fact]
+    public void ParseItemQuestions_ExtractsRowIdQuestionDefAndAnswer()
+    {
+        var questions = OsmService.ParseItemQuestions(Fixture("questions-get-411467.json"));
+
+        Assert.Equal(3, questions.Count);
+        var first = questions[0];
+        Assert.Equal(234758, first.RowId);
+        Assert.Equal(989, first.QuestionDefId);
+        Assert.Equal("", first.Answer);
+    }
+
+    // ── BuildAnswersJson (replay) ──────────────────────────────────────────────
+
+    [Fact]
+    public void BuildAnswersJson_MapsOriginalAnswersToCloneRowIds_ByQuestionDefId()
+    {
+        // Original answers keyed by stable question-definition id
+        var originalByDefId = new Dictionary<int, string> { [989] = "-", [990] = "-", [991] = "-" };
+
+        // The clone has DIFFERENT row ids for the SAME question definitions
+        var cloneQuestions = new List<OsmItemQuestion>
+        {
+            new(555001, 989, ""),
+            new(555002, 990, ""),
+            new(555003, 991, "")
+        };
+
+        var json = OsmService.BuildAnswersJson(originalByDefId, cloneQuestions);
+
+        // Answers posted against the CLONE's row ids, carrying the original answers
+        Assert.Contains("\"id\":555001", json);
+        Assert.Contains("\"id\":555002", json);
+        Assert.Contains("\"id\":555003", json);
+        Assert.Contains("\"answer\":\"-\"", json);
+        Assert.DoesNotContain("234758", json); // not the original row ids
+    }
+
+    [Fact]
+    public void BuildAnswersJson_SkipsQuestions_WithNoOriginalAnswer()
+    {
+        var originalByDefId = new Dictionary<int, string> { [989] = "yes" };
+        var cloneQuestions = new List<OsmItemQuestion>
+        {
+            new(555001, 989, ""),   // has an original answer → included
+            new(555002, 990, "")    // no original answer / blank → skipped
+        };
+
+        var json = OsmService.BuildAnswersJson(originalByDefId, cloneQuestions);
+
+        Assert.Contains("\"id\":555001", json);
+        Assert.DoesNotContain("555002", json);
+    }
+}

--- a/BookingsAssistant.Tests/Services/OsmServiceItemParsingTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceItemParsingTests.cs
@@ -52,6 +52,17 @@ public class OsmServiceItemParsingTests
     }
 
     [Fact]
+    public void ParseBookingItems_CapturesQuestionAnswers_KeyedByQuestionDefId()
+    {
+        var site = ParseRealBooking().Single(i => i.ItemId == "411467");
+
+        // Original answers are needed to replay onto a clone (matched by question-def id)
+        Assert.Equal(3, site.Questions.Count);
+        Assert.Equal(989, site.Questions[0].QuestionDefId);
+        Assert.Equal("-", site.Questions[0].Answer);
+    }
+
+    [Fact]
     public void ParseBookingItems_ReturnsEmpty_WhenNoItems()
         => Assert.Empty(OsmService.ParseBookingItems(
             """{"status":true,"error":null,"data":{"id":1,"items":[]},"meta":[]}"""));

--- a/BookingsAssistant.Tests/Services/OsmServiceItemParsingTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceItemParsingTests.cs
@@ -1,0 +1,70 @@
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Unit tests for OsmService.ParseBookingItems against captured OSM response fixtures
+/// (BookingsAssistant.Tests/Fixtures/OsmItems/, see README.md). These pin the booked-item
+/// shape so the GetBookingItemsAsync seam stays correct.
+/// </summary>
+public class OsmServiceItemParsingTests
+{
+    private static string Fixture(string name) =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "OsmItems", name));
+
+    private static List<BookingItemDto> ParseRealBooking() =>
+        OsmService.ParseBookingItems(Fixture("booking-detail-with-items.json"));
+
+    [Fact]
+    public void ParseBookingItems_ReturnsBothBookedItems()
+        => Assert.Equal(2, ParseRealBooking().Count);
+
+    [Fact]
+    public void ParseBookingItems_MapsSiteItem()
+    {
+        var site = ParseRealBooking().Single(i => i.ItemId == "411467");
+
+        Assert.Equal("site", site.Type);
+        Assert.Equal("1387", site.SiteId);          // campsite_item_id → the item-type id used to re-add
+        Assert.Null(site.ActivityId);
+        Assert.Equal(new DateTime(2027, 12, 4), site.StartDate);
+        Assert.Equal(new DateTime(2027, 12, 5), site.EndDate);
+        Assert.Equal("00:01", site.StartTime);
+        Assert.Equal("23:59", site.EndTime);
+        Assert.Equal(20, site.NumberPeople);
+        Assert.Equal("Hayvern", site.Label);
+    }
+
+    [Fact]
+    public void ParseBookingItems_MapsActivityItem_ViaInstructorFields()
+    {
+        var activity = ParseRealBooking().Single(i => i.ItemId == "411468");
+
+        Assert.Equal("activity", activity.Type);    // discriminated by instructor fields, not the name prefix
+        Assert.Equal("4961", activity.ActivityId);
+        Assert.Null(activity.SiteId);
+        Assert.Equal(new DateTime(2027, 12, 5), activity.StartDate);
+        Assert.Equal("09:00", activity.StartTime);
+        Assert.Equal("10:00", activity.EndTime);
+        Assert.Equal(10, activity.NumberPeople);
+        Assert.Equal("ACTIVITY - Air Rifle Shooting", activity.Label);
+    }
+
+    [Fact]
+    public void ParseBookingItems_ReturnsEmpty_WhenNoItems()
+        => Assert.Empty(OsmService.ParseBookingItems(
+            """{"status":true,"error":null,"data":{"id":1,"items":[]},"meta":[]}"""));
+
+    [Fact]
+    public void ParseBookingItems_ReturnsEmpty_WhenStatusFalse()
+        => Assert.Empty(OsmService.ParseBookingItems(
+            """{"status":false,"error":"nope","data":null,"meta":[]}"""));
+
+    [Theory]
+    [InlineData(null)]
+    [InlineData("")]
+    [InlineData("   ")]
+    public void ParseBookingItems_ReturnsEmpty_ForBlankInput(string? input)
+        => Assert.Empty(OsmService.ParseBookingItems(input));
+}

--- a/BookingsAssistant.Tests/Services/OsmServiceItemParsingTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceItemParsingTests.cs
@@ -45,6 +45,7 @@ public class OsmServiceItemParsingTests
         Assert.Equal("4961", activity.ActivityId);
         Assert.Null(activity.SiteId);
         Assert.Equal(new DateTime(2027, 12, 5), activity.StartDate);
+        Assert.Equal(new DateTime(2027, 12, 5), activity.EndDate);
         Assert.Equal("09:00", activity.StartTime);
         Assert.Equal("10:00", activity.EndTime);
         Assert.Equal(10, activity.NumberPeople);

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -1,7 +1,7 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { bookingsApi } from '../services/apiClient';
-import type { BookingDetail as BookingDetailType } from '../types';
+import type { BookingDetail as BookingDetailType, BookingItem } from '../types';
 
 export default function BookingDetail() {
   const { id } = useParams<{ id: string }>();
@@ -12,6 +12,9 @@ export default function BookingDetail() {
   const [newComment, setNewComment] = useState('');
   const [posting, setPosting] = useState(false);
   const [postError, setPostError] = useState<string | null>(null);
+  const [items, setItems] = useState<BookingItem[] | null>(null);
+  const [itemsLoading, setItemsLoading] = useState(false);
+  const [itemsUnavailable, setItemsUnavailable] = useState(false);
 
   useEffect(() => {
     const fetchBooking = async () => {
@@ -30,6 +33,31 @@ export default function BookingDetail() {
     };
 
     fetchBooking();
+  }, [id]);
+
+  useEffect(() => {
+    const fetchItems = async () => {
+      if (!id) return;
+      setItemsLoading(true);
+      setItemsUnavailable(false);
+      try {
+        const data = await bookingsApi.getItems(parseInt(id));
+        setItems(data);
+      } catch (err: unknown) {
+        // 501 = OSM parsing seam not yet wired; show graceful message rather than crashing
+        const status = (err as { response?: { status?: number } })?.response?.status;
+        if (status === 501) {
+          setItemsUnavailable(true);
+        } else {
+          setItemsUnavailable(true);
+          console.error('Failed to load items', err);
+        }
+      } finally {
+        setItemsLoading(false);
+      }
+    };
+
+    fetchItems();
   }, [id]);
 
   const handlePostComment = async () => {
@@ -208,6 +236,49 @@ export default function BookingDetail() {
           </div>
         ) : (
           <p className="text-gray-500">No emails linked to this booking.</p>
+        )}
+      </div>
+
+      {/* Items */}
+      <div className="bg-white rounded-lg shadow p-6 mb-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">Items</h2>
+        {itemsLoading ? (
+          <p className="text-gray-500">Loading items...</p>
+        ) : itemsUnavailable ? (
+          <p className="text-gray-400 italic">Items not available yet.</p>
+        ) : items && items.length > 0 ? (
+          <div className="space-y-3">
+            {items.map((item) => (
+              <div key={item.itemId} className="p-4 border border-gray-200 rounded bg-gray-50">
+                <div className="flex items-center gap-2 mb-1">
+                  <span className={`px-2 py-0.5 rounded text-xs font-medium ${
+                    item.type === 'site' ? 'bg-green-100 text-green-800' : 'bg-purple-100 text-purple-800'
+                  }`}>
+                    {item.type}
+                  </span>
+                  <span className="font-semibold text-gray-800">{item.label}</span>
+                </div>
+                <div className="text-sm text-gray-600 space-y-0.5">
+                  {item.siteId && <div>Site: {item.siteId}</div>}
+                  {item.activityId && <div>Activity: {item.activityId}</div>}
+                  {item.startDate && (
+                    <div>
+                      Start: {new Date(item.startDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
+                      {item.startTime && ` at ${item.startTime}`}
+                    </div>
+                  )}
+                  {item.endDate && (
+                    <div>
+                      End: {new Date(item.endDate).toLocaleDateString('en-GB', { day: 'numeric', month: 'short', year: 'numeric' })}
+                      {item.endTime && ` at ${item.endTime}`}
+                    </div>
+                  )}
+                </div>
+              </div>
+            ))}
+          </div>
+        ) : (
+          <p className="text-gray-500">No items on this booking.</p>
         )}
       </div>
 

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -46,12 +46,8 @@ export default function BookingDetail() {
       } catch (err: unknown) {
         // 501 = OSM parsing seam not yet wired; show graceful message rather than crashing
         const status = (err as { response?: { status?: number } })?.response?.status;
-        if (status === 501) {
-          setItemsUnavailable(true);
-        } else {
-          setItemsUnavailable(true);
-          console.error('Failed to load items', err);
-        }
+        setItemsUnavailable(true);
+        if (status !== 501) console.error('Failed to load items', err);
       } finally {
         setItemsLoading(false);
       }

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -2,6 +2,7 @@ import axios from 'axios';
 import type {
   Booking,
   BookingDetail,
+  BookingItem,
   Email,
   Link,
   CreateLinkRequest,
@@ -67,6 +68,11 @@ export const bookingsApi = {
 
   postComment: async (id: number, comment: string): Promise<void> => {
     await apiClient.post(`/bookings/${id}/comments`, { comment });
+  },
+
+  getItems: async (id: number): Promise<BookingItem[]> => {
+    const response = await apiClient.get<BookingItem[]>(`/bookings/${id}/items`);
+    return response.data;
   },
 };
 

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -1,12 +1,16 @@
 import axios from 'axios';
 import type {
   Booking,
+  BookingActionResult,
   BookingDetail,
   BookingItem,
+  ChangeSiteRequest,
   Email,
   Link,
   CreateLinkRequest,
   BookingStats,
+  MoveActivityRequest,
+  MoveDatesRequest,
   PagedResult
 } from '../types';
 
@@ -72,6 +76,21 @@ export const bookingsApi = {
 
   getItems: async (id: number): Promise<BookingItem[]> => {
     const response = await apiClient.get<BookingItem[]>(`/bookings/${id}/items`);
+    return response.data;
+  },
+
+  moveActivity: async (id: number, req: MoveActivityRequest): Promise<BookingActionResult> => {
+    const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/move-activity`, req);
+    return response.data;
+  },
+
+  changeSite: async (id: number, req: ChangeSiteRequest): Promise<BookingActionResult> => {
+    const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/change-site`, req);
+    return response.data;
+  },
+
+  moveDates: async (id: number, req: MoveDatesRequest): Promise<BookingActionResult> => {
+    const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/move-dates`, req);
     return response.data;
   },
 };

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -93,3 +93,16 @@ export interface BookingStats {
   provisional: number;
   lastSynced: string | null;
 }
+
+export interface BookingItem {
+  itemId: string;
+  /** "site" or "activity" */
+  type: string;
+  siteId?: string;
+  activityId?: string;
+  startDate?: string;
+  endDate?: string;
+  startTime?: string;
+  endTime?: string;
+  label: string;
+}

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -106,3 +106,36 @@ export interface BookingItem {
   endTime?: string;
   label: string;
 }
+
+/** Result of a booking mutation operation (item replacement). Mirrors BookingActionResult on the backend. */
+export interface BookingActionResult {
+  /** Ids of items successfully created during this operation. */
+  created: string[];
+  /** Ids of items successfully deleted during this operation. */
+  deleted: string[];
+  /** One of: "completed", "completed_with_warnings", "rolled_back", "failed". */
+  status: string;
+  /** Human-readable explanation of the outcome. */
+  message: string;
+  /** The booking's items after the operation completes. */
+  items: BookingItem[];
+}
+
+/** Request to move an activity item (change time or date). */
+export interface MoveActivityRequest {
+  itemId: string;
+  newStartDate?: string;
+  newStartTime?: string;
+  newEndTime?: string;
+}
+
+/** Request to move a site item to a different site. */
+export interface ChangeSiteRequest {
+  itemId: string;
+  newSiteId: string;
+}
+
+/** Request to shift all items in a booking by the given number of days. */
+export interface MoveDatesRequest {
+  dayShift: number;
+}

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.9.24
+version: 0.9.25
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.9.23
+version: 0.9.24
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper


### PR DESCRIPTION
## Summary

Adds a "booking actions" API (`/api/bookings/{id}/actions/*`) for three OSM operations OSM does not support natively: moving an activity to a different time, changing a site assignment, and shifting all booking dates by N days. All three share a single mutation engine (`BookingMutationService`) using a create-all-then-delete-all strategy with rollback. A `GET /api/bookings/{id}/items` endpoint and a read-only React items panel are added as the read-side.

## Approach

Each mutation clones the affected item(s) with overrides applied, creates the clones in OSM first, then deletes the originals only after all creates succeed. Safe ordering: if any create fails, nothing has been deleted yet, so rollback is just deleting the newly-created clones.

Two deferred seams sit at the OSM boundary: `GetBookingItemsAsync` (response parsing), `CreateBookingItemAsync`, and `DeleteBookingItemAsync` throw `NotImplementedException` in the real `OsmService` until example OSM request/response data confirms endpoint URLs and payload shapes. The controller maps these to **HTTP 501** and the React UI degrades gracefully. Engine and controller logic are fully implemented and tested against `FakeOsmService`; only the OSM wire-up is parked (follow-up chunk `osm-payload-mapping`, pending captured example data).

## Key decisions

- **Shared engine:** all three verbs funnel into `ReplaceItemsAsync`; the controller translates verb-specific requests into `ItemReplacement` lists. Eliminates three copies of the create/delete/rollback loop.
- **Create-all before delete-all:** phase 2 (delete originals) only begins if phase 1 (create clones) fully succeeds; mid-phase-1 failure rolls back partial creates and returns `rolled_back`. The booking is never left half-deleted.
- **200 for all engine outcomes:** `completed` / `completed_with_warnings` / `rolled_back` / `failed` all return 200 with a `BookingActionResult` body; HTTP error codes are reserved for transport/input failures (400/404/401/501/502). Caller reads `result.Status`.
- **Interim clone:** `BuildCloneJson` serialises the DTO with overrides; won't round-trip OSM fields outside our DTO — flagged in-code, replaced by the `osm-payload-mapping` chunk.
- **Item-lookup in controller, not engine:** keeps the engine's responsibility narrow (orchestration only).

## Testing strategy

- `BookingMutationServiceTests` (unit, fake OSM): happy path with create-before-delete ordering assertion, single-item, rollback on create failure (originals untouched), `completed_with_warnings` on partial delete failure, override-fidelity (siteId/time/passthrough).
- `BookingActionsItemsTests` (integration): `GET /items` → 200 list / 404 / 501 seam.
- `BookingActionsTests` (integration): all three verbs happy-path, 400 validation, 404 booking/item not found, move-dates shift correctness + time preservation (incl. mixed dated/dateless items), `rolled_back` and `completed_with_warnings` propagation.

**Full suite: 145/145 passing. Frontend: `tsc --noEmit`, `vite build`, `eslint` all clean.**

## Review guidance

- **Riskiest:** `BookingMutationService.ReplaceItemsAsync` rollback — iterates `created` (only what was created), verified correct.
- **Deferred seam:** the three `OsmService` methods → 501 are the only thing blocking real end-to-end use. The follow-up chunk needs a captured live OSM response to confirm the items endpoint shape and create/delete request format.
- **Security:** reviewed — new endpoints are same-origin (no `ExtensionCapture` CORS), inherit the `X-Api-Token` guard, log no PII, and don't inject user input into OSM URLs. Note for the follow-up: URL-encode `itemId`/`siteId` when wiring the create/delete stubs.

Addon version bumped to 0.9.24.

---

## Update — OSM seam now wired (#26 / #27)

The three deferred `OsmService` seams (previously `NotImplementedException` → HTTP 501) are now
implemented against captured OSM request/response data (HAR from a live session; redacted fixtures in
`BookingsAssistant.Tests/Fixtures/OsmItems/`). The booking-actions API is now functional end-to-end.

**What changed:**
- **List:** corrected `GetBookingItemsAsync` to read booked items from `GET /v3/campsites/bookings/{id}`
  (booking-detail), not the `/items` catalogue endpoint. Maps id, site/activity type, dates/times, people, label.
- **Create:** `POST /v3/campsites/bookings/{id}/addItem/{itemTypeId}` — resolves an availability `slot_id`
  for the target date window first (a separate lookup OSM requires), then posts the form.
- **Delete:** `POST /v3/campsites/bookings/items/{id}/delete`.
- **Question replay:** after cloning, the original item's question answers are replayed onto the new item
  (matched by the stable `campsite_booking_question_id`, since per-item answer-row ids differ).
- Seam refactored from an interim `cloneJson` string to a typed `BookingItemCreateSpec`; all OSM
  parse/build logic extracted into unit-tested pure helpers; the now-dead 501 handling removed.

**Still open:** the OAuth `section:campsite_bookings:write` scope coverage for addItem/delete is **unconfirmed**
— the captured HAR used browser session cookies, not our Bearer token. A live smoke test with the addon's
OAuth token is needed before relying on the mutations in production. Frontend action forms remain deferred
(the API is callable; no UI yet). Addon version bumped to 0.9.25.

**Full suite: 172/172 passing.** Reviewed for clarity + security (no must-fix findings); opaque ids URL-encoded.

[release-note]feature: Booking actions API (move activity, change site, shift booking dates) is now live — OSM create/delete wired with availability-slot resolution and question-answer replay.[/release-note]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
