### PR TITLE
Booking-action UI forms (move activity, change site, move dates) (#28)

### DIFF
--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -53,6 +53,32 @@ public class BookingActionsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Lists the bookable sites/pitches the booking's site items could be moved to (for change-site).
+    /// </summary>
+    [HttpGet("{id}/available-sites")]
+    public async Task<ActionResult<List<AvailableSiteDto>>> GetAvailableSites(int id)
+    {
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var sites = await _osmService.GetAvailableSitesAsync(booking.OsmBookingId);
+            return Ok(sites);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching available sites for booking {Id}", id);
+            return StatusCode(502, new { message = "Error fetching sites from OSM", detail = ex.Message });
+        }
+    }
+
     // ── Error mapping convention for mutation endpoints ───────────────────────
     // - 400 Bad Request: missing/invalid request parameters (checked before OSM calls)
     // - 404 Not Found: booking not in DB, or item not in booking's current item list

--- a/BookingsAssistant.Api/Models/AvailableSiteDto.cs
+++ b/BookingsAssistant.Api/Models/AvailableSiteDto.cs
@@ -1,0 +1,12 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// A bookable site/pitch the user can move a booked item to (for the change-site action).
+/// Sourced from the OSM item-type catalogue.
+/// </summary>
+public class AvailableSiteDto
+{
+    /// <summary>OSM item-type id (campsite_item_id), used as newSiteId in a change-site request.</summary>
+    public string Id { get; set; } = string.Empty;
+    public string Name { get; set; } = string.Empty;
+}

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -41,6 +41,12 @@ public interface IOsmService
     /// </summary>
     Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId);
 
+    /// <summary>
+    /// Lists the bookable sites/pitches a booked item could be moved to (for change-site),
+    /// sourced from the OSM item-type catalogue.
+    /// </summary>
+    Task<List<AvailableSiteDto>> GetAvailableSitesAsync(string osmBookingId);
+
     // Auth
     string GetAuthorizationUrl(string redirectUri);
     Task<bool> HandleOAuthCallbackAsync(string code, int userId, string redirectUri);

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -676,8 +676,9 @@ internal class OsmService : IOsmService
 
     /// <summary>
     /// Parses the OSM item-type catalogue (GET /v3/campsites/{id}/items?mode=booking) into the bookable
-    /// sites/pitches: the leaf item-types directly under the "Campsites" and "Indoor Accommodation"
-    /// categories. Category nodes and the (separate) "Activities" tree are excluded. Pure/static for testing.
+    /// sites/pitches: the leaf item-types (nodes that are not themselves parents) under the "Campsites" and
+    /// "Indoor Accommodation" categories. Category nodes and the (separate) "Activities" tree are excluded.
+    /// Pure/static for testing.
     /// </summary>
     internal static List<AvailableSiteDto> ParseAvailableSites(string? catalogueJson)
     {
@@ -688,31 +689,42 @@ internal class OsmService : IOsmService
         if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
             return sites;
 
-        // Site categories (by name) and the set of nodes that are themselves parents (i.e. categories,
-        // not bookable leaves).
-        var siteCategoryIds = new HashSet<int>();
+        // First pass: index nodes by id, group children by parent, find the site category roots
+        // (by name), and record which ids are themselves parents (i.e. categories, not leaves).
+        var nameById = new Dictionary<int, string>();
+        var childrenByParent = new Dictionary<int, List<int>>();
         var parentIds = new HashSet<int>();
-        foreach (var node in data.EnumerateArray())
-        {
-            if (node.TryGetProperty("parent_id", out var p) && p.TryGetInt32(out var pid))
-                parentIds.Add(pid);
-            var name = GetString(node, "name");
-            if (name is "Campsites" or "Indoor Accommodation")
-                siteCategoryIds.Add(GetInt(node, "id"));
-        }
-
+        var siteCategoryIds = new List<int>();
         foreach (var node in data.EnumerateArray())
         {
             var id = GetInt(node, "id");
-            var parentId = node.TryGetProperty("parent_id", out var p) && p.TryGetInt32(out var pid) ? pid : 0;
+            var name = GetString(node, "name") ?? string.Empty;
+            nameById[id] = name;
+            if (node.TryGetProperty("parent_id", out var p) && p.TryGetInt32(out var pid))
+            {
+                parentIds.Add(pid);
+                (childrenByParent.TryGetValue(pid, out var list) ? list : childrenByParent[pid] = new List<int>()).Add(id);
+            }
+            if (name is "Campsites" or "Indoor Accommodation")
+                siteCategoryIds.Add(id);
+        }
 
-            // A bookable site = a child of a site category that is not itself a (sub-)category.
-            if (siteCategoryIds.Contains(parentId) && !parentIds.Contains(id))
-                sites.Add(new AvailableSiteDto
-                {
-                    Id = id.ToString(),
-                    Name = GetString(node, "name") ?? string.Empty
-                });
+        // Walk all descendants of the site categories; the bookable sites are the leaves
+        // (nodes that are not themselves parents of anything). Handles arbitrary nesting depth.
+        var queue = new Queue<int>(siteCategoryIds);
+        var seen = new HashSet<int>(siteCategoryIds);
+        while (queue.Count > 0)
+        {
+            var current = queue.Dequeue();
+            if (!childrenByParent.TryGetValue(current, out var children)) continue;
+            foreach (var child in children)
+            {
+                if (!seen.Add(child)) continue;
+                if (parentIds.Contains(child))
+                    queue.Enqueue(child);   // sub-category — descend
+                else
+                    sites.Add(new AvailableSiteDto { Id = child.ToString(), Name = nameById[child] });
+            }
         }
 
         return sites;

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -391,6 +391,26 @@ internal class OsmService : IOsmService
         return ParseDeleteSucceeded(json);
     }
 
+    public async Task<List<AvailableSiteDto>> GetAvailableSitesAsync(string osmBookingId)
+    {
+        // The bookable site/pitch catalogue comes from the same /items catalogue endpoint
+        // (the item-type tree), filtered to the site categories. See ParseAvailableSites.
+        var url = $"/v3/campsites/{_campsiteId}/items?booking_id={Uri.EscapeDataString(osmBookingId)}&mode=booking&audience=venue";
+
+        var response = await SendAuthorizedAsync(HttpMethod.Get, url, null);
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                throw new InvalidOperationException($"OSM authentication failed fetching sites for booking {osmBookingId}");
+
+            _logger.LogError("OSM catalogue endpoint returned {StatusCode} for booking {BookingId}",
+                response.StatusCode, osmBookingId);
+            return new List<AvailableSiteDto>();
+        }
+
+        return ParseAvailableSites(await response.Content.ReadAsStringAsync());
+    }
+
     private async Task ReplayQuestionAnswersAsync(string itemId, IReadOnlyDictionary<int, string> answersByDefId)
     {
         try
@@ -652,6 +672,50 @@ internal class OsmService : IOsmService
                     Answer = GetString(q, "answer") ?? string.Empty
                 });
         return list;
+    }
+
+    /// <summary>
+    /// Parses the OSM item-type catalogue (GET /v3/campsites/{id}/items?mode=booking) into the bookable
+    /// sites/pitches: the leaf item-types directly under the "Campsites" and "Indoor Accommodation"
+    /// categories. Category nodes and the (separate) "Activities" tree are excluded. Pure/static for testing.
+    /// </summary>
+    internal static List<AvailableSiteDto> ParseAvailableSites(string? catalogueJson)
+    {
+        var sites = new List<AvailableSiteDto>();
+        if (string.IsNullOrWhiteSpace(catalogueJson)) return sites;
+
+        using var doc = JsonDocument.Parse(catalogueJson);
+        if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
+            return sites;
+
+        // Site categories (by name) and the set of nodes that are themselves parents (i.e. categories,
+        // not bookable leaves).
+        var siteCategoryIds = new HashSet<int>();
+        var parentIds = new HashSet<int>();
+        foreach (var node in data.EnumerateArray())
+        {
+            if (node.TryGetProperty("parent_id", out var p) && p.TryGetInt32(out var pid))
+                parentIds.Add(pid);
+            var name = GetString(node, "name");
+            if (name is "Campsites" or "Indoor Accommodation")
+                siteCategoryIds.Add(GetInt(node, "id"));
+        }
+
+        foreach (var node in data.EnumerateArray())
+        {
+            var id = GetInt(node, "id");
+            var parentId = node.TryGetProperty("parent_id", out var p) && p.TryGetInt32(out var pid) ? pid : 0;
+
+            // A bookable site = a child of a site category that is not itself a (sub-)category.
+            if (siteCategoryIds.Contains(parentId) && !parentIds.Contains(id))
+                sites.Add(new AvailableSiteDto
+                {
+                    Id = id.ToString(),
+                    Name = GetString(node, "name") ?? string.Empty
+                });
+        }
+
+        return sites;
     }
 
     /// <summary>Splits an OSM "yyyy-MM-dd HH:mm:ss" timestamp into a date and the "HH:mm" portion of the time.</summary>

--- a/BookingsAssistant.Tests/Controllers/BookingActionsAvailableSitesTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsAvailableSitesTests.cs
@@ -80,4 +80,40 @@ public class BookingActionsAvailableSitesTests : IClassFixture<WebApplicationFac
         var response = await _factory.CreateClient().GetAsync("/api/bookings/999999/available-sites");
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
+
+    [Fact]
+    public async Task GetAvailableSites_Returns200WithEmptyList_WhenNoSites()
+    {
+        var bookingId = await SeedBookingAsync("88002");
+        _fakeOsm.AvailableSitesToReturn = new List<AvailableSiteDto>();
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-sites");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var sites = await response.Content.ReadFromJsonAsync<List<AvailableSiteDto>>();
+        Assert.NotNull(sites);
+        Assert.Empty(sites!);
+    }
+
+    [Fact]
+    public async Task GetAvailableSites_Returns401_WhenOsmAuthFails()
+    {
+        var bookingId = await SeedBookingAsync("88003");
+        _fakeOsm.GetSitesError = new InvalidOperationException("OSM authentication failed fetching sites");
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-sites");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAvailableSites_Returns502_WhenOsmErrors()
+    {
+        var bookingId = await SeedBookingAsync("88004");
+        _fakeOsm.GetSitesError = new Exception("OSM unreachable");
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-sites");
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
 }

--- a/BookingsAssistant.Tests/Controllers/BookingActionsAvailableSitesTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsAvailableSitesTests.cs
@@ -1,0 +1,83 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class BookingActionsAvailableSitesTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsAvailableSitesTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_AvailableSites_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?> { ["Hashing:Iterations"] = "1" }));
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase(dbName));
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    private async Task<int> SeedBookingAsync(string osmBookingId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var booking = new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "Test Group",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Provisional"
+        };
+        db.OsmBookings.Add(booking);
+        await db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    [Fact]
+    public async Task GetAvailableSites_Returns200WithList_WhenBookingExists()
+    {
+        var bookingId = await SeedBookingAsync("88001");
+        _fakeOsm.AvailableSitesToReturn = new List<AvailableSiteDto>
+        {
+            new() { Id = "1387", Name = "Hayvern" },
+            new() { Id = "1404", Name = "Birch" }
+        };
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-sites");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var sites = await response.Content.ReadFromJsonAsync<List<AvailableSiteDto>>();
+        Assert.NotNull(sites);
+        Assert.Equal(2, sites!.Count);
+        Assert.Contains(sites, s => s.Id == "1387" && s.Name == "Hayvern");
+    }
+
+    [Fact]
+    public async Task GetAvailableSites_Returns404_WhenBookingNotFound()
+    {
+        var response = await _factory.CreateClient().GetAsync("/api/bookings/999999/available-sites");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -60,8 +60,14 @@ public class FakeOsmService : IOsmService
 
     public List<AvailableSiteDto> AvailableSitesToReturn { get; set; } = new();
 
+    /// <summary>If set, GetAvailableSitesAsync throws this (to exercise the controller's 401/502 paths).</summary>
+    public Exception? GetSitesError { get; set; }
+
     public Task<List<AvailableSiteDto>> GetAvailableSitesAsync(string osmBookingId)
-        => Task.FromResult(AvailableSitesToReturn);
+    {
+        if (GetSitesError != null) throw GetSitesError;
+        return Task.FromResult(AvailableSitesToReturn);
+    }
 
     // Create / Delete — configurable for mutation service tests
     public List<string> CreatedItemIds { get; set; } = new();

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -58,6 +58,11 @@ public class FakeOsmService : IOsmService
     public Task<List<BookingItemDto>> GetBookingItemsAsync(string osmBookingId)
         => Task.FromResult(ItemsToReturn);
 
+    public List<AvailableSiteDto> AvailableSitesToReturn { get; set; } = new();
+
+    public Task<List<AvailableSiteDto>> GetAvailableSitesAsync(string osmBookingId)
+        => Task.FromResult(AvailableSitesToReturn);
+
     // Create / Delete — configurable for mutation service tests
     public List<string> CreatedItemIds { get; set; } = new();
     private int _createCallCount;

--- a/BookingsAssistant.Tests/Services/OsmServiceAvailableSitesTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceAvailableSitesTests.cs
@@ -1,0 +1,59 @@
+using BookingsAssistant.Api.Services;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Unit tests for OsmService.ParseAvailableSites against the captured OSM catalogue fixture.
+/// "Sites" are the bookable item-types under the "Campsites" / "Indoor Accommodation" categories;
+/// activities and the category nodes themselves are excluded.
+/// </summary>
+public class OsmServiceAvailableSitesTests
+{
+    private static string Catalogue() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "OsmItems", "items-catalogue-list.json"));
+
+    [Fact]
+    public void ParseAvailableSites_IncludesIndoorAccommodationSite()
+    {
+        var sites = OsmService.ParseAvailableSites(Catalogue());
+        var hayvern = sites.SingleOrDefault(s => s.Id == "1387");
+        Assert.NotNull(hayvern);
+        Assert.Equal("Hayvern", hayvern!.Name);
+    }
+
+    [Fact]
+    public void ParseAvailableSites_IncludesCampsitePitch()
+        => Assert.Contains(OsmService.ParseAvailableSites(Catalogue()), s => s.Id == "1404" && s.Name == "Birch");
+
+    [Fact]
+    public void ParseAvailableSites_ExcludesActivities()
+    {
+        var sites = OsmService.ParseAvailableSites(Catalogue());
+        // 4962 = "ACTIVITY - Archery" (under the Activities category)
+        Assert.DoesNotContain(sites, s => s.Id == "4962");
+    }
+
+    [Fact]
+    public void ParseAvailableSites_ExcludesCategoryNodesThemselves()
+    {
+        var sites = OsmService.ParseAvailableSites(Catalogue());
+        // 3868 Campsites, 3867 Indoor Accommodation, 10290 Activities are categories, not bookable sites
+        Assert.DoesNotContain(sites, s => s.Id is "3868" or "3867" or "10290");
+    }
+
+    [Fact]
+    public void ParseAvailableSites_AllEntriesHaveIdAndName()
+    {
+        var sites = OsmService.ParseAvailableSites(Catalogue());
+        Assert.NotEmpty(sites);
+        Assert.All(sites, s =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(s.Id));
+            Assert.False(string.IsNullOrWhiteSpace(s.Name));
+        });
+    }
+
+    [Fact]
+    public void ParseAvailableSites_ReturnsEmpty_ForBlankInput()
+        => Assert.Empty(OsmService.ParseAvailableSites(""));
+}

--- a/BookingsAssistant.Tests/Services/OsmServiceAvailableSitesTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceAvailableSitesTests.cs
@@ -56,4 +56,23 @@ public class OsmServiceAvailableSitesTests
     [Fact]
     public void ParseAvailableSites_ReturnsEmpty_ForBlankInput()
         => Assert.Empty(OsmService.ParseAvailableSites(""));
+
+    [Fact]
+    public void ParseAvailableSites_HandlesSitesNestedUnderASubCategory()
+    {
+        // Campsites(1) → "Tents" sub-category(2) → leaf pitch(3). The leaf is a site;
+        // the sub-category (itself a parent) is excluded.
+        const string json = """
+        {"data":[
+            {"id":1,"parent_id":0,"name":"Campsites"},
+            {"id":2,"parent_id":1,"name":"Tents"},
+            {"id":3,"parent_id":2,"name":"Tent Pitch A"}
+        ]}
+        """;
+        var sites = OsmService.ParseAvailableSites(json);
+        // The leaf pitch is surfaced even though it's nested under a sub-category...
+        Assert.Contains(sites, s => s.Id == "3" && s.Name == "Tent Pitch A");
+        // ...and the intermediate sub-category (itself a parent) is not.
+        Assert.DoesNotContain(sites, s => s.Id == "2");
+    }
 }

--- a/BookingsAssistant.Web/package-lock.json
+++ b/BookingsAssistant.Web/package-lock.json
@@ -16,6 +16,9 @@
       "devDependencies": {
         "@eslint/js": "^9.39.1",
         "@tailwindcss/postcss": "^4.1.18",
+        "@testing-library/jest-dom": "^6.6.3",
+        "@testing-library/react": "^16.1.0",
+        "@testing-library/user-event": "^14.5.2",
         "@types/node": "^24.10.1",
         "@types/react": "^19.2.5",
         "@types/react-dom": "^19.2.3",
@@ -26,12 +29,21 @@
         "eslint-plugin-react-hooks": "^7.0.1",
         "eslint-plugin-react-refresh": "^0.4.24",
         "globals": "^16.5.0",
+        "jsdom": "^25.0.1",
         "postcss": "^8.5.6",
         "tailwindcss": "^4.1.18",
         "typescript": "~5.9.3",
         "typescript-eslint": "^8.46.4",
-        "vite": "^7.2.4"
+        "vite": "^7.2.4",
+        "vitest": "^3.2.4"
       }
+    },
+    "node_modules/@adobe/css-tools": {
+      "version": "4.5.0",
+      "resolved": "https://registry.npmjs.org/@adobe/css-tools/-/css-tools-4.5.0.tgz",
+      "integrity": "sha512-6OzddxPio9UiWTCemp4N8cYLV2ZN1ncRnV1cVGtve7dhPOtRkleRyx32GQCYSwDYgaHU3USMm84tNsvKzRCa1Q==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@alloc/quick-lru": {
       "version": "5.2.0",
@@ -45,6 +57,27 @@
       "funding": {
         "url": "https://github.com/sponsors/sindresorhus"
       }
+    },
+    "node_modules/@asamuzakjp/css-color": {
+      "version": "3.2.0",
+      "resolved": "https://registry.npmjs.org/@asamuzakjp/css-color/-/css-color-3.2.0.tgz",
+      "integrity": "sha512-K1A6z8tS3XsmCMM86xoWdn7Fkdn9m6RSVtocUrJYIwZnFVkng/PvkEoWtOWmP+Scc6saYWHWZYbndEEXxl24jw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/css-calc": "^2.1.3",
+        "@csstools/css-color-parser": "^3.0.9",
+        "@csstools/css-parser-algorithms": "^3.0.4",
+        "@csstools/css-tokenizer": "^3.0.3",
+        "lru-cache": "^10.4.3"
+      }
+    },
+    "node_modules/@asamuzakjp/css-color/node_modules/lru-cache": {
+      "version": "10.4.3",
+      "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-10.4.3.tgz",
+      "integrity": "sha512-JNAzZcXrCt42VGLuYz0zfAzDfAvJWW6AfYlDBQyDV5DClI2m5sAmK+OIO7s59XfsRsWHp02jAJrRadPRGTt6SQ==",
+      "dev": true,
+      "license": "ISC"
     },
     "node_modules/@babel/code-frame": {
       "version": "7.28.6",
@@ -280,6 +313,16 @@
         "@babel/core": "^7.0.0-0"
       }
     },
+    "node_modules/@babel/runtime": {
+      "version": "7.29.7",
+      "resolved": "https://registry.npmjs.org/@babel/runtime/-/runtime-7.29.7.tgz",
+      "integrity": "sha512-Nq8OhGWiZIZGV6hLHoyAKLLcJihP/xFeBMGJoUrxTX2psI8dCifzLhZISFb+VWS3wFMRDmCGw5R+dOySCqPLhw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6.9.0"
+      }
+    },
     "node_modules/@babel/template": {
       "version": "7.28.6",
       "resolved": "https://registry.npmjs.org/@babel/template/-/template-7.28.6.tgz",
@@ -326,6 +369,121 @@
       },
       "engines": {
         "node": ">=6.9.0"
+      }
+    },
+    "node_modules/@csstools/color-helpers": {
+      "version": "5.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/color-helpers/-/color-helpers-5.1.0.tgz",
+      "integrity": "sha512-S11EXWJyy0Mz5SYvRmY8nJYTFFd1LCNV+7cXyAgQtOOuzb4EsgfqDufL+9esx72/eLhsRdGZwaldu/h+E4t4BA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT-0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@csstools/css-calc": {
+      "version": "2.1.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-calc/-/css-calc-2.1.4.tgz",
+      "integrity": "sha512-3N8oaj+0juUw/1H3YwmDDJXCgTB1gKU6Hc/bB502u9zR0q2vd786XJH9QfrKIEgFlZmhZiq6epXl4rHqhzsIgQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-color-parser": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/@csstools/css-color-parser/-/css-color-parser-3.1.0.tgz",
+      "integrity": "sha512-nbtKwh3a6xNVIp/VRuXV64yTKnb1IjTAEEh3irzS+HkKjAOYLTGNb9pmVNntZ8iVBHcWDA2Dof0QtPgFI1BaTA==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "dependencies": {
+        "@csstools/color-helpers": "^5.1.0",
+        "@csstools/css-calc": "^2.1.4"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-parser-algorithms": "^3.0.5",
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-parser-algorithms": {
+      "version": "3.0.5",
+      "resolved": "https://registry.npmjs.org/@csstools/css-parser-algorithms/-/css-parser-algorithms-3.0.5.tgz",
+      "integrity": "sha512-DaDeUkXZKjdGhgYaHNJTV9pV7Y9B3b644jCLs9Upc3VeNGg6LWARAT6O+Q+/COo+2gg/bM5rhpMAtf70WqfBdQ==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@csstools/css-tokenizer": "^3.0.4"
+      }
+    },
+    "node_modules/@csstools/css-tokenizer": {
+      "version": "3.0.4",
+      "resolved": "https://registry.npmjs.org/@csstools/css-tokenizer/-/css-tokenizer-3.0.4.tgz",
+      "integrity": "sha512-Vd/9EVDiu6PPJt9yAh6roZP6El1xHrdvIVGjyBsHR0RYwNHgL7FJPyIIW4fANJNG6FtyZfvlRPpFI4ZM/lubvw==",
+      "dev": true,
+      "funding": [
+        {
+          "type": "github",
+          "url": "https://github.com/sponsors/csstools"
+        },
+        {
+          "type": "opencollective",
+          "url": "https://opencollective.com/csstools"
+        }
+      ],
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/@esbuild/aix-ppc64": {
@@ -1657,6 +1815,104 @@
         "tailwindcss": "4.1.18"
       }
     },
+    "node_modules/@testing-library/dom": {
+      "version": "10.4.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/dom/-/dom-10.4.1.tgz",
+      "integrity": "sha512-o4PXJQidqJl82ckFaXUeoAW+XysPLauYI43Abki5hABd853iMhitooc6znOnczgbTYmEP6U6/y1ZyKAIsvMKGg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "@babel/code-frame": "^7.10.4",
+        "@babel/runtime": "^7.12.5",
+        "@types/aria-query": "^5.0.1",
+        "aria-query": "5.3.0",
+        "dom-accessibility-api": "^0.5.9",
+        "lz-string": "^1.5.0",
+        "picocolors": "1.1.1",
+        "pretty-format": "^27.0.2"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/@testing-library/jest-dom": {
+      "version": "6.9.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/jest-dom/-/jest-dom-6.9.1.tgz",
+      "integrity": "sha512-zIcONa+hVtVSSep9UT3jZ5rizo2BsxgyDYU7WFD5eICBE7no3881HGeb/QkGfsJs6JTkY1aQhT7rIPC7e+0nnA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@adobe/css-tools": "^4.4.0",
+        "aria-query": "^5.0.0",
+        "css.escape": "^1.5.1",
+        "dom-accessibility-api": "^0.6.3",
+        "picocolors": "^1.1.1",
+        "redent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=14",
+        "npm": ">=6",
+        "yarn": ">=1"
+      }
+    },
+    "node_modules/@testing-library/jest-dom/node_modules/dom-accessibility-api": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.6.3.tgz",
+      "integrity": "sha512-7ZgogeTnjuHbo+ct10G9Ffp0mif17idi0IyWNVA/wcwcm7NPOD/WEHVP3n7n3MhXqxoIYm8d6MuZohYWIZ4T3w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/@testing-library/react": {
+      "version": "16.3.2",
+      "resolved": "https://registry.npmjs.org/@testing-library/react/-/react-16.3.2.tgz",
+      "integrity": "sha512-XU5/SytQM+ykqMnAnvB2umaJNIOsLF3PVv//1Ew4CTcpz0/BRyy/af40qqrt7SjKpDdT1saBMc42CUok5gaw+g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@babel/runtime": "^7.12.5"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": "^10.0.0",
+        "@types/react": "^18.0.0 || ^19.0.0",
+        "@types/react-dom": "^18.0.0 || ^19.0.0",
+        "react": "^18.0.0 || ^19.0.0",
+        "react-dom": "^18.0.0 || ^19.0.0"
+      },
+      "peerDependenciesMeta": {
+        "@types/react": {
+          "optional": true
+        },
+        "@types/react-dom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@testing-library/user-event": {
+      "version": "14.6.1",
+      "resolved": "https://registry.npmjs.org/@testing-library/user-event/-/user-event-14.6.1.tgz",
+      "integrity": "sha512-vq7fv0rnt+QTXgPxr5Hjc210p6YKq2kmdziLgnsZGgLJ9e6VAShx1pACLuRjd/AS/sr7phAR58OIIpf0LlmQNw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12",
+        "npm": ">=6"
+      },
+      "peerDependencies": {
+        "@testing-library/dom": ">=7.21.4"
+      }
+    },
+    "node_modules/@types/aria-query": {
+      "version": "5.0.4",
+      "resolved": "https://registry.npmjs.org/@types/aria-query/-/aria-query-5.0.4.tgz",
+      "integrity": "sha512-rfT93uj5s0PRL7EzccGMs3brplhcrghnDoV26NqKhCAS1hVo+WdNsPvE/yb6ilfr5hi2MEk6d5EWJTKdxg8jVw==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
+    },
     "node_modules/@types/babel__core": {
       "version": "7.20.5",
       "resolved": "https://registry.npmjs.org/@types/babel__core/-/babel__core-7.20.5.tgz",
@@ -1701,6 +1957,24 @@
       "dependencies": {
         "@babel/types": "^7.28.2"
       }
+    },
+    "node_modules/@types/chai": {
+      "version": "5.2.3",
+      "resolved": "https://registry.npmjs.org/@types/chai/-/chai-5.2.3.tgz",
+      "integrity": "sha512-Mw558oeA9fFbv65/y4mHtXDs9bPnFMZAL/jxdPFUpOHHIXX91mcgEHbS5Lahr+pwZFR8A7GQleRWeI6cGFC2UA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/deep-eql": "*",
+        "assertion-error": "^2.0.1"
+      }
+    },
+    "node_modules/@types/deep-eql": {
+      "version": "4.0.2",
+      "resolved": "https://registry.npmjs.org/@types/deep-eql/-/deep-eql-4.0.2.tgz",
+      "integrity": "sha512-c9h9dVVMigMPc4bwTvC5dxqtqJZwQPePsWjPlpSOnojbor6pGqdk541lfA7AqFQr5pB1BRdq0juY9db81BwyFw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/@types/estree": {
       "version": "1.0.8",
@@ -2066,6 +2340,121 @@
         "vite": "^4.2.0 || ^5.0.0 || ^6.0.0 || ^7.0.0"
       }
     },
+    "node_modules/@vitest/expect": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/expect/-/expect-3.2.6.tgz",
+      "integrity": "sha512-1+7q9BtaKzEmO+fmNT3kYvoNn5Y71XWAx2Q5HRim4tTVRQVRv4uJFAQ5FbK0OPUeNP/WmVCpxYxoJdvuHVjzBQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/mocker": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/mocker/-/mocker-3.2.6.tgz",
+      "integrity": "sha512-EZOrpDbkKotFAP7wPAQV1UIyoGOk4oX7ynWhBhLB7v+meMHbQhU16oPpIYGTTe4oFlhpryGpgpcZP/sin3hYuw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/spy": "3.2.6",
+        "estree-walker": "^3.0.3",
+        "magic-string": "^0.30.17"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "msw": "^2.4.9",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "peerDependenciesMeta": {
+        "msw": {
+          "optional": true
+        },
+        "vite": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/@vitest/pretty-format": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/pretty-format/-/pretty-format-3.2.6.tgz",
+      "integrity": "sha512-lb7XXXzmm2h2ASzFnRvQpDo6onT1NmMJA3tkGTWiBFtRJ9lxGY3d3mm/Apt36gej2bkkOVLL/yTOtufDaFa/jA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/runner": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/runner/-/runner-3.2.6.tgz",
+      "integrity": "sha512-HYcoSj1w5tcgUnzoF0HcyaAQjpA1gj9ftUJ7iSJSuipc02jW9gKkigwZbjFldAfYHA1fa8UZVRftdMY5msWM9Q==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/utils": "3.2.6",
+        "pathe": "^2.0.3",
+        "strip-literal": "^3.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/snapshot": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/snapshot/-/snapshot-3.2.6.tgz",
+      "integrity": "sha512-H+ZjNTWGpObenh0YnlBctAPnJSI20P81PL8BPzWpx54YXLLTm8hEsWawtcYLMrwvpK48hGxLLbCS+1KRXhsKhw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/spy": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/spy/-/spy-3.2.6.tgz",
+      "integrity": "sha512-oq6BbH68WzcWmwtBrU9nqLeaXTR4XwJF7FSLkKEZo4i6eoXcrxjcwSuTvWBIRUTC6VC72nXYunzqgZA+IKdtxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tinyspy": "^4.0.3"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/@vitest/utils": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/@vitest/utils/-/utils-3.2.6.tgz",
+      "integrity": "sha512-lI23nIs4bnT3T8NIoh+vFaz5s2/DdP0Jgt2jxwgWljvwn82cLJtyi/If+fjFyoLMGIOz0U/fKvWE0d4jsNQEfg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@vitest/pretty-format": "3.2.6",
+        "loupe": "^3.1.4",
+        "tinyrainbow": "^2.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
     "node_modules/acorn": {
       "version": "8.15.0",
       "resolved": "https://registry.npmjs.org/acorn/-/acorn-8.15.0.tgz",
@@ -2089,6 +2478,16 @@
         "acorn": "^6.0.0 || ^7.0.0 || ^8.0.0"
       }
     },
+    "node_modules/agent-base": {
+      "version": "7.1.4",
+      "resolved": "https://registry.npmjs.org/agent-base/-/agent-base-7.1.4.tgz",
+      "integrity": "sha512-MnA+YT8fwfJPgBx3m60MNqakm30XOkyIoH1y6huTQvC0PwZG7ki8NacLBcrPbNoo8vEZy7Jpuk7+jMO+CUovTQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14"
+      }
+    },
     "node_modules/ajv": {
       "version": "6.12.6",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.12.6.tgz",
@@ -2104,6 +2503,17 @@
       "funding": {
         "type": "github",
         "url": "https://github.com/sponsors/epoberezkin"
+      }
+    },
+    "node_modules/ansi-regex": {
+      "version": "5.0.1",
+      "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/ansi-styles": {
@@ -2128,6 +2538,26 @@
       "integrity": "sha512-8+9WqebbFzpX9OR+Wa6O29asIogeRMzcGtAINdpMHHyAg10f05aSFVBbcEqGf/PXw1EjAZ+q2/bEBg3DvurK3Q==",
       "dev": true,
       "license": "Python-2.0"
+    },
+    "node_modules/aria-query": {
+      "version": "5.3.0",
+      "resolved": "https://registry.npmjs.org/aria-query/-/aria-query-5.3.0.tgz",
+      "integrity": "sha512-b0P0sZPKtyu8HkeRAfCq0IfURZK+SuwMjY1UXGBU27wpAiTwQAIlq56IbIO+ytk/JjS1fMR14ee5WBBfKi5J6A==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "dependencies": {
+        "dequal": "^2.0.3"
+      }
+    },
+    "node_modules/assertion-error": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/assertion-error/-/assertion-error-2.0.1.tgz",
+      "integrity": "sha512-Izi8RQcffqCeNVgFigKli1ssklIbpHnCYc6AknXGYoB6grJqyeby7jv12JUQgmTAnIDnbck1uxksT4dzN3PWBA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=12"
+      }
     },
     "node_modules/asynckit": {
       "version": "0.4.0",
@@ -2245,6 +2675,16 @@
         "node": "^6 || ^7 || ^8 || ^9 || ^10 || ^11 || ^12 || >=13.7"
       }
     },
+    "node_modules/cac": {
+      "version": "6.7.14",
+      "resolved": "https://registry.npmjs.org/cac/-/cac-6.7.14.tgz",
+      "integrity": "sha512-b6Ilus+c3RrdDk+JhLKUAQfzzgLEPy6wcXqS7f/xe1EETvsDP6GORG7SFuOs6cID5YkqchW/LXZbX5bc8j7ZcQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/call-bind-apply-helpers": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/call-bind-apply-helpers/-/call-bind-apply-helpers-1.0.2.tgz",
@@ -2289,6 +2729,23 @@
       ],
       "license": "CC-BY-4.0"
     },
+    "node_modules/chai": {
+      "version": "5.3.3",
+      "resolved": "https://registry.npmjs.org/chai/-/chai-5.3.3.tgz",
+      "integrity": "sha512-4zNhdJD/iOjSH0A05ea+Ke6MU5mmpQcbQsSOkgdaUMJ9zTlDTD/GYlwohmIE2u0gaxHYiVHEn1Fw9mZ/ktJWgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "assertion-error": "^2.0.1",
+        "check-error": "^2.1.1",
+        "deep-eql": "^5.0.1",
+        "loupe": "^3.1.0",
+        "pathval": "^2.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/chalk": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-4.1.2.tgz",
@@ -2304,6 +2761,16 @@
       },
       "funding": {
         "url": "https://github.com/chalk/chalk?sponsor=1"
+      }
+    },
+    "node_modules/check-error": {
+      "version": "2.1.3",
+      "resolved": "https://registry.npmjs.org/check-error/-/check-error-2.1.3.tgz",
+      "integrity": "sha512-PAJdDJusoxnwm1VwW07VWwUN1sl7smmC3OKggvndJFadxxDRyFJBX/ggnu/KE4kQAB7a3Dp8f/YXC1FlUprWmA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 16"
       }
     },
     "node_modules/color-convert": {
@@ -2380,12 +2847,54 @@
         "node": ">= 8"
       }
     },
+    "node_modules/css.escape": {
+      "version": "1.5.1",
+      "resolved": "https://registry.npmjs.org/css.escape/-/css.escape-1.5.1.tgz",
+      "integrity": "sha512-YUifsXXuknHlUsmlgyY0PKzgPOr7/FjCePfHNt0jxm83wHZi44VDMQ7/fGNkjY3/jV1MC+1CmZbaHzugyeRtpg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/cssstyle": {
+      "version": "4.6.0",
+      "resolved": "https://registry.npmjs.org/cssstyle/-/cssstyle-4.6.0.tgz",
+      "integrity": "sha512-2z+rWdzbbSZv6/rhtvzvqeZQHrBaqgogqt85sqFNbabZOuFbCVFb8kPeEtZjiKkbrm395irpNKiYeFeLiQnFPg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@asamuzakjp/css-color": "^3.2.0",
+        "rrweb-cssom": "^0.8.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/cssstyle/node_modules/rrweb-cssom": {
+      "version": "0.8.0",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.8.0.tgz",
+      "integrity": "sha512-guoltQEx+9aMf2gDZ0s62EcV8lsXR+0w8915TC3ITdn2YueuNjdAYh/levpU9nFaoChh9RUS5ZdQMrKfVEN9tw==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/csstype": {
       "version": "3.2.3",
       "resolved": "https://registry.npmjs.org/csstype/-/csstype-3.2.3.tgz",
       "integrity": "sha512-z1HGKcYy2xA8AGQfwrn0PAy+PB7X/GSj3UVJW9qKyn43xWa+gl5nXmU4qqLMRzWVLFC8KusUX8T/0kCiOYpAIQ==",
       "dev": true,
       "license": "MIT"
+    },
+    "node_modules/data-urls": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/data-urls/-/data-urls-5.0.0.tgz",
+      "integrity": "sha512-ZYP5VBHshaDAiVZxjbRVcFJpc+4xGgT0bK3vzy1HLN8jTO975HEbuYzZJcHoQEY5K1a0z8YayJkyVETa08eNTg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
     },
     "node_modules/debug": {
       "version": "4.4.3",
@@ -2405,6 +2914,23 @@
         }
       }
     },
+    "node_modules/decimal.js": {
+      "version": "10.6.0",
+      "resolved": "https://registry.npmjs.org/decimal.js/-/decimal.js-10.6.0.tgz",
+      "integrity": "sha512-YpgQiITW3JXGntzdUmyUR1V812Hn8T1YVXhCu+wO3OpS4eU9l4YdD3qjyiKdV6mvV29zapkMeD390UVEf2lkUg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/deep-eql": {
+      "version": "5.0.2",
+      "resolved": "https://registry.npmjs.org/deep-eql/-/deep-eql-5.0.2.tgz",
+      "integrity": "sha512-h5k/5U50IJJFpzfL6nO9jaaumfjO/f2NjK/oYB2Djzm4p9L+3T9qWpZqZ2hAbLPuuYq9wrU08WQyBTL5GbPk5Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/deep-is": {
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/deep-is/-/deep-is-0.1.4.tgz",
@@ -2421,6 +2947,16 @@
         "node": ">=0.4.0"
       }
     },
+    "node_modules/dequal": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/dequal/-/dequal-2.0.3.tgz",
+      "integrity": "sha512-0je+qPKHEMohvfRTCEo3CrPG6cAzAYgmzKyxRiYSSDkS6eGJdyVJm7WaYA5ECaAD9wLB2T4EEeymA5aFVcYXCA==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=6"
+      }
+    },
     "node_modules/detect-libc": {
       "version": "2.1.2",
       "resolved": "https://registry.npmjs.org/detect-libc/-/detect-libc-2.1.2.tgz",
@@ -2430,6 +2966,14 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/dom-accessibility-api": {
+      "version": "0.5.16",
+      "resolved": "https://registry.npmjs.org/dom-accessibility-api/-/dom-accessibility-api-0.5.16.tgz",
+      "integrity": "sha512-X7BJ2yElsnOJ30pZF4uIIDfBEVgF4XEBxL9Bxhy6dnrm5hkzqmsWHGTiHqRiITNhMyFLyAiWndIJP7Z1NTteDg==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/dunder-proto": {
       "version": "1.0.1",
@@ -2466,6 +3010,19 @@
         "node": ">=10.13.0"
       }
     },
+    "node_modules/entities": {
+      "version": "6.0.1",
+      "resolved": "https://registry.npmjs.org/entities/-/entities-6.0.1.tgz",
+      "integrity": "sha512-aN97NXWF6AWBTahfVOIrB/NShkzi5H7F9r1s9mD3cDj4Ko5f2qhhVoYMibXF7GlLveb/D2ioWay8lxI97Ven3g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=0.12"
+      },
+      "funding": {
+        "url": "https://github.com/fb55/entities?sponsor=1"
+      }
+    },
     "node_modules/es-define-property": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/es-define-property/-/es-define-property-1.0.1.tgz",
@@ -2483,6 +3040,13 @@
       "engines": {
         "node": ">= 0.4"
       }
+    },
+    "node_modules/es-module-lexer": {
+      "version": "1.7.0",
+      "resolved": "https://registry.npmjs.org/es-module-lexer/-/es-module-lexer-1.7.0.tgz",
+      "integrity": "sha512-jEQoCwk8hyb2AZziIOLhDqpm5+2ww5uIE6lkO/6jcOCusfk6LhMHpXXfBLXTZ7Ydyt0j4VoUQv6uGNYbdW+kBA==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/es-object-atoms": {
       "version": "1.1.1",
@@ -2750,6 +3314,16 @@
         "node": ">=4.0"
       }
     },
+    "node_modules/estree-walker": {
+      "version": "3.0.3",
+      "resolved": "https://registry.npmjs.org/estree-walker/-/estree-walker-3.0.3.tgz",
+      "integrity": "sha512-7RUKfXgSMMkzt6ZuXmqapOurLGPPfgj6l9uRZ7lRGolvk0y2yocc35LdcxKC5PQZdn2DMqioAQ2NoWcrTKmm6g==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/estree": "^1.0.0"
+      }
+    },
     "node_modules/esutils": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.3.tgz",
@@ -2758,6 +3332,16 @@
       "license": "BSD-2-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/expect-type": {
+      "version": "1.4.0",
+      "resolved": "https://registry.npmjs.org/expect-type/-/expect-type-1.4.0.tgz",
+      "integrity": "sha512-KfYbmpRm0VbLjEvVa9yGwCi9GI34xvi7A/HXYWQO65CSD2u3MczUJSuwXKFIxlGsgBQizV9q5J9NHj4VG0n+pA==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=12.0.0"
       }
     },
     "node_modules/fast-deep-equal": {
@@ -3082,6 +3666,60 @@
         "hermes-estree": "0.25.1"
       }
     },
+    "node_modules/html-encoding-sniffer": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/html-encoding-sniffer/-/html-encoding-sniffer-4.0.0.tgz",
+      "integrity": "sha512-Y22oTqIU4uuPgEemfz7NDJz6OeKf12Lsu+QC+s3BVpda64lTiMYCyGwg5ki4vFxkMwQdeZDl2adZoqUgdFuTgQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "whatwg-encoding": "^3.1.1"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/http-proxy-agent": {
+      "version": "7.0.2",
+      "resolved": "https://registry.npmjs.org/http-proxy-agent/-/http-proxy-agent-7.0.2.tgz",
+      "integrity": "sha512-T1gkAiYYDWYx3V5Bmyu7HcfcvL7mUrTWiM6yOfa3PIphViJ/gFPbvidQ+veqSOHci/PxBcDabeUNCzpOODJZig==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.0",
+        "debug": "^4.3.4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/https-proxy-agent": {
+      "version": "7.0.6",
+      "resolved": "https://registry.npmjs.org/https-proxy-agent/-/https-proxy-agent-7.0.6.tgz",
+      "integrity": "sha512-vK9P5/iUfdl95AI+JVyUuIcVtd4ofvtrOr3HNtM2yxC9bnMbEdp3x01OhQNnjb8IJYi38VlTE3mBXwcfvywuSw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "agent-base": "^7.1.2",
+        "debug": "4"
+      },
+      "engines": {
+        "node": ">= 14"
+      }
+    },
+    "node_modules/iconv-lite": {
+      "version": "0.6.3",
+      "resolved": "https://registry.npmjs.org/iconv-lite/-/iconv-lite-0.6.3.tgz",
+      "integrity": "sha512-4fCk79wshMdzMp2rH06qWrJE4iolqLhCUH+OiuIgU++RB0+94NlDL81atO7GX55uUKueo0txHNtvEyI6D7WdMw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "safer-buffer": ">= 2.1.2 < 3.0.0"
+      },
+      "engines": {
+        "node": ">=0.10.0"
+      }
+    },
     "node_modules/ignore": {
       "version": "5.3.2",
       "resolved": "https://registry.npmjs.org/ignore/-/ignore-5.3.2.tgz",
@@ -3119,6 +3757,16 @@
         "node": ">=0.8.19"
       }
     },
+    "node_modules/indent-string": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-4.0.0.tgz",
+      "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/is-extglob": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/is-extglob/-/is-extglob-2.1.1.tgz",
@@ -3141,6 +3789,13 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/is-potential-custom-element-name": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/is-potential-custom-element-name/-/is-potential-custom-element-name-1.0.1.tgz",
+      "integrity": "sha512-bCYeRA2rVibKZd+s2625gGnGF/t7DSqDs4dP7CrLA1m7jKWz6pps0LpYLJN8Q64HtmPKJ1hrN3nzPNKFEKOUiQ==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/isexe": {
       "version": "2.0.0",
@@ -3177,6 +3832,47 @@
       },
       "bin": {
         "js-yaml": "bin/js-yaml.js"
+      }
+    },
+    "node_modules/jsdom": {
+      "version": "25.0.1",
+      "resolved": "https://registry.npmjs.org/jsdom/-/jsdom-25.0.1.tgz",
+      "integrity": "sha512-8i7LzZj7BF8uplX+ZyOlIz86V6TAsSs+np6m1kpW9u0JWi4z/1t+FzcK1aek+ybTnAC4KhBL4uXCNT0wcUIeCw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cssstyle": "^4.1.0",
+        "data-urls": "^5.0.0",
+        "decimal.js": "^10.4.3",
+        "form-data": "^4.0.0",
+        "html-encoding-sniffer": "^4.0.0",
+        "http-proxy-agent": "^7.0.2",
+        "https-proxy-agent": "^7.0.5",
+        "is-potential-custom-element-name": "^1.0.1",
+        "nwsapi": "^2.2.12",
+        "parse5": "^7.1.2",
+        "rrweb-cssom": "^0.7.1",
+        "saxes": "^6.0.0",
+        "symbol-tree": "^3.2.4",
+        "tough-cookie": "^5.0.0",
+        "w3c-xmlserializer": "^5.0.0",
+        "webidl-conversions": "^7.0.0",
+        "whatwg-encoding": "^3.1.1",
+        "whatwg-mimetype": "^4.0.0",
+        "whatwg-url": "^14.0.0",
+        "ws": "^8.18.0",
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      },
+      "peerDependencies": {
+        "canvas": "^2.11.2"
+      },
+      "peerDependenciesMeta": {
+        "canvas": {
+          "optional": true
+        }
       }
     },
     "node_modules/jsesc": {
@@ -3534,6 +4230,13 @@
       "dev": true,
       "license": "MIT"
     },
+    "node_modules/loupe": {
+      "version": "3.2.1",
+      "resolved": "https://registry.npmjs.org/loupe/-/loupe-3.2.1.tgz",
+      "integrity": "sha512-CdzqowRJCeLU72bHvWqwRBBlLcMEtIvGrlvef74kMnV2AolS9Y8xUv1I0U/MNAWMhBlKIoyuEgoJ0t/bbwHbLQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/lru-cache": {
       "version": "5.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-5.1.1.tgz",
@@ -3542,6 +4245,17 @@
       "license": "ISC",
       "dependencies": {
         "yallist": "^3.0.2"
+      }
+    },
+    "node_modules/lz-string": {
+      "version": "1.5.0",
+      "resolved": "https://registry.npmjs.org/lz-string/-/lz-string-1.5.0.tgz",
+      "integrity": "sha512-h5bgJWpxJNswbU7qCrV0tIKQCaS3blPDrqKWx+QxzuzL1zGUzij9XCWLrSLsJPu5t+eWA/ycetzYAO5IOMcWAQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "bin": {
+        "lz-string": "bin/bin.js"
       }
     },
     "node_modules/magic-string": {
@@ -3582,6 +4296,16 @@
       },
       "engines": {
         "node": ">= 0.6"
+      }
+    },
+    "node_modules/min-indent": {
+      "version": "1.0.1",
+      "resolved": "https://registry.npmjs.org/min-indent/-/min-indent-1.0.1.tgz",
+      "integrity": "sha512-I9jwMn07Sy/IwOj3zVkVik2JTvgpaykDZEigL6Rx6N9LbMywwUSMtxET+7lVoDLLd3O3IXwJwvuuns8UB/HeAg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=4"
       }
     },
     "node_modules/minimatch": {
@@ -3634,6 +4358,13 @@
       "version": "2.0.27",
       "resolved": "https://registry.npmjs.org/node-releases/-/node-releases-2.0.27.tgz",
       "integrity": "sha512-nmh3lCkYZ3grZvqcCH+fjmQ7X+H0OeZgP40OierEaAptX4XofMh5kwNbWh7lBduUzCcV/8kZ+NDLCwm2iorIlA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/nwsapi": {
+      "version": "2.2.24",
+      "resolved": "https://registry.npmjs.org/nwsapi/-/nwsapi-2.2.24.tgz",
+      "integrity": "sha512-7YRhZ3jS45LwmSCT4b2sVFHt/WuovaktDU07QrtOBY2PXskss5a9jfmR9jptyumwXST+rFjrmppMY1KT/yn35A==",
       "dev": true,
       "license": "MIT"
     },
@@ -3700,6 +4431,19 @@
         "node": ">=6"
       }
     },
+    "node_modules/parse5": {
+      "version": "7.3.0",
+      "resolved": "https://registry.npmjs.org/parse5/-/parse5-7.3.0.tgz",
+      "integrity": "sha512-IInvU7fabl34qmi9gY8XOVxhYyMyuH2xUNpb2q8/Y+7552KlejkRvqvD19nMoUW/uQGGbqNpA6Tufu5FL5BZgw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "entities": "^6.0.0"
+      },
+      "funding": {
+        "url": "https://github.com/inikulin/parse5?sponsor=1"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-4.0.0.tgz",
@@ -3718,6 +4462,23 @@
       "license": "MIT",
       "engines": {
         "node": ">=8"
+      }
+    },
+    "node_modules/pathe": {
+      "version": "2.0.3",
+      "resolved": "https://registry.npmjs.org/pathe/-/pathe-2.0.3.tgz",
+      "integrity": "sha512-WUjGcAqP1gQacoQe+OBJsFA7Ld4DyXuUIjZ5cc75cLHvJ7dtNsTugphxIADwspS+AraAUePCKrSVtPLFj/F88w==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/pathval": {
+      "version": "2.0.1",
+      "resolved": "https://registry.npmjs.org/pathval/-/pathval-2.0.1.tgz",
+      "integrity": "sha512-//nshmD55c46FuFw26xV/xFAaB5HF9Xdap7HJBBnrKdAd6/GxDBaNA1870O79+9ueg61cZLSVc+OaFlfmObYVQ==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">= 14.16"
       }
     },
     "node_modules/picocolors": {
@@ -3786,6 +4547,36 @@
         "node": ">= 0.8.0"
       }
     },
+    "node_modules/pretty-format": {
+      "version": "27.5.1",
+      "resolved": "https://registry.npmjs.org/pretty-format/-/pretty-format-27.5.1.tgz",
+      "integrity": "sha512-Qb1gy5OrP5+zDf2Bvnzdl3jsTf1qXVMazbvCoKhtKqVs4/YK4ozX4gKQJJVyNe+cajNPn0KoC0MC3FUmaHWEmQ==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "dependencies": {
+        "ansi-regex": "^5.0.1",
+        "ansi-styles": "^5.0.0",
+        "react-is": "^17.0.1"
+      },
+      "engines": {
+        "node": "^10.13.0 || ^12.13.0 || ^14.15.0 || >=15.0.0"
+      }
+    },
+    "node_modules/pretty-format/node_modules/ansi-styles": {
+      "version": "5.2.0",
+      "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-5.2.0.tgz",
+      "integrity": "sha512-Cxwpt2SfTzTtXcfOlzGEee8O+c+MmUgGrNiBcXnuWxuFJHe6a5Hz7qwhwe5OgaSYI0IJvkLqWX1ASG+cJOkEiA==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true,
+      "engines": {
+        "node": ">=10"
+      },
+      "funding": {
+        "url": "https://github.com/chalk/ansi-styles?sponsor=1"
+      }
+    },
     "node_modules/proxy-from-env": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/proxy-from-env/-/proxy-from-env-1.1.0.tgz",
@@ -3822,6 +4613,14 @@
       "peerDependencies": {
         "react": "^19.2.4"
       }
+    },
+    "node_modules/react-is": {
+      "version": "17.0.2",
+      "resolved": "https://registry.npmjs.org/react-is/-/react-is-17.0.2.tgz",
+      "integrity": "sha512-w2GsyukL62IJnlaff/nRegPQR94C/XXamvMWmSHRJ4y7Ts/4ocGRmTHvOs8PSE6pB3dWOrD/nueuU5sduBsQ4w==",
+      "dev": true,
+      "license": "MIT",
+      "peer": true
     },
     "node_modules/react-refresh": {
       "version": "0.18.0",
@@ -3869,6 +4668,20 @@
       "peerDependencies": {
         "react": ">=18",
         "react-dom": ">=18"
+      }
+    },
+    "node_modules/redent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/redent/-/redent-3.0.0.tgz",
+      "integrity": "sha512-6tDA8g98We0zd0GvVeMT9arEOnTw9qM03L9cJXaCjrip1OO764RDBLBfrB4cwzNGDj5OA5ioymC9GkizgWJDUg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "indent-string": "^4.0.0",
+        "strip-indent": "^3.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/resolve-from": {
@@ -3926,6 +4739,33 @@
         "fsevents": "~2.3.2"
       }
     },
+    "node_modules/rrweb-cssom": {
+      "version": "0.7.1",
+      "resolved": "https://registry.npmjs.org/rrweb-cssom/-/rrweb-cssom-0.7.1.tgz",
+      "integrity": "sha512-TrEMa7JGdVm0UThDJSx7ddw5nVm3UJS9o9CCIZ72B1vSyEZoziDqBYP3XIoi/12lKrJR8rE3jeFHMok2F/Mnsg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/safer-buffer": {
+      "version": "2.1.2",
+      "resolved": "https://registry.npmjs.org/safer-buffer/-/safer-buffer-2.1.2.tgz",
+      "integrity": "sha512-YZo3K82SD7Riyi0E1EQPojLz7kpepnSQI9IyPbHHg1XXXevb5dJI7tpyN2ADxGcQbHG7vcyRHk0cbwqcQriUtg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/saxes": {
+      "version": "6.0.0",
+      "resolved": "https://registry.npmjs.org/saxes/-/saxes-6.0.0.tgz",
+      "integrity": "sha512-xAg7SOnEhrm5zI3puOOKyy1OMcMlIJZYNJY7xLBwSze0UjhPLnWfj2GF2EpT0jmzaJKIWKHLsaSSajf35bcYnA==",
+      "dev": true,
+      "license": "ISC",
+      "dependencies": {
+        "xmlchars": "^2.2.0"
+      },
+      "engines": {
+        "node": ">=v12.22.7"
+      }
+    },
     "node_modules/scheduler": {
       "version": "0.27.0",
       "resolved": "https://registry.npmjs.org/scheduler/-/scheduler-0.27.0.tgz",
@@ -3971,6 +4811,13 @@
         "node": ">=8"
       }
     },
+    "node_modules/siginfo": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/siginfo/-/siginfo-2.0.0.tgz",
+      "integrity": "sha512-ybx0WO1/8bSBLEWXZvEd7gMW3Sn3JFlW3TvX1nREbDLRNQNaeNN8WK0meBwPdAaOI7TtRRRJn/Es1zhrrCHu7g==",
+      "dev": true,
+      "license": "ISC"
+    },
     "node_modules/source-map-js": {
       "version": "1.2.1",
       "resolved": "https://registry.npmjs.org/source-map-js/-/source-map-js-1.2.1.tgz",
@@ -3979,6 +4826,33 @@
       "license": "BSD-3-Clause",
       "engines": {
         "node": ">=0.10.0"
+      }
+    },
+    "node_modules/stackback": {
+      "version": "0.0.2",
+      "resolved": "https://registry.npmjs.org/stackback/-/stackback-0.0.2.tgz",
+      "integrity": "sha512-1XMJE5fQo1jGH6Y/7ebnwPOBEkIEnT4QF32d5R1+VXdXveM0IBMJt8zfaxX1P3QhVwrYe+576+jkANtSS2mBbw==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/std-env": {
+      "version": "3.10.0",
+      "resolved": "https://registry.npmjs.org/std-env/-/std-env-3.10.0.tgz",
+      "integrity": "sha512-5GS12FdOZNliM5mAOxFRg7Ir0pWz8MdpYm6AY6VPkGpbA7ZzmbzNcBJQ0GPvvyWgcY7QAhCgf9Uy89I03faLkg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/strip-indent": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-3.0.0.tgz",
+      "integrity": "sha512-laJTa3Jb+VQpaC6DseHhF7dXVqHTfJPCRDaEbid/drOhgitgYku/letMUqOXFoWV0zIIUbjpdH2t+tYj4bQMRQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "min-indent": "^1.0.0"
+      },
+      "engines": {
+        "node": ">=8"
       }
     },
     "node_modules/strip-json-comments": {
@@ -3994,6 +4868,26 @@
         "url": "https://github.com/sponsors/sindresorhus"
       }
     },
+    "node_modules/strip-literal": {
+      "version": "3.1.0",
+      "resolved": "https://registry.npmjs.org/strip-literal/-/strip-literal-3.1.0.tgz",
+      "integrity": "sha512-8r3mkIM/2+PpjHoOtiAW8Rg3jJLHaV7xPwG+YRGrv6FP0wwk/toTpATxWYOW0BKdWwl82VT2tFYi5DlROa0Mxg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "js-tokens": "^9.0.1"
+      },
+      "funding": {
+        "url": "https://github.com/sponsors/antfu"
+      }
+    },
+    "node_modules/strip-literal/node_modules/js-tokens": {
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-9.0.1.tgz",
+      "integrity": "sha512-mxa9E9ITFOt0ban3j6L5MpjwegGz6lBQmM1IJkWeBZGcMxto50+eWdjC/52xDbS2vy0k7vIMK0Fe2wfL9OQSpQ==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/supports-color": {
       "version": "7.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-7.2.0.tgz",
@@ -4006,6 +4900,13 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/symbol-tree": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/symbol-tree/-/symbol-tree-3.2.4.tgz",
+      "integrity": "sha512-9QNk5KwDF+Bvz+PyObkmSYjI5ksVUYtjW7AU22r2NKcfLJcXp96hkDWU3+XndOsUb+AQ9QhfzfCT2O+CNWT5Tw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/tailwindcss": {
       "version": "4.1.18",
@@ -4028,6 +4929,20 @@
         "url": "https://opencollective.com/webpack"
       }
     },
+    "node_modules/tinybench": {
+      "version": "2.9.0",
+      "resolved": "https://registry.npmjs.org/tinybench/-/tinybench-2.9.0.tgz",
+      "integrity": "sha512-0+DUvqWMValLmha6lr4kD8iAMK1HzV0/aKnCtWb9v9641TnP/MFb7Pc2bxoxQjTXAErryXVgUOfv2YqNllqGeg==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tinyexec": {
+      "version": "0.3.2",
+      "resolved": "https://registry.npmjs.org/tinyexec/-/tinyexec-0.3.2.tgz",
+      "integrity": "sha512-KQQR9yN7R5+OSwaK0XQoj22pwHoTlgYqmUscPYoknOoWCWfj/5/ABTMRi69FrKU5ffPVh5QcFikpWJI/P1ocHA==",
+      "dev": true,
+      "license": "MIT"
+    },
     "node_modules/tinyglobby": {
       "version": "0.2.15",
       "resolved": "https://registry.npmjs.org/tinyglobby/-/tinyglobby-0.2.15.tgz",
@@ -4043,6 +4958,82 @@
       },
       "funding": {
         "url": "https://github.com/sponsors/SuperchupuDev"
+      }
+    },
+    "node_modules/tinypool": {
+      "version": "1.1.1",
+      "resolved": "https://registry.npmjs.org/tinypool/-/tinypool-1.1.1.tgz",
+      "integrity": "sha512-Zba82s87IFq9A9XmjiX5uZA/ARWDrB03OHlq+Vw1fSdt0I+4/Kutwy8BP4Y/y/aORMo61FQ0vIb5j44vSo5Pkg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": "^18.0.0 || >=20.0.0"
+      }
+    },
+    "node_modules/tinyrainbow": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/tinyrainbow/-/tinyrainbow-2.0.0.tgz",
+      "integrity": "sha512-op4nsTR47R6p0vMUUoYl/a+ljLFVtlfaXkLQmqfLR1qHma1h/ysYk4hEXZ880bf2CYgTskvTa/e196Vd5dDQXw==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tinyspy": {
+      "version": "4.0.4",
+      "resolved": "https://registry.npmjs.org/tinyspy/-/tinyspy-4.0.4.tgz",
+      "integrity": "sha512-azl+t0z7pw/z958Gy9svOTuzqIk6xq+NSheJzn5MMWtWTFywIacg2wUlzKFGtt3cthx0r2SxMK0yzJOR0IES7Q==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=14.0.0"
+      }
+    },
+    "node_modules/tldts": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts/-/tldts-6.1.86.tgz",
+      "integrity": "sha512-WMi/OQ2axVTf/ykqCQgXiIct+mSQDFdH2fkwhPwgEwvJ1kSzZRiinb0zF2Xb8u4+OqPChmyI6MEu4EezNJz+FQ==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tldts-core": "^6.1.86"
+      },
+      "bin": {
+        "tldts": "bin/cli.js"
+      }
+    },
+    "node_modules/tldts-core": {
+      "version": "6.1.86",
+      "resolved": "https://registry.npmjs.org/tldts-core/-/tldts-core-6.1.86.tgz",
+      "integrity": "sha512-Je6p7pkk+KMzMv2XXKmAE3McmolOQFdxkKw0R8EYNr7sELW46JqnNeTX8ybPiQgvg1ymCoF8LXs5fzFaZvJPTA==",
+      "dev": true,
+      "license": "MIT"
+    },
+    "node_modules/tough-cookie": {
+      "version": "5.1.2",
+      "resolved": "https://registry.npmjs.org/tough-cookie/-/tough-cookie-5.1.2.tgz",
+      "integrity": "sha512-FVDYdxtnj0G6Qm/DhNPSb8Ju59ULcup3tuJxkFb5K8Bv2pUXILbf0xZWU8PX8Ov19OXljbUyveOFwRMwkXzO+A==",
+      "dev": true,
+      "license": "BSD-3-Clause",
+      "dependencies": {
+        "tldts": "^6.1.32"
+      },
+      "engines": {
+        "node": ">=16"
+      }
+    },
+    "node_modules/tr46": {
+      "version": "5.1.1",
+      "resolved": "https://registry.npmjs.org/tr46/-/tr46-5.1.1.tgz",
+      "integrity": "sha512-hdF5ZgjTqgAntKkklYw0R03MG2x/bSzTtkxmIRw/sTNV8YXsCJ1tfLAX23lhxhHJlEf3CRCOCGGWw3vI3GaSPw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "punycode": "^2.3.1"
+      },
+      "engines": {
+        "node": ">=18"
       }
     },
     "node_modules/ts-api-utils": {
@@ -4232,6 +5223,163 @@
         }
       }
     },
+    "node_modules/vite-node": {
+      "version": "3.2.4",
+      "resolved": "https://registry.npmjs.org/vite-node/-/vite-node-3.2.4.tgz",
+      "integrity": "sha512-EbKSKh+bh1E1IFxeO0pg1n4dvoOTt0UDiXMd/qn++r98+jPO1xtJilvXldeuQ8giIB5IkpjCgMleHMNEsGH6pg==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "cac": "^6.7.14",
+        "debug": "^4.4.1",
+        "es-module-lexer": "^1.7.0",
+        "pathe": "^2.0.3",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0"
+      },
+      "bin": {
+        "vite-node": "vite-node.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      }
+    },
+    "node_modules/vitest": {
+      "version": "3.2.6",
+      "resolved": "https://registry.npmjs.org/vitest/-/vitest-3.2.6.tgz",
+      "integrity": "sha512-xejya+bT/j/+R/AGa1XOfRxLmNUlLtlwjRsFUILF+xHfzElmGcmFydy2gqqIrd62ptIEfwVMofd19uNWD9L7Nw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "@types/chai": "^5.2.2",
+        "@vitest/expect": "3.2.6",
+        "@vitest/mocker": "3.2.6",
+        "@vitest/pretty-format": "^3.2.6",
+        "@vitest/runner": "3.2.6",
+        "@vitest/snapshot": "3.2.6",
+        "@vitest/spy": "3.2.6",
+        "@vitest/utils": "3.2.6",
+        "chai": "^5.2.0",
+        "debug": "^4.4.1",
+        "expect-type": "^1.2.1",
+        "magic-string": "^0.30.17",
+        "pathe": "^2.0.3",
+        "picomatch": "^4.0.2",
+        "std-env": "^3.9.0",
+        "tinybench": "^2.9.0",
+        "tinyexec": "^0.3.2",
+        "tinyglobby": "^0.2.14",
+        "tinypool": "^1.1.1",
+        "tinyrainbow": "^2.0.0",
+        "vite": "^5.0.0 || ^6.0.0 || ^7.0.0-0",
+        "vite-node": "3.2.4",
+        "why-is-node-running": "^2.3.0"
+      },
+      "bin": {
+        "vitest": "vitest.mjs"
+      },
+      "engines": {
+        "node": "^18.0.0 || ^20.0.0 || >=22.0.0"
+      },
+      "funding": {
+        "url": "https://opencollective.com/vitest"
+      },
+      "peerDependencies": {
+        "@edge-runtime/vm": "*",
+        "@types/debug": "^4.1.12",
+        "@types/node": "^18.0.0 || ^20.0.0 || >=22.0.0",
+        "@vitest/browser": "3.2.6",
+        "@vitest/ui": "3.2.6",
+        "happy-dom": "*",
+        "jsdom": "*"
+      },
+      "peerDependenciesMeta": {
+        "@edge-runtime/vm": {
+          "optional": true
+        },
+        "@types/debug": {
+          "optional": true
+        },
+        "@types/node": {
+          "optional": true
+        },
+        "@vitest/browser": {
+          "optional": true
+        },
+        "@vitest/ui": {
+          "optional": true
+        },
+        "happy-dom": {
+          "optional": true
+        },
+        "jsdom": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/w3c-xmlserializer": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/w3c-xmlserializer/-/w3c-xmlserializer-5.0.0.tgz",
+      "integrity": "sha512-o8qghlI8NZHU1lLPrpi2+Uq7abh4GGPpYANlalzWxyWteJOCsr/P+oPBA49TOLu5FTZO4d3F9MnWJfiMo4BkmA==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "xml-name-validator": "^5.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/webidl-conversions": {
+      "version": "7.0.0",
+      "resolved": "https://registry.npmjs.org/webidl-conversions/-/webidl-conversions-7.0.0.tgz",
+      "integrity": "sha512-VwddBukDzu71offAQR975unBIGqfKZpM+8ZX6ySk8nYhVoo5CYaZyzt3YBvYtRtO+aoGlqxPg/B87NGVZ/fu6g==",
+      "dev": true,
+      "license": "BSD-2-Clause",
+      "engines": {
+        "node": ">=12"
+      }
+    },
+    "node_modules/whatwg-encoding": {
+      "version": "3.1.1",
+      "resolved": "https://registry.npmjs.org/whatwg-encoding/-/whatwg-encoding-3.1.1.tgz",
+      "integrity": "sha512-6qN4hJdMwfYBtE3YBTTHhoeuUrDBPZmbQaxWAqSALV/MeEnR5z1xd8UKud2RAkFoPkmB+hli1TZSnyi84xz1vQ==",
+      "deprecated": "Use @exodus/bytes instead for a more spec-conformant and faster implementation",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "iconv-lite": "0.6.3"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-mimetype": {
+      "version": "4.0.0",
+      "resolved": "https://registry.npmjs.org/whatwg-mimetype/-/whatwg-mimetype-4.0.0.tgz",
+      "integrity": "sha512-QaKxh0eNIi2mE9p2vEdzfagOKHCcj1pJ56EEHGQOVxp8r9/iszLUUV7v89x9O1p/T+NlTM5W7jW6+cz4Fq1YVg==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/whatwg-url": {
+      "version": "14.2.0",
+      "resolved": "https://registry.npmjs.org/whatwg-url/-/whatwg-url-14.2.0.tgz",
+      "integrity": "sha512-De72GdQZzNTUBBChsXueQUnPKDkg/5A5zp7pFDuQAj5UFoENpiACU0wlCvzpAGnTkj++ihpKwKyYewn/XNUbKw==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "tr46": "^5.1.0",
+        "webidl-conversions": "^7.0.0"
+      },
+      "engines": {
+        "node": ">=18"
+      }
+    },
     "node_modules/which": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/which/-/which-2.0.2.tgz",
@@ -4248,6 +5396,23 @@
         "node": ">= 8"
       }
     },
+    "node_modules/why-is-node-running": {
+      "version": "2.3.0",
+      "resolved": "https://registry.npmjs.org/why-is-node-running/-/why-is-node-running-2.3.0.tgz",
+      "integrity": "sha512-hUrmaWBdVDcxvYqnyh09zunKzROWjbZTiNy8dBEjkS7ehEDQibXJ7XvlmtbwuTclUiIyN+CyXQD4Vmko8fNm8w==",
+      "dev": true,
+      "license": "MIT",
+      "dependencies": {
+        "siginfo": "^2.0.0",
+        "stackback": "0.0.2"
+      },
+      "bin": {
+        "why-is-node-running": "cli.js"
+      },
+      "engines": {
+        "node": ">=8"
+      }
+    },
     "node_modules/word-wrap": {
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/word-wrap/-/word-wrap-1.2.5.tgz",
@@ -4257,6 +5422,45 @@
       "engines": {
         "node": ">=0.10.0"
       }
+    },
+    "node_modules/ws": {
+      "version": "8.21.0",
+      "resolved": "https://registry.npmjs.org/ws/-/ws-8.21.0.tgz",
+      "integrity": "sha512-Vsp28b7DRcimFQvrqu2Wek3z1iYxDCWqHYB8Qsnk/S4RfaCQzPGPyBNuVjJV3cd6UiKtUtp6sNM77gWvzcCH+g==",
+      "dev": true,
+      "license": "MIT",
+      "engines": {
+        "node": ">=10.0.0"
+      },
+      "peerDependencies": {
+        "bufferutil": "^4.0.1",
+        "utf-8-validate": ">=5.0.2"
+      },
+      "peerDependenciesMeta": {
+        "bufferutil": {
+          "optional": true
+        },
+        "utf-8-validate": {
+          "optional": true
+        }
+      }
+    },
+    "node_modules/xml-name-validator": {
+      "version": "5.0.0",
+      "resolved": "https://registry.npmjs.org/xml-name-validator/-/xml-name-validator-5.0.0.tgz",
+      "integrity": "sha512-EvGK8EJ3DhaHfbRlETOWAS5pO9MZITeauHKJyb8wyajUfQUenkIg2MvLDTZ4T/TgIcm3HU0TFBgWWboAZ30UHg==",
+      "dev": true,
+      "license": "Apache-2.0",
+      "engines": {
+        "node": ">=18"
+      }
+    },
+    "node_modules/xmlchars": {
+      "version": "2.2.0",
+      "resolved": "https://registry.npmjs.org/xmlchars/-/xmlchars-2.2.0.tgz",
+      "integrity": "sha512-JZnDKK8B0RCDw84FNdDAIpZK+JuJw+s7Lz8nksI7SIuU3UXJJslUthsi+uWBUYOwPFwW7W7PRLRfUKpxjtjFCw==",
+      "dev": true,
+      "license": "MIT"
     },
     "node_modules/yallist": {
       "version": "3.1.1",

--- a/BookingsAssistant.Web/package.json
+++ b/BookingsAssistant.Web/package.json
@@ -7,7 +7,8 @@
     "dev": "vite",
     "build": "tsc -b && vite build",
     "lint": "eslint .",
-    "preview": "vite preview"
+    "preview": "vite preview",
+    "test": "vitest run"
   },
   "dependencies": {
     "axios": "^1.13.4",
@@ -22,8 +23,12 @@
     "@types/react": "^19.2.5",
     "@types/react-dom": "^19.2.3",
     "@types/react-router-dom": "^5.3.3",
+    "@testing-library/jest-dom": "^6.6.3",
+    "@testing-library/react": "^16.1.0",
+    "@testing-library/user-event": "^14.5.2",
     "@vitejs/plugin-react": "^5.1.1",
     "autoprefixer": "^10.4.23",
+    "jsdom": "^25.0.1",
     "eslint": "^9.39.1",
     "eslint-plugin-react-hooks": "^7.0.1",
     "eslint-plugin-react-refresh": "^0.4.24",
@@ -32,6 +37,7 @@
     "tailwindcss": "^4.1.18",
     "typescript": "~5.9.3",
     "typescript-eslint": "^8.46.4",
-    "vite": "^7.2.4"
+    "vite": "^7.2.4",
+    "vitest": "^3.2.4"
   }
 }

--- a/BookingsAssistant.Web/src/components/BookingDetail.itemActions.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.itemActions.test.tsx
@@ -60,6 +60,31 @@ describe('move-activity action', () => {
     }));
     expect(await screen.findByRole('status')).toHaveTextContent(/replaced 1 item/i);
   });
+
+  it('submits a new date when only the date field is filled', async () => {
+    api.moveActivity.mockResolvedValue(ok([activity]));
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.click(screen.getByRole('button', { name: /move activity/i }));
+    await user.type(screen.getByLabelText(/new date/i), '2027-12-20');
+    await user.click(screen.getByRole('button', { name: /^move$/i }));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.moveActivity).toHaveBeenCalledWith(1, {
+      itemId: '411468', newStartDate: '2027-12-20',
+    }));
+  });
+
+  it('disables Move until at least one field is changed (no pointless no-op)', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.click(screen.getByRole('button', { name: /move activity/i }));
+    expect(screen.getByRole('button', { name: /^move$/i })).toBeDisabled();
+  });
 });
 
 describe('change-site action', () => {

--- a/BookingsAssistant.Web/src/components/BookingDetail.itemActions.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.itemActions.test.tsx
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BookingDetail from './BookingDetail';
+import { bookingsApi } from '../services/apiClient';
+import type { BookingActionResult, BookingItem } from '../types';
+
+vi.mock('../services/apiClient', () => ({
+  bookingsApi: {
+    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(),
+    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const api = bookingsApi as any;
+
+const booking = {
+  id: 1, osmBookingId: '179743', customerName: 'Test', startDate: '2027-12-04',
+  endDate: '2027-12-05', status: 'Provisional', fullDetails: '', comments: [], linkedEmails: [],
+};
+const activity: BookingItem = { itemId: '411468', type: 'activity', activityId: '4961', label: 'Air Rifle', startDate: '2027-12-05', startTime: '09:00', endTime: '10:00' };
+const site: BookingItem = { itemId: '411467', type: 'site', siteId: '1387', label: 'Hayvern', startDate: '2027-12-04', endDate: '2027-12-05' };
+
+const ok = (items: BookingItem[]): BookingActionResult =>
+  ({ created: ['999'], deleted: ['x'], status: 'completed', message: 'Replaced 1 item(s) successfully.', items });
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/bookings/1']}>
+      <Routes><Route path="/bookings/:id" element={<BookingDetail />} /></Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getById.mockResolvedValue(booking);
+  api.getItems.mockResolvedValue([activity, site]);
+  api.getAvailableSites.mockResolvedValue([
+    { id: '1387', name: 'Hayvern' }, { id: '1404', name: 'Birch' }, { id: '1386', name: 'Alpha House' },
+  ]);
+});
+
+describe('move-activity action', () => {
+  it('submits new times for an activity item after confirmation', async () => {
+    api.moveActivity.mockResolvedValue(ok([activity]));
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.click(screen.getByRole('button', { name: /move activity/i }));
+    await user.type(screen.getByLabelText(/new start time/i), '14:00');
+    await user.type(screen.getByLabelText(/new end time/i), '15:00');
+    await user.click(screen.getByRole('button', { name: /^move$/i }));   // open confirm gate
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.moveActivity).toHaveBeenCalledWith(1, {
+      itemId: '411468', newStartTime: '14:00', newEndTime: '15:00',
+    }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/replaced 1 item/i);
+  });
+});
+
+describe('change-site action', () => {
+  it('offers other sites (excluding the current one) and submits the chosen site', async () => {
+    api.changeSite.mockResolvedValue(ok([site]));
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.click(screen.getByRole('button', { name: /change site/i }));
+
+    const select = await screen.findByLabelText(/new site/i);
+    // Current site (Hayvern/1387) must be excluded; alternatives present
+    expect(screen.queryByRole('option', { name: 'Hayvern' })).not.toBeInTheDocument();
+    expect(screen.getByRole('option', { name: 'Birch' })).toBeInTheDocument();
+
+    await user.selectOptions(select, '1404');
+    await user.click(screen.getByRole('button', { name: /^change$/i }));   // open confirm gate
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.changeSite).toHaveBeenCalledWith(1, { itemId: '411467', newSiteId: '1404' }));
+  });
+
+  it('shows a no-alternatives message when only the current site exists', async () => {
+    api.getAvailableSites.mockResolvedValue([{ id: '1387', name: 'Hayvern' }]);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.click(screen.getByRole('button', { name: /change site/i }));
+    expect(await screen.findByText(/no alternative sites/i)).toBeInTheDocument();
+    expect(api.changeSite).not.toHaveBeenCalled();
+  });
+});

--- a/BookingsAssistant.Web/src/components/BookingDetail.moveDates.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.moveDates.test.tsx
@@ -1,0 +1,98 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BookingDetail from './BookingDetail';
+import { bookingsApi } from '../services/apiClient';
+import type { BookingActionResult, BookingItem } from '../types';
+
+vi.mock('../services/apiClient', () => ({
+  bookingsApi: {
+    getById: vi.fn(),
+    getItems: vi.fn(),
+    getAvailableSites: vi.fn(),
+    moveDates: vi.fn(),
+    moveActivity: vi.fn(),
+    changeSite: vi.fn(),
+  },
+}));
+
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const api = bookingsApi as any;
+
+const booking = {
+  id: 1, osmBookingId: '179743', customerName: 'Test', startDate: '2027-12-04',
+  endDate: '2027-12-05', status: 'Provisional', fullDetails: '', comments: [], linkedEmails: [],
+};
+const initialItems: BookingItem[] = [
+  { itemId: '411467', type: 'site', siteId: '1387', label: 'Hayvern', startDate: '2027-12-04', endDate: '2027-12-05' },
+];
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/bookings/1']}>
+      <Routes><Route path="/bookings/:id" element={<BookingDetail />} /></Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getById.mockResolvedValue(booking);
+  api.getItems.mockResolvedValue(initialItems);
+  api.getAvailableSites.mockResolvedValue([]);
+});
+
+describe('move-dates action', () => {
+  it('submits dayShift after confirmation and shows a success banner', async () => {
+    const result: BookingActionResult = {
+      created: ['999'], deleted: ['411467'], status: 'completed', message: 'Replaced 1 item(s) successfully.',
+      items: [{ ...initialItems[0], itemId: '999', startDate: '2027-12-11', endDate: '2027-12-12' }],
+    };
+    api.moveDates.mockResolvedValue(result);
+    const user = userEvent.setup();
+    renderDetail();
+
+    await screen.findByText(/Booking #179743/);
+
+    await user.type(screen.getByLabelText(/shift all booking dates/i), '7');
+    await user.click(screen.getByRole('button', { name: /^move dates$/i }));
+
+    // Confirmation gate appears; no API call yet
+    expect(api.moveDates).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.moveDates).toHaveBeenCalledWith(1, { dayShift: 7 }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/replaced 1 item/i);
+  });
+
+  it('shows an amber warnings banner for completed_with_warnings', async () => {
+    api.moveDates.mockResolvedValue({
+      created: ['999'], deleted: [], status: 'completed_with_warnings',
+      message: 'Created 1 item(s) but only deleted 0 of 1 originals.', items: initialItems,
+    } as BookingActionResult);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.type(screen.getByLabelText(/shift all booking dates/i), '3');
+    await user.click(screen.getByRole('button', { name: /^move dates$/i }));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    const banner = await screen.findByRole('status');
+    expect(banner).toHaveTextContent(/only deleted 0 of 1/i);
+    expect(banner.className).toMatch(/amber|yellow/);
+  });
+
+  it('cancelling the confirmation does not call the API', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.type(screen.getByLabelText(/shift all booking dates/i), '2');
+    await user.click(screen.getByRole('button', { name: /^move dates$/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(api.moveDates).not.toHaveBeenCalled();
+  });
+});

--- a/BookingsAssistant.Web/src/components/BookingDetail.moveDates.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.moveDates.test.tsx
@@ -64,6 +64,23 @@ describe('move-dates action', () => {
 
     await waitFor(() => expect(api.moveDates).toHaveBeenCalledWith(1, { dayShift: 7 }));
     expect(await screen.findByRole('status')).toHaveTextContent(/replaced 1 item/i);
+    // Items list is refreshed in place from result.items (shifted date now shown)
+    expect(await screen.findByText(/11 Dec 2027/)).toBeInTheDocument();
+  });
+
+  it('shows a red error banner when the action call throws', async () => {
+    api.moveDates.mockRejectedValue(new Error('network down'));
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.type(screen.getByLabelText(/shift all booking dates/i), '5');
+    await user.click(screen.getByRole('button', { name: /^move dates$/i }));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    const banner = await screen.findByRole('status');
+    expect(banner).toHaveTextContent(/could not be completed/i);
+    expect(banner.className).toMatch(/red/);
   });
 
   it('shows an amber warnings banner for completed_with_warnings', async () => {

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -1,7 +1,16 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { bookingsApi } from '../services/apiClient';
-import type { BookingActionResult, BookingDetail as BookingDetailType, BookingItem } from '../types';
+import type {
+  AvailableSite,
+  BookingActionResult,
+  BookingDetail as BookingDetailType,
+  BookingItem,
+  ChangeSiteRequest,
+  MoveActivityRequest,
+} from '../types';
+
+type ItemActionKind = 'move-activity' | 'change-site';
 
 /** Tailwind classes for the action result banner, keyed by BookingActionResult.status. */
 function actionBannerClass(status: string): string {
@@ -32,6 +41,15 @@ export default function BookingDetail() {
   const [actionError, setActionError] = useState<string | null>(null);
   const [dayShift, setDayShift] = useState('');
   const [confirmingMoveDates, setConfirmingMoveDates] = useState(false);
+
+  // Per-item actions (move-activity / change-site)
+  const [availableSites, setAvailableSites] = useState<AvailableSite[]>([]);
+  const [activeItemAction, setActiveItemAction] = useState<{ itemId: string; kind: ItemActionKind } | null>(null);
+  const [confirmingItemAction, setConfirmingItemAction] = useState(false);
+  const [newStartDate, setNewStartDate] = useState('');
+  const [newStartTime, setNewStartTime] = useState('');
+  const [newEndTime, setNewEndTime] = useState('');
+  const [newSiteId, setNewSiteId] = useState('');
 
   useEffect(() => {
     const fetchBooking = async () => {
@@ -73,6 +91,14 @@ export default function BookingDetail() {
     fetchItems();
   }, [id]);
 
+  useEffect(() => {
+    if (!id) return;
+    // Sites for the change-site dropdown; best-effort (empty list disables change-site).
+    bookingsApi.getAvailableSites(parseInt(id))
+      .then(setAvailableSites)
+      .catch(() => setAvailableSites([]));
+  }, [id]);
+
   const handlePostComment = async () => {
     if (!newComment.trim() || !id) return;
     setPosting(true);
@@ -107,6 +133,8 @@ export default function BookingDetail() {
     } finally {
       setActionInProgress(false);
       setConfirmingMoveDates(false);
+      setActiveItemAction(null);
+      setConfirmingItemAction(false);
     }
   };
 
@@ -114,6 +142,30 @@ export default function BookingDetail() {
     const shift = parseInt(dayShift, 10);
     if (!id || Number.isNaN(shift) || shift === 0) return;
     runAction(() => bookingsApi.moveDates(parseInt(id), { dayShift: shift }));
+  };
+
+  const openItemAction = (itemId: string, kind: ItemActionKind) => {
+    setActiveItemAction({ itemId, kind });
+    setConfirmingItemAction(false);
+    setNewStartDate('');
+    setNewStartTime('');
+    setNewEndTime('');
+    setNewSiteId('');
+  };
+
+  const handleMoveActivity = (itemId: string) => {
+    if (!id) return;
+    const req: MoveActivityRequest = { itemId };
+    if (newStartDate) req.newStartDate = newStartDate;
+    if (newStartTime) req.newStartTime = newStartTime;
+    if (newEndTime) req.newEndTime = newEndTime;
+    runAction(() => bookingsApi.moveActivity(parseInt(id), req));
+  };
+
+  const handleChangeSite = (itemId: string) => {
+    if (!id || !newSiteId) return;
+    const req: ChangeSiteRequest = { itemId, newSiteId };
+    runAction(() => bookingsApi.changeSite(parseInt(id), req));
   };
 
   if (loading) {
@@ -374,6 +426,114 @@ export default function BookingDetail() {
                     </div>
                   )}
                 </div>
+
+                {/* Per-item action trigger */}
+                {activeItemAction?.itemId !== item.itemId && (
+                  <div className="mt-2">
+                    {item.type === 'activity' && (
+                      <button
+                        onClick={() => openItemAction(item.itemId, 'move-activity')}
+                        disabled={actionInProgress}
+                        className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                      >
+                        Move activity
+                      </button>
+                    )}
+                    {item.type === 'site' && (
+                      <button
+                        onClick={() => openItemAction(item.itemId, 'change-site')}
+                        disabled={actionInProgress}
+                        className="px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                      >
+                        Change site
+                      </button>
+                    )}
+                  </div>
+                )}
+
+                {/* Move-activity form */}
+                {activeItemAction?.itemId === item.itemId && activeItemAction.kind === 'move-activity' && (
+                  <div className="mt-3 border-t pt-3 space-y-2">
+                    <div>
+                      <label htmlFor={`sd-${item.itemId}`} className="block text-sm font-medium text-gray-700">New date</label>
+                      <input id={`sd-${item.itemId}`} type="date" value={newStartDate}
+                        onChange={(e) => setNewStartDate(e.target.value)} disabled={actionInProgress}
+                        className="p-2 border border-gray-300 rounded" />
+                    </div>
+                    <div>
+                      <label htmlFor={`st-${item.itemId}`} className="block text-sm font-medium text-gray-700">New start time</label>
+                      <input id={`st-${item.itemId}`} type="time" value={newStartTime}
+                        onChange={(e) => setNewStartTime(e.target.value)} disabled={actionInProgress}
+                        className="p-2 border border-gray-300 rounded" />
+                    </div>
+                    <div>
+                      <label htmlFor={`et-${item.itemId}`} className="block text-sm font-medium text-gray-700">New end time</label>
+                      <input id={`et-${item.itemId}`} type="time" value={newEndTime}
+                        onChange={(e) => setNewEndTime(e.target.value)} disabled={actionInProgress}
+                        className="p-2 border border-gray-300 rounded" />
+                    </div>
+                    {!confirmingItemAction ? (
+                      <div>
+                        <button onClick={() => setConfirmingItemAction(true)} disabled={actionInProgress}
+                          className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">Move</button>
+                        <button onClick={() => setActiveItemAction(null)} disabled={actionInProgress}
+                          className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                      </div>
+                    ) : (
+                      <div className="text-sm text-gray-700">
+                        Recreate this activity at the new time, then delete the original?
+                        <button onClick={() => handleMoveActivity(item.itemId)} disabled={actionInProgress}
+                          className="ml-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50">
+                          {actionInProgress ? 'Working…' : 'Confirm'}</button>
+                        <button onClick={() => setConfirmingItemAction(false)} disabled={actionInProgress}
+                          className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                      </div>
+                    )}
+                  </div>
+                )}
+
+                {/* Change-site form */}
+                {activeItemAction?.itemId === item.itemId && activeItemAction.kind === 'change-site' && (() => {
+                  const otherSites = availableSites.filter((s) => s.id !== item.siteId);
+                  return (
+                    <div className="mt-3 border-t pt-3 space-y-2">
+                      {otherSites.length === 0 ? (
+                        <p className="text-sm text-gray-500">No alternative sites available.</p>
+                      ) : (
+                        <>
+                          <label htmlFor={`site-${item.itemId}`} className="block text-sm font-medium text-gray-700">New site</label>
+                          <select id={`site-${item.itemId}`} value={newSiteId}
+                            onChange={(e) => setNewSiteId(e.target.value)} disabled={actionInProgress}
+                            className="p-2 border border-gray-300 rounded">
+                            <option value="">Select a site…</option>
+                            {otherSites.map((s) => <option key={s.id} value={s.id}>{s.name}</option>)}
+                          </select>
+                          {!confirmingItemAction ? (
+                            <div>
+                              <button onClick={() => { if (newSiteId) setConfirmingItemAction(true); }} disabled={actionInProgress || !newSiteId}
+                                className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">Change</button>
+                              <button onClick={() => setActiveItemAction(null)} disabled={actionInProgress}
+                                className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                            </div>
+                          ) : (
+                            <div className="text-sm text-gray-700">
+                              Recreate this booking on the new site, then delete the original?
+                              <button onClick={() => handleChangeSite(item.itemId)} disabled={actionInProgress}
+                                className="ml-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50">
+                                {actionInProgress ? 'Working…' : 'Confirm'}</button>
+                              <button onClick={() => setConfirmingItemAction(false)} disabled={actionInProgress}
+                                className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                            </div>
+                          )}
+                        </>
+                      )}
+                      {otherSites.length === 0 && (
+                        <button onClick={() => setActiveItemAction(null)}
+                          className="px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Close</button>
+                      )}
+                    </div>
+                  );
+                })()}
               </div>
             ))}
           </div>

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -1,7 +1,17 @@
 import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { bookingsApi } from '../services/apiClient';
-import type { BookingDetail as BookingDetailType, BookingItem } from '../types';
+import type { BookingActionResult, BookingDetail as BookingDetailType, BookingItem } from '../types';
+
+/** Tailwind classes for the action result banner, keyed by BookingActionResult.status. */
+function actionBannerClass(status: string): string {
+  switch (status) {
+    case 'completed': return 'bg-green-100 border-green-400 text-green-800';
+    case 'completed_with_warnings': return 'bg-amber-100 border-amber-400 text-amber-800';
+    case 'rolled_back': return 'bg-blue-100 border-blue-400 text-blue-800';
+    default: return 'bg-red-100 border-red-400 text-red-800'; // failed
+  }
+}
 
 export default function BookingDetail() {
   const { id } = useParams<{ id: string }>();
@@ -15,6 +25,13 @@ export default function BookingDetail() {
   const [items, setItems] = useState<BookingItem[] | null>(null);
   const [itemsLoading, setItemsLoading] = useState(false);
   const [itemsUnavailable, setItemsUnavailable] = useState(false);
+
+  // Booking actions (move-dates here; per-item actions added alongside)
+  const [actionInProgress, setActionInProgress] = useState(false);
+  const [actionResult, setActionResult] = useState<BookingActionResult | null>(null);
+  const [actionError, setActionError] = useState<string | null>(null);
+  const [dayShift, setDayShift] = useState('');
+  const [confirmingMoveDates, setConfirmingMoveDates] = useState(false);
 
   useEffect(() => {
     const fetchBooking = async () => {
@@ -72,6 +89,31 @@ export default function BookingDetail() {
     } finally {
       setPosting(false);
     }
+  };
+
+  // Runs a booking action: shows progress, then renders the result banner and
+  // refreshes the items list in place from the action response (no extra fetch).
+  const runAction = async (fn: () => Promise<BookingActionResult>) => {
+    setActionInProgress(true);
+    setActionError(null);
+    setActionResult(null);
+    try {
+      const result = await fn();
+      setActionResult(result);
+      setItems(result.items);
+    } catch (err) {
+      setActionError('The action could not be completed. Please try again.');
+      console.error(err);
+    } finally {
+      setActionInProgress(false);
+      setConfirmingMoveDates(false);
+    }
+  };
+
+  const handleMoveDates = () => {
+    const shift = parseInt(dayShift, 10);
+    if (!id || Number.isNaN(shift) || shift === 0) return;
+    runAction(() => bookingsApi.moveDates(parseInt(id), { dayShift: shift }));
   };
 
   if (loading) {
@@ -233,6 +275,68 @@ export default function BookingDetail() {
         ) : (
           <p className="text-gray-500">No emails linked to this booking.</p>
         )}
+      </div>
+
+      {/* Booking Actions */}
+      <div className="bg-white rounded-lg shadow p-6 mb-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">Booking Actions</h2>
+
+        {actionResult && (
+          <div role="status" className={`mb-4 p-3 border rounded ${actionBannerClass(actionResult.status)}`}>
+            {actionResult.message}
+          </div>
+        )}
+        {actionError && (
+          <div role="status" className="mb-4 p-3 border rounded bg-red-100 border-red-400 text-red-800">
+            {actionError}
+          </div>
+        )}
+
+        <div className="border-t pt-4">
+          <label htmlFor="dayShift" className="block text-sm font-medium text-gray-700 mb-1">
+            Shift all booking dates by (days)
+          </label>
+          <div className="flex flex-wrap items-center gap-2">
+            <input
+              id="dayShift"
+              type="number"
+              value={dayShift}
+              onChange={(e) => setDayShift(e.target.value)}
+              disabled={actionInProgress}
+              className="w-24 p-2 border border-gray-300 rounded"
+            />
+            {!confirmingMoveDates ? (
+              <button
+                onClick={() => {
+                  const shift = parseInt(dayShift, 10);
+                  if (!Number.isNaN(shift) && shift !== 0) setConfirmingMoveDates(true);
+                }}
+                disabled={actionInProgress}
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+              >
+                Move dates
+              </button>
+            ) : (
+              <span className="text-sm text-gray-700">
+                Recreate every item shifted by {dayShift} day(s), then delete the originals?
+                <button
+                  onClick={handleMoveDates}
+                  disabled={actionInProgress}
+                  className="ml-2 px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+                >
+                  {actionInProgress ? 'Working…' : 'Confirm'}
+                </button>
+                <button
+                  onClick={() => setConfirmingMoveDates(false)}
+                  disabled={actionInProgress}
+                  className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400 disabled:opacity-50"
+                >
+                  Cancel
+                </button>
+              </span>
+            )}
+          </div>
+        </div>
       </div>
 
       {/* Items */}

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -45,6 +45,7 @@ export default function BookingDetail() {
   // Per-item actions (move-activity / change-site)
   const [availableSites, setAvailableSites] = useState<AvailableSite[]>([]);
   const [activeItemAction, setActiveItemAction] = useState<{ itemId: string; kind: ItemActionKind } | null>(null);
+  // Confirm-gate flag for whichever per-item action is currently open (only one at a time).
   const [confirmingItemAction, setConfirmingItemAction] = useState(false);
   const [newStartDate, setNewStartDate] = useState('');
   const [newStartTime, setNewStartTime] = useState('');
@@ -144,6 +145,8 @@ export default function BookingDetail() {
     runAction(() => bookingsApi.moveDates(parseInt(id), { dayShift: shift }));
   };
 
+  // Opens a per-item form. Always resets the (component-level, shared) form fields so
+  // values from a previously-opened item can't leak into the new form.
   const openItemAction = (itemId: string, kind: ItemActionKind) => {
     setActiveItemAction({ itemId, kind });
     setConfirmingItemAction(false);
@@ -474,7 +477,9 @@ export default function BookingDetail() {
                     </div>
                     {!confirmingItemAction ? (
                       <div>
-                        <button onClick={() => setConfirmingItemAction(true)} disabled={actionInProgress}
+                        {/* Require at least one changed field — an all-empty move is a pointless recreate+delete. */}
+                        <button onClick={() => setConfirmingItemAction(true)}
+                          disabled={actionInProgress || !(newStartDate || newStartTime || newEndTime)}
                           className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">Move</button>
                         <button onClick={() => setActiveItemAction(null)} disabled={actionInProgress}
                           className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
@@ -492,7 +497,8 @@ export default function BookingDetail() {
                   </div>
                 )}
 
-                {/* Change-site form */}
+                {/* Change-site form. IIFE so we can derive otherSites once for both the
+                    empty-state check and the dropdown. */}
                 {activeItemAction?.itemId === item.itemId && activeItemAction.kind === 'change-site' && (() => {
                   const otherSites = availableSites.filter((s) => s.id !== item.siteId);
                   return (

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type {
+  AvailableSite,
   Booking,
   BookingActionResult,
   BookingDetail,
@@ -76,6 +77,11 @@ export const bookingsApi = {
 
   getItems: async (id: number): Promise<BookingItem[]> => {
     const response = await apiClient.get<BookingItem[]>(`/bookings/${id}/items`);
+    return response.data;
+  },
+
+  getAvailableSites: async (id: number): Promise<AvailableSite[]> => {
+    const response = await apiClient.get<AvailableSite[]>(`/bookings/${id}/available-sites`);
     return response.data;
   },
 

--- a/BookingsAssistant.Web/src/test/setup.ts
+++ b/BookingsAssistant.Web/src/test/setup.ts
@@ -1,0 +1,1 @@
+import '@testing-library/jest-dom';

--- a/BookingsAssistant.Web/src/test/smoke.test.tsx
+++ b/BookingsAssistant.Web/src/test/smoke.test.tsx
@@ -1,0 +1,11 @@
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+
+// Proves the test harness is wired: Vitest runs, RTL renders into jsdom,
+// and the jest-dom matchers (toBeInTheDocument) are available.
+describe('test harness', () => {
+  it('renders a component and jest-dom matchers work', () => {
+    render(<div>harness ok</div>);
+    expect(screen.getByText('harness ok')).toBeInTheDocument();
+  });
+});

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -139,3 +139,9 @@ export interface ChangeSiteRequest {
 export interface MoveDatesRequest {
   dayShift: number;
 }
+
+/** A bookable site/pitch a booked item can be moved to (for change-site). */
+export interface AvailableSite {
+  id: string;
+  name: string;
+}

--- a/BookingsAssistant.Web/vite.config.ts
+++ b/BookingsAssistant.Web/vite.config.ts
@@ -1,3 +1,4 @@
+/// <reference types="vitest/config" />
 import { defineConfig } from 'vite'
 import react from '@vitejs/plugin-react'
 
@@ -13,5 +14,11 @@ export default defineConfig({
         secure: false,
       }
     }
+  },
+  test: {
+    environment: 'jsdom',
+    globals: true,
+    setupFiles: ['./src/test/setup.ts'],
+    css: false,
   }
 })

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.9.25
+version: 0.9.26
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper


### PR DESCRIPTION
## Summary

Implements the booking-action **UI forms** (issue #28) on top of the actions API + wired OSM seam from PR #25. `BookingDetail` gains three actions:

- **Move dates** — shift the whole booking by N days (booking-level)
- **Move activity** — reschedule a single activity item (new date / start / end time)
- **Change site** — reassign a site item to an alternative pitch (dropdown)

Plus a small backend endpoint to feed the change-site dropdown.

> Stacked on `bookings-actions` (base of this PR). Once PR #25 merges, GitHub will retarget this to `main`.

## What's included

- **`GET /api/bookings/{id}/available-sites`** → `{id,name}[]` — bookable sites for the change-site dropdown, parsed from the OSM item-type catalogue (`OsmService.ParseAvailableSites`: leaf item-types under the "Campsites"/"Indoor Accommodation" categories, at any nesting depth; activities/categories excluded). New `AvailableSiteDto`, `IOsmService`/`FakeOsmService` method, `bookingsApi.getAvailableSites`.
- **Three inline action forms** in `BookingDetail.tsx`, each with a two-step **confirm gate** before the destructive create+delete, a status-coloured **result banner** (completed / completed_with_warnings — lists leftover duplicates / rolled_back / failed), and **in-place items refresh** from `result.items` (no extra fetch).
- **Frontend test harness** — first Vitest + React Testing Library setup in the project.

## Key decisions

- **In-place refresh:** `runAction` sets `items` directly from the action response rather than re-fetching.
- **Change-site excludes the current site** (`s.id !== item.siteId`); empty list disables the action with a message.
- **Move-activity requires a changed field** — submit is disabled for an all-empty (no-op) move.
- **Inline confirm gate**, not a modal — matches the existing house style (no modal component in the codebase).
- **Best-effort site loading** — a failed `available-sites` fetch just disables change-site, never blocks the page.

## Testing

- Backend **184/184** (`OsmServiceAvailableSitesTests` incl. nested-sites; `BookingActionsAvailableSitesTests` 200/empty/404/401/502).
- Frontend **10/10** RTL (move-dates submit/warnings/cancel/error/refresh; move-activity by time & by date, all-empty guard; change-site exclusion/submit/empty-state).
- `npm run build` (tsc + vite) and `eslint` clean.

> **Dev note:** the dev host has no npm on PATH; the frontend toolchain (install/test/build/lint) runs in a `node:22` Docker container against a bind-mounted `BookingsAssistant.Web`. See `.workflow-state.md`.

## Review guidance

- `OsmService.ParseAvailableSites` derives the site categories from the names "Campsites"/"Indoor Accommodation" — confirm those are stable OSM strings for this campsite.
- The per-item action state (`activeItemAction` / `confirmingItemAction`) allows one open form at a time; `openItemAction` resets the shared form fields on every entry.
- **Still open (from #27):** the OSM `section:campsite_bookings:write` scope is unconfirmed (HAR used cookies, not our Bearer token). Real submissions may return `rolled_back`/`failed` until a live token smoke test confirms scope — the result banner surfaces this gracefully.

[release-note]feature: Booking actions UI — move an activity, change a site, or shift all booking dates from the booking detail page, with confirmation and result feedback.[/release-note]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
