### PR TITLE
Fix change-site for multi-night stays (OSM slot resolution)

### DIFF
--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -459,9 +459,17 @@ internal class OsmService : IOsmService
     }
 
     /// <summary>
-    /// Finds the availability slot id whose date window matches the requested start/end
-    /// dates (times within the slot are flexible and supplied separately). Returns null
-    /// when no available slot covers the window.
+    /// Finds the availability slot id for the requested start/end dates (times within the
+    /// slot are flexible and supplied separately). Returns null when no available slot
+    /// covers the window.
+    ///
+    /// OSM returns availability as per-session slots, not one slot per arbitrary stay
+    /// length. A multi-night stay therefore rarely has a slot whose <c>end</c> falls on the
+    /// departure date: instead there is a <c>multi_day</c> slot starting on the arrival date
+    /// whose <c>end</c> is only the first night but whose <c>available_until</c> marks how
+    /// far the stay can run. We take an exact single-slot span match if one exists
+    /// (same-day bookings, and slots already covering the window), otherwise fall back to a
+    /// slot on the arrival date whose <c>available_until</c> reaches the departure date.
     /// </summary>
     internal static string? ResolveSlotId(string? availabilityJson, DateTime startDate, DateTime endDate)
     {
@@ -471,6 +479,8 @@ internal class OsmService : IOsmService
         if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
             return null;
 
+        string? multiNightMatch = null;
+
         foreach (var slot in data.EnumerateArray())
         {
             // OSM marks booked-out slots with available:false; an absent flag counts as
@@ -478,15 +488,30 @@ internal class OsmService : IOsmService
             if (slot.TryGetProperty("available", out var avail) && avail.ValueKind == JsonValueKind.False)
                 continue;
 
-            // Slots are matched on date span only; the exact times within the window are
+            // Every candidate must begin on the arrival date; times within the slot are
             // flexible and supplied separately in the create form.
             var (slotStart, _) = SplitTimestamp(GetString(slot, "start"));
+            if (slotStart != startDate.Date)
+                continue;
+
+            // Exact single-slot span match — first one wins (same-day stays, or a slot that
+            // already spans the whole window).
             var (slotEnd, _) = SplitTimestamp(GetString(slot, "end"));
-            if (slotStart == startDate.Date && slotEnd == endDate.Date)
-                return GetString(slot, "id");   // first slot matching the date span
+            if (slotEnd == endDate.Date)
+                return GetString(slot, "id");
+
+            // Multi-night fallback: a slot on the arrival date whose availability extends
+            // (via available_until) to at least the departure date. First such slot wins,
+            // but only if no exact match is found, so it never overrides a same-day slot.
+            if (multiNightMatch is null && endDate.Date > startDate.Date)
+            {
+                var (availableUntil, _) = SplitTimestamp(GetString(slot, "available_until"));
+                if (availableUntil is not null && availableUntil >= endDate.Date)
+                    multiNightMatch = GetString(slot, "id");
+            }
         }
 
-        return null;
+        return multiNightMatch;
     }
 
     /// <summary>Builds the OSM addItem form fields from a create spec and resolved slot id.</summary>

--- a/BookingsAssistant.Tests/Fixtures/OsmItems/availability-overnight-multiday.json
+++ b/BookingsAssistant.Tests/Fixtures/OsmItems/availability-overnight-multiday.json
@@ -1,0 +1,47 @@
+{
+  "status": true,
+  "error": null,
+  "data": [
+    {
+      "start": "2026-07-17 00:01:00",
+      "end": "2026-07-17 16:59:00",
+      "available": true,
+      "available_until": false,
+      "multi_day": false,
+      "id": 8272
+    },
+    {
+      "start": "2026-07-17 09:00:00",
+      "end": "2026-07-18 22:00:00",
+      "available": true,
+      "available_until": "2026-07-20 22:00:00",
+      "multi_day": true,
+      "id": 8273
+    },
+    {
+      "start": "2026-07-17 17:00:00",
+      "end": "2026-07-17 23:59:00",
+      "available": true,
+      "available_until": false,
+      "multi_day": false,
+      "id": 8274
+    },
+    {
+      "start": "2026-07-18 09:00:00",
+      "end": "2026-07-19 22:00:00",
+      "available": true,
+      "available_until": "2026-07-20 22:00:00",
+      "multi_day": true,
+      "id": 8273
+    },
+    {
+      "start": "2026-07-20 00:01:00",
+      "end": "2026-07-20 16:59:00",
+      "available": true,
+      "available_until": false,
+      "multi_day": false,
+      "id": 8272
+    }
+  ],
+  "meta": { "min_people": 0, "max_people": 50 }
+}

--- a/BookingsAssistant.Tests/Services/OsmServiceItemMutationTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceItemMutationTests.cs
@@ -34,6 +34,31 @@ public class OsmServiceItemMutationTests
             new DateTime(2030, 1, 1), new DateTime(2030, 1, 2)));
 
     [Fact]
+    public void ResolveSlotId_MatchesMultiNightStay_ViaAvailableUntil()
+        // A 3-night stay (17→20 Jul) has no single slot ending on the 20th. OSM returns a
+        // multi_day slot starting on the arrival date (id 8273) whose `end` is the first
+        // night (18 Jul) but whose `available_until` (20 Jul) covers the departure date.
+        => Assert.Equal("8273", OsmService.ResolveSlotId(
+            Fixture("availability-overnight-multiday.json"),
+            new DateTime(2026, 7, 17), new DateTime(2026, 7, 20)));
+
+    [Fact]
+    public void ResolveSlotId_MatchesSameDay_WhenStayIsOneDay()
+        // A single-day booking on the arrival date must still pick a same-day slot, not the
+        // overnight multi_day one — exact-span matching takes precedence over the fallback.
+        => Assert.Equal("8272", OsmService.ResolveSlotId(
+            Fixture("availability-overnight-multiday.json"),
+            new DateTime(2026, 7, 17), new DateTime(2026, 7, 17)));
+
+    [Fact]
+    public void ResolveSlotId_ReturnsNull_WhenAvailableUntilDoesNotReachDeparture()
+        // No exact-span slot and the arrival-date slot's availability stops short of the
+        // requested departure → no usable slot.
+        => Assert.Null(OsmService.ResolveSlotId(
+            Fixture("availability-overnight-multiday.json"),
+            new DateTime(2026, 7, 17), new DateTime(2026, 7, 25)));
+
+    [Fact]
     public void ResolveSlotId_SkipsUnavailableSlot_AndPicksAvailableMatch()
     {
         // Two slots share the same date span; the first is unavailable and must be skipped.

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.9.28
+version: 0.9.29
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper


### PR DESCRIPTION
## Summary

Fixes the change-site action (and move-dates / move-activity) failing with **"No available OSM slot"** for any multi-night booking. Bumps the add-on to 0.9.29.

## The bug

`ResolveSlotId` only accepted a slot whose `end` date equalled the booking's departure date:

```csharp
if (slotStart == startDate.Date && slotEnd == endDate.Date) ...
```

But OSM returns availability as **per-session slots**, not one slot per arbitrary stay length. A multi-night stay has a `multi_day` slot that starts on the arrival date, whose `end` is only the *first night* but whose **`available_until`** marks how far the stay can run. For a 17→20 Jul booking the right slot (id 8273) has `start: 2026-07-17`, `end: 2026-07-18`, `available_until: 2026-07-20` — so the old exact-`end` check never matched and the create threw before anything changed (the booking was left intact).

## The fix

`OsmService.ResolveSlotId`:
- Keep the exact single-slot span match (same-day bookings, and slots already covering the window) — takes precedence, so single-day behaviour is unchanged.
- Add a multi-night fallback: a slot on the **arrival date** whose **`available_until`** reaches at least the departure date. First such slot wins; never overrides an exact same-day match.

Captured a real OSM availability response (booking 149925, 17–20 Jul) as a fixture and added regression tests:
- multi-night stay resolves via `available_until` (→ slot 8273)
- single-day stay still picks the same-day slot (not the overnight one)
- returns null when `available_until` stops short of the departure date

## Testing

Backend: 187 tests passing (`dotnet test`), including 3 new slot-resolution cases.

[release-note]bug: Fix "No available OSM slot" when moving a multi-night booking to a different site[/release-note]

🤖 Generated with [Claude Code](https://claude.com/claude-code)
