### PR TITLE
Reduce OSM sync payload to avoid 429s; fetch comments ad-hoc on booking open

### DIFF
--- a/BookingsAssistant.Api/Controllers/BookingsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingsController.cs
@@ -150,6 +150,39 @@ public class BookingsController : ControllerBase
         if (booking == null)
             return NotFound();
 
+        var freshComments = await _osmService.GetBookingCommentsAsync(booking.OsmBookingId);
+        if (freshComments.Count > 0)
+        {
+            var existingComments = await _context.OsmComments
+                .Where(c => c.OsmBookingId == booking.OsmBookingId)
+                .ToDictionaryAsync(c => c.OsmCommentId);
+
+            foreach (var comment in freshComments)
+            {
+                if (existingComments.TryGetValue(comment.OsmCommentId, out var entity))
+                {
+                    entity.AuthorName = comment.AuthorName;
+                    entity.TextPreview = comment.TextPreview;
+                    entity.LastFetched = DateTime.UtcNow;
+                }
+                else
+                {
+                    _context.OsmComments.Add(new Data.Entities.OsmComment
+                    {
+                        OsmBookingId = booking.OsmBookingId,
+                        OsmCommentId = comment.OsmCommentId,
+                        AuthorName = comment.AuthorName,
+                        TextPreview = comment.TextPreview,
+                        CreatedDate = comment.CreatedDate,
+                        IsNew = true,
+                        LastFetched = DateTime.UtcNow
+                    });
+                }
+            }
+
+            await _context.SaveChangesAsync();
+        }
+
         // Get linked emails via ApplicationLinks join
         var linkedEmails = await _context.ApplicationLinks
             .Where(l => l.OsmBookingId == id)

--- a/BookingsAssistant.Api/Controllers/BookingsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingsController.cs
@@ -131,21 +131,6 @@ public class BookingsController : ControllerBase
 
             var result = await UpsertBookingsAsync(allBookings);
 
-            // Fetch and persist comments for active bookings only (Provisional + Confirmed)
-            // to avoid hammering the OSM API for 1000+ past/cancelled bookings
-            var activeOsmIds = allBookings
-                .Where(b => b.Status == "Provisional" || b.Status == "Confirmed")
-                .Select(b => b.OsmBookingId)
-                .ToList();
-
-            var (commentsAdded, commentsUpdated) = await UpsertCommentsAsync(activeOsmIds);
-            result.CommentsAdded = commentsAdded;
-            result.CommentsUpdated = commentsUpdated;
-
-            _logger.LogInformation(
-                "Comment sync: {Added} added, {Updated} updated across {Count} active bookings",
-                commentsAdded, commentsUpdated, activeOsmIds.Count);
-
             return Ok(result);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
@@ -305,47 +290,5 @@ public class BookingsController : ControllerBase
         await _context.SaveChangesAsync();
         _logger.LogInformation("OSM sync: {Added} added, {Updated} updated", added, updated);
         return new SyncResult { Added = added, Updated = updated };
-    }
-
-    private async Task<(int added, int updated)> UpsertCommentsAsync(List<string> osmBookingIds)
-    {
-        int added = 0, updated = 0;
-
-        foreach (var osmBookingId in osmBookingIds)
-        {
-            var (_, comments) = await _osmService.GetBookingDetailsAsync(osmBookingId);
-
-            foreach (var comment in comments)
-            {
-                var existing = await _context.OsmComments
-                    .FirstOrDefaultAsync(c => c.OsmCommentId == comment.OsmCommentId);
-
-                if (existing != null)
-                {
-                    existing.AuthorName = comment.AuthorName;
-                    existing.TextPreview = comment.TextPreview;
-                    existing.LastFetched = DateTime.UtcNow;
-                    updated++;
-                }
-                else
-                {
-                    _context.OsmComments.Add(new Data.Entities.OsmComment
-                    {
-                        OsmBookingId = osmBookingId,
-                        OsmCommentId = comment.OsmCommentId,
-                        AuthorName = comment.AuthorName,
-                        TextPreview = comment.TextPreview,
-                        CreatedDate = comment.CreatedDate,
-                        IsNew = true,
-                        LastFetched = DateTime.UtcNow
-                    });
-                    added++;
-                }
-            }
-
-            await _context.SaveChangesAsync();
-        }
-
-        return (added, updated);
     }
 }

--- a/BookingsAssistant.Api/Controllers/BookingsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingsController.cs
@@ -150,6 +150,7 @@ public class BookingsController : ControllerBase
         if (booking == null)
             return NotFound();
 
+        // Refresh from OSM; on failure/empty response, existing DB rows below are left untouched.
         var freshComments = await _osmService.GetBookingCommentsAsync(booking.OsmBookingId);
         if (freshComments.Count > 0)
         {

--- a/BookingsAssistant.Api/Models/BookingDetailDto.cs
+++ b/BookingsAssistant.Api/Models/BookingDetailDto.cs
@@ -8,7 +8,7 @@ public class BookingDetailDto
 public DateTime StartDate { get; set; }
     public DateTime EndDate { get; set; }
     public string Status { get; set; } = string.Empty;
-    public string FullDetails { get; set; } = string.Empty; // JSON from OSM
+    public string FullDetails { get; set; } = string.Empty; // Always "{}" — booking item/detail JSON is no longer fetched here; see GetBookingItemsAsync for ad-hoc item detail.
     public List<CommentDto> Comments { get; set; } = new();
     public List<EmailDto> LinkedEmails { get; set; } = new();
 }

--- a/BookingsAssistant.Api/Models/SyncResult.cs
+++ b/BookingsAssistant.Api/Models/SyncResult.cs
@@ -5,6 +5,4 @@ public class SyncResult
     public int Added { get; set; }
     public int Updated { get; set; }
     public int Total => Added + Updated;
-    public int CommentsAdded { get; set; }
-    public int CommentsUpdated { get; set; }
 }

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -22,6 +22,10 @@ builder.Services.AddDataProtection()
 // Add OSM OAuth service with HttpClient
 builder.Services.AddHttpClient<IOsmAuthService, OsmAuthService>();
 
+// Add OSM rate-limit cooldown (singleton — shared across every OsmService instance,
+// since AddHttpClient below creates a new OsmService per resolution/request)
+builder.Services.AddSingleton<OsmRateLimitCooldown>();
+
 // Add OSM service with HttpClient
 builder.Services.AddHttpClient<IOsmService, OsmService>();
 

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -6,9 +6,14 @@ public interface IOsmService
 {
     // Bookings
     Task<List<BookingDto>> GetBookingsAsync(string status);
-    Task<(string FullDetails, List<CommentDto> Comments)> GetBookingDetailsAsync(string osmBookingId);
 
     // Comments
+    /// <summary>
+    /// Fetches the current comments for a booking directly from OSM.
+    /// Returns an empty list if the fetch fails (no way to distinguish
+    /// "no comments" from "fetch failed" from the return value alone).
+    /// </summary>
+    Task<List<CommentDto>> GetBookingCommentsAsync(string osmBookingId);
     Task<CommentDto?> PostCommentAsync(string osmBookingId, string comment);
 
     // Email

--- a/BookingsAssistant.Api/Services/OsmRateLimitCooldown.cs
+++ b/BookingsAssistant.Api/Services/OsmRateLimitCooldown.cs
@@ -1,0 +1,39 @@
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Cross-request OSM rate-limit cooldown state, registered as a singleton so
+/// it is shared across every <see cref="OsmService"/> instance. OsmService is
+/// registered via <c>AddHttpClient</c>, which — per ASP.NET Core's typed-client
+/// pattern — creates a new OsmService per resolution, i.e. effectively per HTTP
+/// request. Without this shared singleton, a proactive pause learned from one
+/// request (e.g. a low X-RateLimit-Remaining on one call) would be forgotten as
+/// soon as that request finished, leaving no cross-request throttling between
+/// the two current callers of rate-limited OSM calls:
+/// <see cref="BookingsController"/>'s per-booking-open live comment fetch and
+/// <see cref="BookingDetailBackfillService"/>'s periodic batches.
+/// Thread-safe via a simple lock; this is a low-frequency check, not a hot path.
+/// </summary>
+public class OsmRateLimitCooldown
+{
+    private readonly object _gate = new();
+    private DateTimeOffset _cooldownUntil = DateTimeOffset.MinValue;
+
+    /// <summary>How long the caller should wait before its next OSM request, or null if none.</summary>
+    public TimeSpan? TimeUntilReady()
+    {
+        lock (_gate)
+        {
+            var wait = _cooldownUntil - DateTimeOffset.UtcNow;
+            return wait > TimeSpan.Zero ? wait : null;
+        }
+    }
+
+    /// <summary>Pauses every caller (across all OsmService instances) until the given time.</summary>
+    public void PauseUntil(DateTimeOffset until)
+    {
+        lock (_gate)
+        {
+            _cooldownUntil = until;
+        }
+    }
+}

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -11,21 +11,19 @@ internal class OsmService : IOsmService
     private readonly IConfiguration _configuration;
     private readonly ILogger<OsmService> _logger;
     private readonly IOsmAuthService _osmAuthService;
+    private readonly OsmRateLimitCooldown _rateLimitCooldown;
     private readonly string _baseUrl;
     private readonly string _campsiteId;
     private readonly string _sectionId;
 
-    // When OSM signals we're nearly out of quota we pause new requests until
-    // this time. Shared across the request loop within a single OsmService
-    // instance (e.g. one sync's comment loop or one backfill batch).
-    private DateTimeOffset _cooldownUntil = DateTimeOffset.MinValue;
-
-    public OsmService(HttpClient httpClient, IConfiguration configuration, ILogger<OsmService> logger, IOsmAuthService osmAuthService)
+    public OsmService(HttpClient httpClient, IConfiguration configuration, ILogger<OsmService> logger,
+        IOsmAuthService osmAuthService, OsmRateLimitCooldown rateLimitCooldown)
     {
         _httpClient = httpClient;
         _configuration = configuration;
         _logger = logger;
         _osmAuthService = osmAuthService;
+        _rateLimitCooldown = rateLimitCooldown;
 
         _baseUrl = _configuration["Osm:BaseUrl"] ?? "https://www.onlinescoutmanager.co.uk";
         _campsiteId = _configuration["Osm:CampsiteId"] ?? throw new InvalidOperationException("OSM CampsiteId not configured");
@@ -974,11 +972,11 @@ internal class OsmService : IOsmService
         const int maxAttempts = 4;
         for (var attempt = 1; ; attempt++)
         {
-            var wait = _cooldownUntil - DateTimeOffset.UtcNow;
-            if (wait > TimeSpan.Zero)
+            var wait = _rateLimitCooldown.TimeUntilReady();
+            if (wait is not null)
             {
-                _logger.LogWarning("OSM rate limit: pausing {Seconds:F0}s before next request", wait.TotalSeconds);
-                await Task.Delay(wait, ct);
+                _logger.LogWarning("OSM rate limit: pausing {Seconds:F0}s before next request", wait.Value.TotalSeconds);
+                await Task.Delay(wait.Value, ct);
             }
 
             var request = await requestFactory();
@@ -1012,7 +1010,7 @@ internal class OsmService : IOsmService
         var pause = OsmRateLimit.GetProactiveDelay(remaining, reset, DateTimeOffset.UtcNow);
         if (pause is not null)
         {
-            _cooldownUntil = DateTimeOffset.UtcNow + pause.Value;
+            _rateLimitCooldown.PauseUntil(DateTimeOffset.UtcNow + pause.Value);
             _logger.LogWarning("OSM API rate limit low ({Remaining} left); pausing {Seconds:F0}s until reset",
                 remaining, pause.Value.TotalSeconds);
         }

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -100,51 +100,22 @@ internal class OsmService : IOsmService
         }
     }
 
-    public async Task<(string FullDetails, List<CommentDto> Comments)> GetBookingDetailsAsync(string osmBookingId)
+    public async Task<List<CommentDto>> GetBookingCommentsAsync(string osmBookingId)
     {
         try
         {
-            _logger.LogInformation("Fetching OSM booking details for booking: {BookingId}", osmBookingId);
+            _logger.LogInformation("Fetching OSM comments for booking: {BookingId}", osmBookingId);
 
-            // Fetch booking details and comments in parallel
-            var detailsUrl = $"/v3/campsites/{_campsiteId}/items?booking_id={osmBookingId}&mode=booking&audience=venue";
             var commentsUrl = $"/v3/comments/campsite_booking/{osmBookingId}/list?section_id={_sectionId}";
 
-            // Get access token and make authenticated requests (rate-limit aware)
-            var token = await GetAccessTokenAsync();
-
-            HttpRequestMessage BuildGet(string url)
+            var commentsResponse = await SendWithRateLimitAsync(async () =>
             {
-                var req = new HttpRequestMessage(HttpMethod.Get, url);
+                var token = await GetAccessTokenAsync();
+                var req = new HttpRequestMessage(HttpMethod.Get, commentsUrl);
                 req.Headers.Authorization = new System.Net.Http.Headers.AuthenticationHeaderValue("Bearer", token);
                 return req;
-            }
+            });
 
-            var detailsTask = SendWithRateLimitAsync(() => Task.FromResult(BuildGet(detailsUrl)));
-            var commentsTask = SendWithRateLimitAsync(() => Task.FromResult(BuildGet(commentsUrl)));
-
-            await Task.WhenAll(detailsTask, commentsTask);
-
-            var detailsResponse = await detailsTask;
-            var commentsResponse = await commentsTask;
-
-            // Process details
-            string fullDetails = string.Empty;
-            if (detailsResponse.IsSuccessStatusCode)
-            {
-                fullDetails = await detailsResponse.Content.ReadAsStringAsync();
-            }
-            else
-            {
-                _logger.LogError("OSM API returned error status for details: {StatusCode}", detailsResponse.StatusCode);
-
-                if (detailsResponse.StatusCode == System.Net.HttpStatusCode.Unauthorized)
-                {
-                    _logger.LogError("OSM API authentication failed for details. Token may be invalid or expired.");
-                }
-            }
-
-            // Process comments
             var comments = new List<CommentDto>();
             if (commentsResponse.IsSuccessStatusCode)
             {
@@ -166,15 +137,20 @@ internal class OsmService : IOsmService
             else
             {
                 _logger.LogError("OSM API returned error status for comments: {StatusCode}", commentsResponse.StatusCode);
+
+                if (commentsResponse.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                {
+                    _logger.LogError("OSM API authentication failed for comments. Token may be invalid or expired.");
+                }
             }
 
-            _logger.LogInformation("Successfully fetched booking details and {Count} comments from OSM", comments.Count);
-            return (fullDetails, comments);
+            _logger.LogInformation("Successfully fetched {Count} comments from OSM", comments.Count);
+            return comments;
         }
         catch (Exception ex)
         {
-            _logger.LogError(ex, "Error fetching booking details from OSM API");
-            return (string.Empty, new List<CommentDto>());
+            _logger.LogError(ex, "Error fetching comments from OSM API");
+            return new List<CommentDto>();
         }
     }
 

--- a/BookingsAssistant.Tests/Controllers/BookingDetailTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingDetailTests.cs
@@ -16,10 +16,12 @@ namespace BookingsAssistant.Tests.Controllers;
 public class BookingDetailTests : IClassFixture<WebApplicationFactory<Program>>
 {
     private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
 
     public BookingDetailTests(WebApplicationFactory<Program> factory)
     {
         var dbName = "TestDb_BookingDetail_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
         _factory = factory.WithWebHostBuilder(builder =>
         {
             builder.ConfigureAppConfiguration((_, cfg) =>
@@ -37,7 +39,7 @@ public class BookingDetailTests : IClassFixture<WebApplicationFactory<Program>>
                     options.UseInMemoryDatabase(dbName));
 
                 services.RemoveAll<IOsmService>();
-                services.AddSingleton<IOsmService>(new FakeOsmService());
+                services.AddSingleton<IOsmService>(_fakeOsm);
             });
         });
     }
@@ -167,5 +169,178 @@ public class BookingDetailTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal("Lonely Scout Group", detail.CustomerName);
         Assert.Empty(detail.LinkedEmails);
         Assert.Empty(detail.Comments);
+    }
+
+    [Fact]
+    public async Task GetById_AddsCommentThatOnlyExistsInOsm()
+    {
+        int bookingId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var booking = new OsmBooking
+            {
+                OsmBookingId = "55003",
+                CustomerName = "Live Fetch Group",
+                StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc),
+                Status = "Provisional",
+                LastFetched = DateTime.UtcNow
+            };
+            db.OsmBookings.Add(booking);
+            await db.SaveChangesAsync();
+
+            bookingId = booking.Id;
+        }
+
+        _fakeOsm.CommentsByBookingId["55003"] = new List<CommentDto>
+        {
+            new CommentDto
+            {
+                OsmBookingId = "55003",
+                OsmCommentId = "cmt-live-1",
+                AuthorName = "Warden",
+                TextPreview = "Arriving late on Friday",
+                CreatedDate = new DateTime(2026, 5, 20, 9, 0, 0, DateTimeKind.Utc),
+                IsNew = false
+            }
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/bookings/{bookingId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var detail = await response.Content.ReadFromJsonAsync<BookingDetailDto>();
+        Assert.NotNull(detail);
+
+        Assert.Single(detail.Comments);
+        Assert.Equal("cmt-live-1", detail.Comments[0].OsmCommentId);
+        Assert.Equal("Warden", detail.Comments[0].AuthorName);
+        Assert.Equal("Arriving late on Friday", detail.Comments[0].TextPreview);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var stored = await db.OsmComments.SingleAsync(c => c.OsmCommentId == "cmt-live-1");
+            Assert.Equal("55003", stored.OsmBookingId);
+        }
+    }
+
+    [Fact]
+    public async Task GetById_UpdatesExistingCommentText_WhenOsmHasNewerText()
+    {
+        int bookingId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var booking = new OsmBooking
+            {
+                OsmBookingId = "55004",
+                CustomerName = "Update Group",
+                StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc),
+                Status = "Provisional",
+                LastFetched = DateTime.UtcNow
+            };
+            db.OsmBookings.Add(booking);
+
+            db.OsmComments.Add(new OsmComment
+            {
+                OsmBookingId = "55004",
+                OsmCommentId = "cmt-002",
+                AuthorName = "Site Manager",
+                TextPreview = "Old text",
+                CreatedDate = new DateTime(2026, 5, 10, 9, 0, 0, DateTimeKind.Utc),
+                IsNew = false
+            });
+
+            await db.SaveChangesAsync();
+            bookingId = booking.Id;
+        }
+
+        _fakeOsm.CommentsByBookingId["55004"] = new List<CommentDto>
+        {
+            new CommentDto
+            {
+                OsmBookingId = "55004",
+                OsmCommentId = "cmt-002",
+                AuthorName = "Site Manager",
+                TextPreview = "Updated text from OSM",
+                CreatedDate = new DateTime(2026, 5, 10, 9, 0, 0, DateTimeKind.Utc),
+                IsNew = false
+            }
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/bookings/{bookingId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var detail = await response.Content.ReadFromJsonAsync<BookingDetailDto>();
+        Assert.NotNull(detail);
+
+        Assert.Single(detail.Comments);
+        Assert.Equal("cmt-002", detail.Comments[0].OsmCommentId);
+        Assert.Equal("Updated text from OSM", detail.Comments[0].TextPreview);
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var count = await db.OsmComments.CountAsync(c => c.OsmBookingId == "55004");
+            Assert.Equal(1, count);
+        }
+    }
+
+    [Fact]
+    public async Task GetById_KeepsExistingComments_WhenOsmFetchReturnsNone()
+    {
+        int bookingId;
+
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+            var booking = new OsmBooking
+            {
+                OsmBookingId = "55005",
+                CustomerName = "Failed Fetch Group",
+                StartDate = new DateTime(2026, 6, 1, 0, 0, 0, DateTimeKind.Utc),
+                EndDate = new DateTime(2026, 6, 3, 0, 0, 0, DateTimeKind.Utc),
+                Status = "Provisional",
+                LastFetched = DateTime.UtcNow
+            };
+            db.OsmBookings.Add(booking);
+
+            db.OsmComments.Add(new OsmComment
+            {
+                OsmBookingId = "55005",
+                OsmCommentId = "cmt-003",
+                AuthorName = "Site Manager",
+                TextPreview = "Existing comment untouched",
+                CreatedDate = new DateTime(2026, 5, 10, 9, 0, 0, DateTimeKind.Utc),
+                IsNew = false
+            });
+
+            await db.SaveChangesAsync();
+            bookingId = booking.Id;
+        }
+
+        // No entry configured in _fakeOsm.CommentsByBookingId for "55005",
+        // so GetBookingCommentsAsync returns an empty list, simulating a
+        // failed or empty fetch from OSM.
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/bookings/{bookingId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var detail = await response.Content.ReadFromJsonAsync<BookingDetailDto>();
+        Assert.NotNull(detail);
+
+        Assert.Single(detail.Comments);
+        Assert.Equal("cmt-003", detail.Comments[0].OsmCommentId);
+        Assert.Equal("Existing comment untouched", detail.Comments[0].TextPreview);
     }
 }

--- a/BookingsAssistant.Tests/Controllers/CommentSyncTests.cs
+++ b/BookingsAssistant.Tests/Controllers/CommentSyncTests.cs
@@ -43,9 +43,10 @@ public class CommentSyncTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
-    public async Task Sync_PersistsCommentsForActiveBookings()
+    public async Task Sync_DoesNotFetchOrPersistComments()
     {
-        // Fake OSM returns one provisional and one confirmed booking, each with a comment
+        // Fake OSM has comments configured for active bookings, but bulk sync should
+        // never fetch or persist them — comment sync moved to the booking-detail endpoint.
         _fakeOsm.BookingsToReturn = new List<BookingDto>
         {
             new() { OsmBookingId = "77001", CustomerName = "Scout Troop A",
@@ -62,151 +63,13 @@ public class CommentSyncTests : IClassFixture<WebApplicationFactory<Program>>
                     TextPreview = "Deposit received", CreatedDate = DateTime.UtcNow.AddDays(-2) }
         };
 
-        _fakeOsm.CommentsByBookingId["77002"] = new List<CommentDto>
-        {
-            new() { OsmCommentId = "cmt-2", AuthorName = "Admin",
-                    TextPreview = "Confirmed pitch A3", CreatedDate = DateTime.UtcNow.AddDays(-1) }
-        };
-
         var client = _factory.CreateClient();
         var response = await client.PostAsync("/api/bookings/sync", null);
 
         Assert.Equal(HttpStatusCode.OK, response.StatusCode);
         var result = await response.Content.ReadFromJsonAsync<SyncResult>();
         Assert.NotNull(result);
-        Assert.Equal(2, result.CommentsAdded);
-        Assert.Equal(0, result.CommentsUpdated);
-
-        using var scope = _factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-        var comment1 = await db.OsmComments.FirstOrDefaultAsync(c => c.OsmCommentId == "cmt-1");
-        Assert.NotNull(comment1);
-        Assert.Equal("77001", comment1.OsmBookingId);
-        Assert.Equal("Site Manager", comment1.AuthorName);
-        Assert.Equal("Deposit received", comment1.TextPreview);
-        Assert.True(comment1.IsNew);
-
-        var comment2 = await db.OsmComments.FirstOrDefaultAsync(c => c.OsmCommentId == "cmt-2");
-        Assert.NotNull(comment2);
-        Assert.Equal("77002", comment2.OsmBookingId);
-        Assert.Equal("Admin", comment2.AuthorName);
-        Assert.Equal("Confirmed pitch A3", comment2.TextPreview);
-    }
-
-    [Fact]
-    public async Task Sync_UpsertsDuplicateComments()
-    {
-        // First sync: inserts a comment
-        _fakeOsm.BookingsToReturn = new List<BookingDto>
-        {
-            new() { OsmBookingId = "77010", CustomerName = "Cubs Pack",
-                    StartDate = DateTime.UtcNow.AddDays(5), EndDate = DateTime.UtcNow.AddDays(7),
-                    Status = "Provisional" }
-        };
-
-        _fakeOsm.CommentsByBookingId["77010"] = new List<CommentDto>
-        {
-            new() { OsmCommentId = "cmt-10", AuthorName = "Site Manager",
-                    TextPreview = "Original text", CreatedDate = DateTime.UtcNow.AddDays(-3) }
-        };
-
-        var client = _factory.CreateClient();
-        var firstResponse = await client.PostAsync("/api/bookings/sync", null);
-        Assert.Equal(HttpStatusCode.OK, firstResponse.StatusCode);
-        var firstResult = await firstResponse.Content.ReadFromJsonAsync<SyncResult>();
-        Assert.NotNull(firstResult);
-        Assert.Equal(1, firstResult.CommentsAdded);
-        Assert.Equal(0, firstResult.CommentsUpdated);
-
-        // Second sync: same OsmCommentId but updated author/text — should upsert, not duplicate
-        _fakeOsm.CommentsByBookingId["77010"] = new List<CommentDto>
-        {
-            new() { OsmCommentId = "cmt-10", AuthorName = "Site Manager (updated)",
-                    TextPreview = "Updated text", CreatedDate = DateTime.UtcNow.AddDays(-3) }
-        };
-
-        var secondResponse = await client.PostAsync("/api/bookings/sync", null);
-        Assert.Equal(HttpStatusCode.OK, secondResponse.StatusCode);
-        var secondResult = await secondResponse.Content.ReadFromJsonAsync<SyncResult>();
-        Assert.NotNull(secondResult);
-        Assert.Equal(0, secondResult.CommentsAdded);
-        Assert.Equal(1, secondResult.CommentsUpdated);
-
-        using var scope = _factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-
-        // Only one row in DB — no duplicates
-        var allComments = await db.OsmComments.Where(c => c.OsmCommentId == "cmt-10").ToListAsync();
-        Assert.Single(allComments);
-        Assert.Equal("Site Manager (updated)", allComments[0].AuthorName);
-        Assert.Equal("Updated text", allComments[0].TextPreview);
-    }
-
-    [Fact]
-    public async Task Sync_HandlesBookingsWithNoComments()
-    {
-        // A booking with no comments should not cause errors
-        _fakeOsm.BookingsToReturn = new List<BookingDto>
-        {
-            new() { OsmBookingId = "77020", CustomerName = "Silent Group",
-                    StartDate = DateTime.UtcNow.AddDays(5), EndDate = DateTime.UtcNow.AddDays(7),
-                    Status = "Provisional" }
-        };
-
-        // No entry in CommentsByBookingId — fake returns empty list
-
-        var client = _factory.CreateClient();
-        var response = await client.PostAsync("/api/bookings/sync", null);
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await response.Content.ReadFromJsonAsync<SyncResult>();
-        Assert.NotNull(result);
-        Assert.Equal(1, result.Added);
-        Assert.Equal(0, result.CommentsAdded);
-        Assert.Equal(0, result.CommentsUpdated);
-
-        using var scope = _factory.Services.CreateScope();
-        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
-        var commentCount = await db.OsmComments.CountAsync(c => c.OsmBookingId == "77020");
-        Assert.Equal(0, commentCount);
-    }
-
-    [Fact]
-    public async Task Sync_DoesNotFetchComments_ForPastOrCancelledBookings()
-    {
-        // Past and cancelled bookings should not have their comments fetched
-        _fakeOsm.BookingsToReturn = new List<BookingDto>
-        {
-            new() { OsmBookingId = "77030", CustomerName = "Old Group",
-                    StartDate = DateTime.UtcNow.AddDays(-30), EndDate = DateTime.UtcNow.AddDays(-28),
-                    Status = "Past" },
-            new() { OsmBookingId = "77031", CustomerName = "Cancelled Group",
-                    StartDate = DateTime.UtcNow.AddDays(5), EndDate = DateTime.UtcNow.AddDays(7),
-                    Status = "Cancelled" }
-        };
-
-        // These comments exist in the fake but should never be fetched
-        _fakeOsm.CommentsByBookingId["77030"] = new List<CommentDto>
-        {
-            new() { OsmCommentId = "cmt-30", AuthorName = "Someone",
-                    TextPreview = "Should not be synced", CreatedDate = DateTime.UtcNow.AddDays(-30) }
-        };
-
-        _fakeOsm.CommentsByBookingId["77031"] = new List<CommentDto>
-        {
-            new() { OsmCommentId = "cmt-31", AuthorName = "Someone",
-                    TextPreview = "Should not be synced", CreatedDate = DateTime.UtcNow.AddDays(-5) }
-        };
-
-        var client = _factory.CreateClient();
-        var response = await client.PostAsync("/api/bookings/sync", null);
-
-        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
-        var result = await response.Content.ReadFromJsonAsync<SyncResult>();
-        Assert.NotNull(result);
-        Assert.Equal(0, result.CommentsAdded);
-        Assert.Equal(0, result.CommentsUpdated);
+        Assert.Equal(2, result.Added);
 
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -8,7 +8,6 @@ public class FakeOsmService : IOsmService
     public List<BookingDto> BookingsToReturn { get; set; } = new();
     public List<BookingDto>? ConfirmedBookingsToReturn { get; set; }
     public Dictionary<string, List<CommentDto>> CommentsByBookingId { get; } = new();
-    public Dictionary<string, string> DetailsJsonByBookingId { get; } = new();
     public CommentDto? CommentToReturn { get; set; }
     public bool ShouldFailSend { get; set; }
 
@@ -23,15 +22,12 @@ public class FakeOsmService : IOsmService
         return Task.FromResult(BookingsToReturn);
     }
 
-    public Task<(string FullDetails, List<CommentDto> Comments)> GetBookingDetailsAsync(string osmBookingId)
+    public Task<List<CommentDto>> GetBookingCommentsAsync(string osmBookingId)
     {
         var comments = CommentsByBookingId.TryGetValue(osmBookingId, out var list)
             ? list
             : new List<CommentDto>();
-        var details = DetailsJsonByBookingId.TryGetValue(osmBookingId, out var json)
-            ? json
-            : string.Empty;
-        return Task.FromResult((details, comments));
+        return Task.FromResult(comments);
     }
 
     public Task<CommentDto?> PostCommentAsync(string osmBookingId, string comment)

--- a/BookingsAssistant.Tests/Services/OsmRateLimitCooldownTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmRateLimitCooldownTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using BookingsAssistant.Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Proves the rate-limit cooldown is shared across separate OsmService instances —
+/// simulating how AddHttpClient resolves a new OsmService per HTTP request, so a
+/// per-instance field would give zero cross-request throttling (see OsmRateLimitCooldown).
+/// </summary>
+public class OsmRateLimitCooldownTests
+{
+    private static IConfiguration BuildConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Osm:CampsiteId"] = "1",
+                ["Osm:SectionId"] = "2"
+            })
+            .Build();
+
+    private class FakeOsmAuthService : IOsmAuthService
+    {
+        public Task<string> GetValidAccessTokenAsync(int userId) => Task.FromResult("fake-token");
+        public string GetAuthorizationUrl(string redirectUri) => string.Empty;
+        public Task<bool> HandleCallbackAsync(string code, int userId, string redirectUri) => Task.FromResult(true);
+    }
+
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public StubHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(_response);
+    }
+
+    private static OsmService CreateService(HttpResponseMessage response, OsmRateLimitCooldown cooldown)
+    {
+        var httpClient = new HttpClient(new StubHandler(response));
+        return new OsmService(httpClient, BuildConfig(), NullLogger<OsmService>.Instance,
+            new FakeOsmAuthService(), cooldown);
+    }
+
+    private static HttpResponseMessage BookingsResponse(string? remaining = null, string? reset = null)
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"status":true,"data":[]}""")
+        };
+        if (remaining != null) response.Headers.Add("X-RateLimit-Remaining", remaining);
+        if (reset != null) response.Headers.Add("X-RateLimit-Reset", reset);
+        return response;
+    }
+
+    [Fact]
+    public async Task PauseTriggeredByOneInstance_IsVisibleOnTheSharedSingleton()
+    {
+        // Two separate OsmService instances, as AddHttpClient would resolve for two
+        // different HTTP requests, sharing one injected cooldown singleton.
+        var cooldown = new OsmRateLimitCooldown();
+        var serviceA = CreateService(BookingsResponse(remaining: "3", reset: "30"), cooldown);
+
+        Assert.Null(cooldown.TimeUntilReady());
+        await serviceA.GetBookingsAsync("confirmed");
+
+        // The pause instance A observed must land on the shared singleton (not a field
+        // local to serviceA), so a second, freshly-constructed instance sees it too.
+        var wait = cooldown.TimeUntilReady();
+        Assert.NotNull(wait);
+        Assert.InRange(wait.Value.TotalSeconds, 1, 30);
+    }
+
+    [Fact]
+    public async Task SecondFreshInstance_WaitsForCooldownSetByFirstInstance()
+    {
+        var cooldown = new OsmRateLimitCooldown();
+
+        // Instance A (request #1): OSM reports quota nearly exhausted. Reset window is
+        // 1s — the smallest whole-second pause GetProactiveDelay can report — so this
+        // test's real wait stays well under a second rather than a multi-second sleep.
+        var serviceA = CreateService(BookingsResponse(remaining: "3", reset: "1"), cooldown);
+        await serviceA.GetBookingsAsync("confirmed");
+
+        // Instance B (request #2): brand new OsmService, own HttpClient/handler, no
+        // local cooldown state of its own — only the shared singleton says to wait.
+        var serviceB = CreateService(BookingsResponse(), cooldown);
+        var stopwatch = System.Diagnostics.Stopwatch.StartNew();
+        await serviceB.GetBookingsAsync("confirmed");
+        stopwatch.Stop();
+
+        // If the cooldown were still a per-instance field (the bug this fix addresses),
+        // instance B would have its own fresh MinValue cooldown and return near-instantly.
+        Assert.True(stopwatch.Elapsed.TotalMilliseconds >= 700,
+            $"expected instance B to honour instance A's cooldown; elapsed={stopwatch.Elapsed}");
+    }
+
+    [Fact]
+    public void SeparateCooldownInstances_DoNotShareState()
+    {
+        // Sanity check on OsmRateLimitCooldown itself: only a shared *instance* (as DI's
+        // singleton registration guarantees) propagates the pause — two independent
+        // instances behave like the old per-OsmService field.
+        var cooldownA = new OsmRateLimitCooldown();
+        var cooldownB = new OsmRateLimitCooldown();
+
+        cooldownA.PauseUntil(DateTimeOffset.UtcNow.AddSeconds(30));
+
+        Assert.NotNull(cooldownA.TimeUntilReady());
+        Assert.Null(cooldownB.TimeUntilReady());
+    }
+}

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.9.29
+version: 0.9.30
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper


### PR DESCRIPTION
## Summary

`POST /api/bookings/sync` was making 2 extra OSM API calls per active (Provisional/Confirmed) booking purely to fetch and persist comments, on top of the 5 parallel list calls the bulk sync already fires. With enough active bookings this reliably tripped OSM's 429 rate limit, causing syncs to fail (as happened after the sync hadn't run since 30/6 and was run manually against a large backlog). This change removes comment fetching from bulk sync entirely and moves it to the point where a comment is actually needed — opening an individual booking.

## Approach

Bulk sync is now stripped back to the minimum: the 5 parallel status-list calls plus the booking upsert, and nothing per-booking. Comment freshness moves to `GET /api/bookings/{id}`, which fetches that one booking's comments live from OSM on every open and upserts them into `OsmComments` by `OsmCommentId` before serving the response. This trades a large, bursty, up-front cost (proportional to the number of active bookings) for a small, steady, on-demand cost (one OSM call per booking view) — which is what drove the decision, since the up-front burst was the direct cause of the 429s. As part of the same move, the old `GetBookingDetailsAsync` — which fetched an unused `/items` detail payload alongside comments in two parallel OSM calls — was replaced with a comments-only `GetBookingCommentsAsync` that makes a single call.

A final-review security pass also found that the OSM rate-limit cooldown state lived on a per-request `OsmService` instance (registered via `AddHttpClient`), so it never persisted across requests — meaning rapid/repeated booking opens would have gotten zero cross-request throttling, defeating the point of this change. That's fixed by moving the cooldown into a shared singleton (`OsmRateLimitCooldown`).

## Key decisions

- **The "new comments" dashboard feed (`GET /api/comments`) is now populated lazily, and this is an accepted tradeoff.** It reads from the `OsmComments` table, which bulk sync used to keep proactively populated for every active booking. Now comments are only fetched/refreshed when a booking is individually opened, so the feed will only surface new comments for bookings someone has actually viewed. This is a deliberate concession to eliminate the 429s, not an oversight — the alternative (keep proactively fetching all active bookings' comments) is exactly what caused the problem.
- **Fail-open on the live fetch.** `GetById` only touches the DB when `GetBookingCommentsAsync` returns a non-empty list. Since the service returns an empty list both for "no comments" and "fetch failed", a failed OSM call leaves existing DB comments untouched rather than wiping them — the booking view degrades to last-known state instead of appearing to lose comments.
- **Dropped the unused `/items` detail payload** that the old dual-call method fetched but never used.
- **Removed `CommentsAdded`/`CommentsUpdated` from `SyncResult`** since sync no longer owns comment persistence.
- **Extracted OSM rate-limit cooldown into a singleton** (`OsmRateLimitCooldown`) shared across all `OsmService` instances, so the proactive backoff actually works across separate requests — closes a gap that could have reintroduced 429s at the single-booking level now that comments are fetched live on every open.

## Testing strategy

202/202 tests pass. Highlights:
- `CommentSyncTests` reduced to `Sync_DoesNotFetchOrPersistComments`, guarding against comment-fetching creeping back into bulk sync.
- `BookingDetailTests` gained 3 tests for the live-refresh path: comment added from OSM, existing comment updated in place, existing comments preserved when OSM fetch returns nothing (locks in the fail-open behavior).
- `OsmRateLimitCooldownTests` (new) proves the cooldown is honored across separate `OsmService` instances, not just within one.

## Review guidance

- Focus on `BookingsController.GetById` — the live-fetch/upsert/fail-open logic is the behavioral heart of this change.
- Sanity-check the dashboard-feed tradeoff against how it's actually used day to day — that's the one product-visible behavior change.
- `OsmRateLimitCooldown` and its wiring into `OsmService`/`Program.cs` is straightforward but worth a look since it's the fix for a real (if narrow) regression risk this review caught.
