### PR TITLE
Add /bookings search page (find bookings by name, ID, or date range)

### DIFF
--- a/BookingsAssistant.Web/src/App.tsx
+++ b/BookingsAssistant.Web/src/App.tsx
@@ -1,12 +1,14 @@
 import { Routes, Route } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import BookingDetail from './components/BookingDetail';
+import BookingList from './components/BookingList';
 
 function App() {
   return (
     <div className="min-h-screen bg-gray-100">
       <Routes>
         <Route path="/" element={<Dashboard />} />
+        <Route path="/bookings" element={<BookingList />} />
         <Route path="/bookings/:id" element={<BookingDetail />} />
       </Routes>
     </div>

--- a/BookingsAssistant.Web/src/components/BookingList.tsx
+++ b/BookingsAssistant.Web/src/components/BookingList.tsx
@@ -16,6 +16,8 @@ export default function BookingList() {
   const [includePastCancelled, setIncludePastCancelled] = useState(false);
 
   useEffect(() => {
+    // Loads all bookings (all statuses) into the browser; filtering is done client-side.
+    // Revisit with a server-side status filter / pagination if the dataset grows large.
     bookingsApi
       .getAll()
       .then(setAllBookings)

--- a/BookingsAssistant.Web/src/components/BookingList.tsx
+++ b/BookingsAssistant.Web/src/components/BookingList.tsx
@@ -1,0 +1,116 @@
+import { useState, useEffect, useMemo } from 'react';
+import { Link } from 'react-router-dom';
+import { bookingsApi } from '../services/apiClient';
+import type { Booking } from '../types';
+import BookingCard from './BookingCard';
+import { filterBookings } from '../utils/bookingFilter';
+
+export default function BookingList() {
+  const [allBookings, setAllBookings] = useState<Booking[]>([]);
+  const [loading, setLoading] = useState(true);
+  const [error, setError] = useState<string | null>(null);
+
+  const [search, setSearch] = useState('');
+  const [dateFrom, setDateFrom] = useState('');
+  const [dateTo, setDateTo] = useState('');
+  const [includePastCancelled, setIncludePastCancelled] = useState(false);
+
+  useEffect(() => {
+    bookingsApi
+      .getAll()
+      .then(setAllBookings)
+      .catch(() => setError('Failed to load bookings'))
+      .finally(() => setLoading(false));
+  }, []);
+
+  const filteredBookings = useMemo(
+    () => filterBookings(allBookings, { search, dateFrom, dateTo, includePastCancelled }),
+    [allBookings, search, dateFrom, dateTo, includePastCancelled]
+  );
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <div className="flex items-center gap-4 mb-6">
+        <Link to="/" className="text-sm text-blue-600 hover:underline">
+          ← Dashboard
+        </Link>
+        <h1 className="text-2xl font-bold text-gray-800">All Bookings</h1>
+      </div>
+
+      {/* Filters */}
+      <div className="bg-white rounded-lg shadow p-4 mb-6 space-y-4">
+        <div>
+          <label htmlFor="search" className="block text-sm font-medium text-gray-700 mb-1">
+            Search
+          </label>
+          <input
+            id="search"
+            type="text"
+            placeholder="Name or booking ID…"
+            value={search}
+            onChange={(e) => setSearch(e.target.value)}
+            className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+          />
+        </div>
+
+        <div className="flex flex-wrap gap-4">
+          <div className="flex-1 min-w-36">
+            <label htmlFor="dateFrom" className="block text-sm font-medium text-gray-700 mb-1">
+              From
+            </label>
+            <input
+              id="dateFrom"
+              type="date"
+              value={dateFrom}
+              onChange={(e) => setDateFrom(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+          <div className="flex-1 min-w-36">
+            <label htmlFor="dateTo" className="block text-sm font-medium text-gray-700 mb-1">
+              To
+            </label>
+            <input
+              id="dateTo"
+              type="date"
+              value={dateTo}
+              onChange={(e) => setDateTo(e.target.value)}
+              className="w-full border border-gray-300 rounded px-3 py-2 text-sm focus:outline-none focus:ring-2 focus:ring-blue-500"
+            />
+          </div>
+        </div>
+
+        <label className="flex items-center gap-2 text-sm text-gray-700 cursor-pointer select-none">
+          <input
+            type="checkbox"
+            checked={includePastCancelled}
+            onChange={(e) => setIncludePastCancelled(e.target.checked)}
+            className="rounded border-gray-300"
+          />
+          Include past &amp; cancelled
+        </label>
+      </div>
+
+      {/* Results */}
+      {loading && <p className="text-sm text-gray-400">Loading…</p>}
+
+      {error && (
+        <div className="p-4 bg-red-100 border border-red-400 text-red-700 rounded text-sm">
+          {error}
+        </div>
+      )}
+
+      {!loading && !error && filteredBookings.length === 0 && (
+        <p className="text-sm text-gray-400">No bookings match your search.</p>
+      )}
+
+      {!loading && !error && filteredBookings.length > 0 && (
+        <div className="space-y-2">
+          {filteredBookings.map((booking) => (
+            <BookingCard key={booking.id} booking={booking} />
+          ))}
+        </div>
+      )}
+    </div>
+  );
+}

--- a/BookingsAssistant.Web/src/components/Dashboard.tsx
+++ b/BookingsAssistant.Web/src/components/Dashboard.tsx
@@ -1,4 +1,5 @@
 import { useState, useEffect, useCallback } from 'react';
+import { Link } from 'react-router-dom';
 import { bookingsApi, emailsApi, syncApi } from '../services/apiClient';
 import apiClient from '../services/apiClient';
 import type { Booking, BookingStats, Email, GateCodeStatus } from '../types';
@@ -177,6 +178,15 @@ export default function Dashboard() {
           colorClass="text-amber-600"
         />
       </div>
+
+      {/* Browse link — always visible once loading is done */}
+      {!loading && (
+        <div className="mt-6 text-right">
+          <Link to="/bookings" className="text-sm text-blue-600 hover:underline">
+            Browse all bookings →
+          </Link>
+        </div>
+      )}
 
       {/* Upcoming arrivals */}
       {!loading && upcomingBookings.length > 0 && (

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -30,6 +30,7 @@ export interface Booking {
   id: number;
   osmBookingId: string;
   customerName: string;
+  // Reserved for the BookingDetail view only. The GET /api/bookings list endpoint must NOT project customer email — raw emails are never loaded into the list.
   customerEmail?: string;
   startDate: string;
   endDate: string;

--- a/BookingsAssistant.Web/src/utils/bookingFilter.test.ts
+++ b/BookingsAssistant.Web/src/utils/bookingFilter.test.ts
@@ -1,0 +1,170 @@
+import { describe, it, expect } from 'vitest';
+import { filterBookings } from './bookingFilter';
+import type { Booking } from '../types';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function makeBooking(overrides: Partial<Booking> & { id: number }): Booking {
+  return {
+    osmBookingId: String(overrides.id * 100),
+    customerName: 'Default Name',
+    startDate: '2027-06-01',
+    endDate: '2027-06-07',
+    status: 'Confirmed',
+    ...overrides,
+  };
+}
+
+const noFilter = {
+  search: '',
+  dateFrom: '',
+  dateTo: '',
+  includePastCancelled: true,
+};
+
+// ── Free-text search ──────────────────────────────────────────────────────────
+
+describe('filterBookings — free-text search', () => {
+  const bookings = [
+    makeBooking({ id: 1, osmBookingId: '12345', customerName: 'Alice Smith' }),
+    makeBooking({ id: 2, osmBookingId: '67890', customerName: 'Bob Jones' }),
+  ];
+
+  it('matches a booking whose customerName contains the query (case-insensitive)', () => {
+    const result = filterBookings(bookings, { ...noFilter, search: 'alice' });
+    expect(result).toHaveLength(1);
+    expect(result[0].customerName).toBe('Alice Smith');
+  });
+
+  it('matches a booking whose osmBookingId contains the query', () => {
+    const result = filterBookings(bookings, { ...noFilter, search: '678' });
+    expect(result).toHaveLength(1);
+    expect(result[0].osmBookingId).toBe('67890');
+  });
+
+  it('matches case-insensitively against customerName', () => {
+    const result = filterBookings(bookings, { ...noFilter, search: 'ALICE' });
+    expect(result).toHaveLength(1);
+    expect(result[0].customerName).toBe('Alice Smith');
+  });
+
+  it('returns an empty array when the query matches nothing', () => {
+    const result = filterBookings(bookings, { ...noFilter, search: 'zzznomatch' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('returns all bookings when search is empty', () => {
+    const result = filterBookings(bookings, { ...noFilter, search: '' });
+    expect(result).toHaveLength(2);
+  });
+});
+
+// ── Date range filtering ──────────────────────────────────────────────────────
+
+describe('filterBookings — date range', () => {
+  // stay: 10–20 June
+  const stayJune = makeBooking({ id: 1, startDate: '2027-06-10', endDate: '2027-06-20' });
+  // stay: 25 June – 5 July (overlaps into July)
+  const stayJulyOverlap = makeBooking({ id: 2, startDate: '2027-06-25', endDate: '2027-07-05' });
+  // stay: entirely in May
+  const stayMay = makeBooking({ id: 3, startDate: '2027-05-01', endDate: '2027-05-10' });
+  // stay: 1–30 July
+  const stayJuly = makeBooking({ id: 4, startDate: '2027-07-01', endDate: '2027-07-30' });
+
+  it('includes a stay fully inside the date range', () => {
+    const result = filterBookings([stayJune], { ...noFilter, dateFrom: '2027-06-01', dateTo: '2027-06-30' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('includes a stay that overlaps the start boundary (booking starts before dateFrom but ends within range)', () => {
+    // booking 25 Jun–5 Jul, range from 1 Jul; booking ends after dateFrom so it overlaps
+    const result = filterBookings([stayJulyOverlap], { ...noFilter, dateFrom: '2027-07-01', dateTo: '2027-07-31' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('excludes a stay entirely before the date range', () => {
+    const result = filterBookings([stayMay], { ...noFilter, dateFrom: '2027-06-01', dateTo: '2027-06-30' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('excludes a stay entirely after the date range', () => {
+    const result = filterBookings([stayJuly], { ...noFilter, dateFrom: '2027-05-01', dateTo: '2027-05-31' });
+    expect(result).toHaveLength(0);
+  });
+
+  it('with only dateFrom set, includes stays ending on or after dateFrom', () => {
+    // stayJune ends 20 Jun; dateFrom 15 Jun => overlaps
+    const result = filterBookings([stayJune, stayMay], { ...noFilter, dateFrom: '2027-06-15', dateTo: '' });
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(stayJune);
+  });
+
+  it('with only dateTo set, includes stays starting on or before dateTo', () => {
+    // stayJuly starts 1 Jul; dateTo 15 Jul => included
+    // stayMay starts 1 May; dateTo 15 Jul => also included
+    const result = filterBookings([stayJuly, stayMay], { ...noFilter, dateFrom: '', dateTo: '2027-07-15' });
+    expect(result).toHaveLength(2);
+  });
+
+  it('with neither dateFrom nor dateTo, applies no date filtering', () => {
+    const all = [stayJune, stayJulyOverlap, stayMay, stayJuly];
+    const result = filterBookings(all, { ...noFilter, dateFrom: '', dateTo: '' });
+    expect(result).toHaveLength(4);
+  });
+});
+
+// ── includePastCancelled toggle ───────────────────────────────────────────────
+
+describe('filterBookings — includePastCancelled toggle', () => {
+  const confirmed = makeBooking({ id: 1, status: 'Confirmed' });
+  const future = makeBooking({ id: 2, status: 'Future' });
+  const provisional = makeBooking({ id: 3, status: 'Provisional' });
+  const past = makeBooking({ id: 4, status: 'Past' });
+  const cancelled = makeBooking({ id: 5, status: 'Cancelled' });
+
+  it('hides past and cancelled when includePastCancelled is false', () => {
+    const result = filterBookings(
+      [confirmed, future, provisional, past, cancelled],
+      { ...noFilter, includePastCancelled: false }
+    );
+    expect(result.map((b) => b.status)).toEqual(
+      expect.arrayContaining(['Confirmed', 'Future', 'Provisional'])
+    );
+    expect(result.map((b) => b.status)).not.toContain('Past');
+    expect(result.map((b) => b.status)).not.toContain('Cancelled');
+  });
+
+  it('shows past and cancelled when includePastCancelled is true', () => {
+    const result = filterBookings(
+      [confirmed, future, provisional, past, cancelled],
+      { ...noFilter, includePastCancelled: true }
+    );
+    expect(result).toHaveLength(5);
+  });
+
+  it('always shows active statuses regardless of toggle', () => {
+    const result = filterBookings([confirmed, future, provisional], {
+      ...noFilter,
+      includePastCancelled: false,
+    });
+    expect(result).toHaveLength(3);
+  });
+});
+
+// ── Sort order ────────────────────────────────────────────────────────────────
+
+describe('filterBookings — sort order', () => {
+  it('returns results sorted by startDate ascending', () => {
+    const bookings = [
+      makeBooking({ id: 1, startDate: '2027-09-01', endDate: '2027-09-07' }),
+      makeBooking({ id: 2, startDate: '2027-06-01', endDate: '2027-06-07' }),
+      makeBooking({ id: 3, startDate: '2027-07-15', endDate: '2027-07-20' }),
+    ];
+    const result = filterBookings(bookings, noFilter);
+    expect(result.map((b) => b.startDate)).toEqual([
+      '2027-06-01',
+      '2027-07-15',
+      '2027-09-01',
+    ]);
+  });
+});

--- a/BookingsAssistant.Web/src/utils/bookingFilter.test.ts
+++ b/BookingsAssistant.Web/src/utils/bookingFilter.test.ts
@@ -15,6 +15,7 @@ function makeBooking(overrides: Partial<Booking> & { id: number }): Booking {
   };
 }
 
+// includePastCancelled: true so status filtering doesn't interfere with the other test groups
 const noFilter = {
   search: '',
   dateFrom: '',
@@ -30,11 +31,13 @@ describe('filterBookings — free-text search', () => {
     makeBooking({ id: 2, osmBookingId: '67890', customerName: 'Bob Jones' }),
   ];
 
-  it('matches a booking whose customerName contains the query (case-insensitive)', () => {
+  it('matches customerName case-insensitively with a lowercase query', () => {
     const lower = filterBookings(bookings, { ...noFilter, search: 'alice' });
     expect(lower).toHaveLength(1);
     expect(lower[0].customerName).toBe('Alice Smith');
+  });
 
+  it('matches customerName case-insensitively with an uppercase query', () => {
     const upper = filterBookings(bookings, { ...noFilter, search: 'ALICE' });
     expect(upper).toHaveLength(1);
     expect(upper[0].customerName).toBe('Alice Smith');

--- a/BookingsAssistant.Web/src/utils/bookingFilter.test.ts
+++ b/BookingsAssistant.Web/src/utils/bookingFilter.test.ts
@@ -31,21 +31,19 @@ describe('filterBookings — free-text search', () => {
   ];
 
   it('matches a booking whose customerName contains the query (case-insensitive)', () => {
-    const result = filterBookings(bookings, { ...noFilter, search: 'alice' });
-    expect(result).toHaveLength(1);
-    expect(result[0].customerName).toBe('Alice Smith');
+    const lower = filterBookings(bookings, { ...noFilter, search: 'alice' });
+    expect(lower).toHaveLength(1);
+    expect(lower[0].customerName).toBe('Alice Smith');
+
+    const upper = filterBookings(bookings, { ...noFilter, search: 'ALICE' });
+    expect(upper).toHaveLength(1);
+    expect(upper[0].customerName).toBe('Alice Smith');
   });
 
   it('matches a booking whose osmBookingId contains the query', () => {
     const result = filterBookings(bookings, { ...noFilter, search: '678' });
     expect(result).toHaveLength(1);
     expect(result[0].osmBookingId).toBe('67890');
-  });
-
-  it('matches case-insensitively against customerName', () => {
-    const result = filterBookings(bookings, { ...noFilter, search: 'ALICE' });
-    expect(result).toHaveLength(1);
-    expect(result[0].customerName).toBe('Alice Smith');
   });
 
   it('returns an empty array when the query matches nothing', () => {
@@ -57,6 +55,11 @@ describe('filterBookings — free-text search', () => {
     const result = filterBookings(bookings, { ...noFilter, search: '' });
     expect(result).toHaveLength(2);
   });
+
+  it('returns an empty array when given an empty bookings list', () => {
+    const result = filterBookings([], noFilter);
+    expect(result).toHaveLength(0);
+  });
 });
 
 // ── Date range filtering ──────────────────────────────────────────────────────
@@ -64,7 +67,7 @@ describe('filterBookings — free-text search', () => {
 describe('filterBookings — date range', () => {
   // stay: 10–20 June
   const stayJune = makeBooking({ id: 1, startDate: '2027-06-10', endDate: '2027-06-20' });
-  // stay: 25 June – 5 July (overlaps into July)
+  // stay: 25 June – 5 July (straddles the 1 July boundary)
   const stayJulyOverlap = makeBooking({ id: 2, startDate: '2027-06-25', endDate: '2027-07-05' });
   // stay: entirely in May
   const stayMay = makeBooking({ id: 3, startDate: '2027-05-01', endDate: '2027-05-10' });
@@ -76,8 +79,8 @@ describe('filterBookings — date range', () => {
     expect(result).toHaveLength(1);
   });
 
-  it('includes a stay that overlaps the start boundary (booking starts before dateFrom but ends within range)', () => {
-    // booking 25 Jun–5 Jul, range from 1 Jul; booking ends after dateFrom so it overlaps
+  it('includes a stay that straddles the lower bound (starts before dateFrom, ends after it)', () => {
+    // booking 25 Jun–5 Jul; range from 1 Jul — the booking's end crosses into the range
     const result = filterBookings([stayJulyOverlap], { ...noFilter, dateFrom: '2027-07-01', dateTo: '2027-07-31' });
     expect(result).toHaveLength(1);
   });
@@ -92,16 +95,27 @@ describe('filterBookings — date range', () => {
     expect(result).toHaveLength(0);
   });
 
+  it('includes a stay whose endDate exactly equals dateFrom (boundary-exact overlap)', () => {
+    // stayJune ends 20 Jun; dateFrom exactly 20 Jun — boundary should be inclusive
+    const result = filterBookings([stayJune], { ...noFilter, dateFrom: '2027-06-20', dateTo: '2027-06-30' });
+    expect(result).toHaveLength(1);
+  });
+
+  it('includes a stay whose startDate exactly equals dateTo (boundary-exact overlap)', () => {
+    // stayJuly starts 1 Jul; dateTo exactly 1 Jul — boundary should be inclusive
+    const result = filterBookings([stayJuly], { ...noFilter, dateFrom: '2027-06-01', dateTo: '2027-07-01' });
+    expect(result).toHaveLength(1);
+  });
+
   it('with only dateFrom set, includes stays ending on or after dateFrom', () => {
-    // stayJune ends 20 Jun; dateFrom 15 Jun => overlaps
+    // stayJune ends 20 Jun; dateFrom 15 Jun => overlaps; stayMay ends 10 May => excluded
     const result = filterBookings([stayJune, stayMay], { ...noFilter, dateFrom: '2027-06-15', dateTo: '' });
     expect(result).toHaveLength(1);
     expect(result[0]).toBe(stayJune);
   });
 
   it('with only dateTo set, includes stays starting on or before dateTo', () => {
-    // stayJuly starts 1 Jul; dateTo 15 Jul => included
-    // stayMay starts 1 May; dateTo 15 Jul => also included
+    // stayJuly starts 1 Jul; dateTo 15 Jul => included; stayMay starts 1 May => included
     const result = filterBookings([stayJuly, stayMay], { ...noFilter, dateFrom: '', dateTo: '2027-07-15' });
     expect(result).toHaveLength(2);
   });
@@ -141,13 +155,24 @@ describe('filterBookings — includePastCancelled toggle', () => {
     );
     expect(result).toHaveLength(5);
   });
+});
 
-  it('always shows active statuses regardless of toggle', () => {
-    const result = filterBookings([confirmed, future, provisional], {
-      ...noFilter,
-      includePastCancelled: false,
-    });
-    expect(result).toHaveLength(3);
+// ── Combined filters ──────────────────────────────────────────────────────────
+
+describe('filterBookings — combined filters', () => {
+  it('applies search, date range, and status toggle together', () => {
+    const alice = makeBooking({ id: 1, customerName: 'Alice Smith', startDate: '2027-06-10', endDate: '2027-06-20', status: 'Confirmed' });
+    const bob = makeBooking({ id: 2, customerName: 'Bob Jones', startDate: '2027-06-10', endDate: '2027-06-20', status: 'Confirmed' });
+    const alicePast = makeBooking({ id: 3, customerName: 'Alice Smith', startDate: '2026-01-01', endDate: '2026-01-07', status: 'Past' });
+
+    // search="alice", dateFrom in June 2027, includePastCancelled=false
+    // => alice (June, Confirmed) matches; bob excluded by search; alicePast excluded by status
+    const result = filterBookings(
+      [alice, bob, alicePast],
+      { search: 'alice', dateFrom: '2027-06-01', dateTo: '2027-06-30', includePastCancelled: false }
+    );
+    expect(result).toHaveLength(1);
+    expect(result[0]).toBe(alice);
   });
 });
 

--- a/BookingsAssistant.Web/src/utils/bookingFilter.ts
+++ b/BookingsAssistant.Web/src/utils/bookingFilter.ts
@@ -41,8 +41,8 @@ export function filterBookings(
       // Date range overlap: booking's [startDate, endDate] intersects [dateFrom, dateTo]
       // Overlap condition: bookingStart <= dateTo AND bookingEnd >= dateFrom
       if (dateFrom || dateTo) {
-        const bookingStart = b.startDate.slice(0, 10);
-        const bookingEnd = b.endDate.slice(0, 10);
+        const bookingStart = b.startDate.slice(0, 10); // take YYYY-MM-DD from ISO string
+        const bookingEnd = b.endDate.slice(0, 10);     // take YYYY-MM-DD from ISO string
 
         if (dateTo && bookingStart > dateTo) return false;
         if (dateFrom && bookingEnd < dateFrom) return false;

--- a/BookingsAssistant.Web/src/utils/bookingFilter.ts
+++ b/BookingsAssistant.Web/src/utils/bookingFilter.ts
@@ -1,0 +1,54 @@
+import type { Booking } from '../types';
+
+export interface BookingFilterParams {
+  search: string;
+  dateFrom: string;
+  dateTo: string;
+  includePastCancelled: boolean;
+}
+
+/** Statuses shown when "include past & cancelled" is OFF. */
+const ACTIVE_STATUSES = new Set(['confirmed', 'future', 'provisional']);
+
+/**
+ * Filters and sorts bookings by the given search/date/status params.
+ *
+ * - search: case-insensitive substring match against osmBookingId OR customerName
+ * - dateFrom / dateTo: stay-overlap filter (booking's [startDate, endDate] intersects [dateFrom, dateTo])
+ * - includePastCancelled: when false, only active statuses (Confirmed, Future, Provisional) are shown
+ * - Results are sorted by startDate ascending
+ */
+export function filterBookings(
+  bookings: Booking[],
+  { search, dateFrom, dateTo, includePastCancelled }: BookingFilterParams
+): Booking[] {
+  const query = search.trim().toLowerCase();
+
+  return bookings
+    .filter((b) => {
+      // Status filter
+      if (!includePastCancelled && !ACTIVE_STATUSES.has(b.status.toLowerCase())) {
+        return false;
+      }
+
+      // Free-text search
+      if (query) {
+        const matchesId = b.osmBookingId.toLowerCase().includes(query);
+        const matchesName = b.customerName.toLowerCase().includes(query);
+        if (!matchesId && !matchesName) return false;
+      }
+
+      // Date range overlap: booking's [startDate, endDate] intersects [dateFrom, dateTo]
+      // Overlap condition: bookingStart <= dateTo AND bookingEnd >= dateFrom
+      if (dateFrom || dateTo) {
+        const bookingStart = b.startDate.slice(0, 10);
+        const bookingEnd = b.endDate.slice(0, 10);
+
+        if (dateTo && bookingStart > dateTo) return false;
+        if (dateFrom && bookingEnd < dateFrom) return false;
+      }
+
+      return true;
+    })
+    .sort((a, b) => a.startDate.localeCompare(b.startDate));
+}

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.9.26
+version: 0.9.27
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper


### PR DESCRIPTION
## Summary

The dashboard previously showed only a 7-day upcoming-arrivals widget, so there was no way to browse, search, or filter the full booking list from the web UI — the reported "can't move-site beyond 7 days" was really "there's no way to reach a booking beyond 7 days." This PR adds a `/bookings` search page so any booking can be found by name, ID, or date range, and its detail page (and move-site / other actions) reached.

## Approach

The page fetches all bookings once via the existing `bookingsApi.getAll()` and filters client-side on every keystroke using a pure `filterBookings` helper. No backend changes were needed. `BookingCard` (previously unused) is reused so rows render consistently with the rest of the app. The deliberate tradeoff is loading the full booking set upfront — fine for a small campsite dataset and far simpler than paginated search endpoints. Server-side filtering would be the right next step only if load times become noticeable.

## Key decisions

- **Client-side filtering, full load accepted.** Simplicity over scale for a single-user add-on; the same data was already reachable via the existing API. A comment flags this for future revisitors.
- **Stay-overlap date matching** (`bookingStart <= dateTo AND bookingEnd >= dateFrom`) rather than "starts within range" — a booking straddling the range boundary is still relevant.
- **Single "include past & cancelled" toggle** rather than a five-way status multi-select — operators almost always want active bookings; one opt-in covers the historical-search case with less friction.
- **`filterBookings` extracted as a pure function** in `utils/bookingFilter.ts` so all filtering/sorting is unit-tested without rendering a component; `BookingList` is pure wiring.

## Testing strategy

19 unit tests in `bookingFilter.test.ts` cover the helper in isolation:
- **Free-text (6):** name match (lower- and upper-case queries), ID match, no-match, empty query, empty input list.
- **Date range (9):** fully inside, straddles lower bound, entirely before/after, exact boundaries (endDate == dateFrom, startDate == dateTo), open-ended (only dateFrom, only dateTo, neither).
- **Status toggle (2):** hides past/cancelled when off; shows all when on.
- **Combined (1)** and **sort order (1).**

Full frontend suite: 29 tests passing; `npm run build` and `npm run lint` clean. (Frontend tooling runs via a node Docker container — no host npm.)

## Review guidance

- **`bookingFilter.ts` date-overlap predicate** is the riskiest part — standard interval-intersection; the boundary/straddle tests pin its inclusivity.
- `BookingList.tsx`, `Dashboard.tsx`, `App.tsx` are straightforward wiring (fetch, memo, render, route, link).
- `ACTIVE_STATUSES` compares lowercased status strings; confirmed the backend emits only `confirmed/future/provisional/past/cancelled` (no `current`).

[release-note][/release-note]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
