### PR TITLE
Add LLM-assisted Triage: draft OSM action plans from customer emails for human approval

### DIFF
--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -10,20 +10,19 @@ namespace BookingsAssistant.Api.Controllers;
 public class BookingActionsController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
-    // Used to resolve booking items by id before delegating the mutation to the engine.
     private readonly IOsmService _osmService;
-    private readonly IBookingMutationService _mutationService;
+    private readonly IBookingItemActionService _itemActionService;
     private readonly ILogger<BookingActionsController> _logger;
 
     public BookingActionsController(
         ApplicationDbContext context,
         IOsmService osmService,
-        IBookingMutationService mutationService,
+        IBookingItemActionService itemActionService,
         ILogger<BookingActionsController> logger)
     {
         _context = context;
         _osmService = osmService;
-        _mutationService = mutationService;
+        _itemActionService = itemActionService;
         _logger = logger;
     }
 
@@ -103,23 +102,12 @@ public class BookingActionsController : ControllerBase
 
         try
         {
-            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
-            var item = items.FirstOrDefault(i => i.ItemId == request.ItemId);
-            if (item == null)
-                return NotFound(new { message = $"Item '{request.ItemId}' not found in booking {id}" });
-
-            var replacement = new ItemReplacement
-            {
-                Original = item,
-                NewStartDate = request.NewStartDate,
-                NewStartTime = request.NewStartTime,
-                NewEndTime = request.NewEndTime
-            };
-
-            var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, new[] { replacement });
-            var summary = BookingActionCommentComposer.ComposeMoveActivitySummary(item, request);
-            await PostAuditCommentAsync(booking, result, summary);
+            var result = await _itemActionService.MoveActivityAsync(booking.OsmBookingId, request);
             return Ok(result);
+        }
+        catch (BookingItemNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
         {
@@ -150,21 +138,12 @@ public class BookingActionsController : ControllerBase
 
         try
         {
-            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
-            var item = items.FirstOrDefault(i => i.ItemId == request.ItemId);
-            if (item == null)
-                return NotFound(new { message = $"Item '{request.ItemId}' not found in booking {id}" });
-
-            var replacement = new ItemReplacement
-            {
-                Original = item,
-                NewSiteId = request.NewSiteId
-            };
-
-            var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, new[] { replacement });
-            var summary = BookingActionCommentComposer.ComposeChangeSiteSummary(item, request);
-            await PostAuditCommentAsync(booking, result, summary);
+            var result = await _itemActionService.ChangeSiteAsync(booking.OsmBookingId, request);
             return Ok(result);
+        }
+        catch (BookingItemNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
         {
@@ -194,23 +173,7 @@ public class BookingActionsController : ControllerBase
 
         try
         {
-            var items = await _osmService.GetBookingItemsAsync(booking.OsmBookingId);
-
-            var replacements = items.Select(item => new ItemReplacement
-            {
-                Original = item,
-                NewStartDate = item.StartDate.HasValue
-                    ? item.StartDate.Value.AddDays(request.DayShift)
-                    : null,
-                NewEndDate = item.EndDate.HasValue
-                    ? item.EndDate.Value.AddDays(request.DayShift)
-                    : null
-                // StartTime and EndTime are preserved (not overridden)
-            }).ToList();
-
-            var result = await _mutationService.ReplaceItemsAsync(booking.OsmBookingId, replacements);
-            var summary = BookingActionCommentComposer.ComposeMoveDatesSummary(request);
-            await PostAuditCommentAsync(booking, result, summary);
+            var result = await _itemActionService.MoveDatesAsync(booking.OsmBookingId, request);
             return Ok(result);
         }
         catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
@@ -222,49 +185,5 @@ public class BookingActionsController : ControllerBase
             _logger.LogError(ex, "Error during move-dates for booking {Id}", id);
             return StatusCode(502, new { message = "Error executing move-dates", detail = ex.Message });
         }
-    }
-
-    // ── Audit-trail comment posting ───────────────────────────────────────────
-    // Runs after a mutation completes. Posts the given summary as an OSM comment and
-    // persists it locally (same shape as BookingsController.PostComment) so it shows up
-    // immediately. Only Completed/CompletedWithWarnings results get a comment — a rolled
-    // back or failed move has nothing to summarize. A failed comment post never fails the
-    // request; it downgrades the result to CompletedWithWarnings instead.
-    private async Task PostAuditCommentAsync(Data.Entities.OsmBooking booking, BookingActionResult result, string summary)
-    {
-        if (result.Status != BookingActionStatus.Completed && result.Status != BookingActionStatus.CompletedWithWarnings)
-            return;
-
-        CommentDto? posted;
-        try
-        {
-            posted = await _osmService.PostCommentAsync(booking.OsmBookingId, summary);
-        }
-        catch (Exception ex)
-        {
-            _logger.LogWarning(ex,
-                "PostAuditCommentAsync: failed to post audit comment for booking {BookingId}",
-                booking.OsmBookingId);
-            posted = null;
-        }
-
-        if (posted == null)
-        {
-            result.Status = BookingActionStatus.CompletedWithWarnings;
-            result.Message += "; audit comment failed to post";
-            return;
-        }
-
-        _context.OsmComments.Add(new Data.Entities.OsmComment
-        {
-            OsmBookingId = booking.OsmBookingId,
-            OsmCommentId = posted.OsmCommentId,
-            AuthorName = posted.AuthorName,
-            TextPreview = posted.TextPreview,
-            CreatedDate = posted.CreatedDate,
-            IsNew = false,
-            LastFetched = DateTime.UtcNow
-        });
-        await _context.SaveChangesAsync();
     }
 }

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -72,19 +72,33 @@ public class PlansController : ControllerBase
     }
 
     /// <summary>
-    /// Drafts a new action plan from a customer email via the LLM. A ProposedPlan row is
-    /// persisted immediately (before drafting runs) so there's always a record, even if
-    /// drafting fails. On success the row is updated with the validated actions JSON,
-    /// staying AwaitingApproval; on failure — both LLM attempts invalid, or DraftPlanAsync
-    /// itself throwing (e.g. a network failure or non-2xx from Open WebUI) — it becomes
-    /// Failed and SourceEmailText is purged, since Failed plans have no Approve/Reject path
-    /// to purge it later (see PII inventory in CLAUDE.md).
+    /// Drafts a new action plan from a customer email via the LLM. If an OsmBookingId is
+    /// given, it must resolve to a known, non-past booking (404/400 otherwise) — the LLM has
+    /// no way to know a booking has already ended, so this is checked up front rather than
+    /// left for a human to catch during approval. A ProposedPlan row is persisted immediately
+    /// (before drafting runs) so there's always a record, even if drafting fails. On success
+    /// the row is updated with the validated actions JSON, staying AwaitingApproval; on
+    /// failure — both LLM attempts invalid, or DraftPlanAsync itself throwing (e.g. a network
+    /// failure or non-2xx from Open WebUI) — it becomes Failed and SourceEmailText is purged,
+    /// since Failed plans have no Approve/Reject path to purge it later (see PII inventory in
+    /// CLAUDE.md).
     /// </summary>
     [HttpPost]
     public async Task<ActionResult<ProposedPlanDto>> Create([FromBody] CreatePlanRequest request)
     {
         if (string.IsNullOrWhiteSpace(request.SourceEmailText))
             return BadRequest(new { message = "sourceEmailText is required" });
+
+        if (!string.IsNullOrWhiteSpace(request.OsmBookingId))
+        {
+            var booking = await _context.OsmBookings
+                .FirstOrDefaultAsync(b => b.OsmBookingId == request.OsmBookingId);
+            if (booking == null)
+                return NotFound(new { message = $"Booking '{request.OsmBookingId}' not found" });
+
+            if (booking.EndDate.Date < DateTime.UtcNow.Date)
+                return BadRequest(new { message = $"Booking '{request.OsmBookingId}' has already ended ({booking.EndDate:yyyy-MM-dd}); cannot draft a plan against a past booking" });
+        }
 
         var plan = new ProposedPlan
         {

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -44,4 +44,22 @@ public class PlansController : ControllerBase
 
         return Ok(plans);
     }
+
+    [HttpGet("{id}")]
+    public async Task<ActionResult<ProposedPlanDto>> GetById(int id)
+    {
+        var plan = await _context.ProposedPlans.FindAsync(id);
+        if (plan == null)
+            return NotFound();
+
+        return Ok(new ProposedPlanDto
+        {
+            Id = plan.Id,
+            Status = plan.Status.ToString(),
+            SourceEmailText = plan.SourceEmailText,
+            OsmBookingId = plan.OsmBookingId,
+            ActionsJson = plan.ActionsJson,
+            CreatedAt = plan.CreatedAt
+        });
+    }
 }

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -1,0 +1,36 @@
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Models;
+using Microsoft.AspNetCore.Mvc;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookingsAssistant.Api.Controllers;
+
+[ApiController]
+[Route("api/[controller]")]
+public class PlansController : ControllerBase
+{
+    private readonly ApplicationDbContext _context;
+
+    public PlansController(ApplicationDbContext context)
+    {
+        _context = context;
+    }
+
+    [HttpGet]
+    public async Task<ActionResult<List<ProposedPlanDto>>> GetAll()
+    {
+        var plans = await _context.ProposedPlans
+            .Select(p => new ProposedPlanDto
+            {
+                Id = p.Id,
+                Status = p.Status.ToString(),
+                SourceEmailText = p.SourceEmailText,
+                OsmBookingId = p.OsmBookingId,
+                ActionsJson = p.ActionsJson,
+                CreatedAt = p.CreatedAt
+            })
+            .ToListAsync();
+
+        return Ok(plans);
+    }
+}

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -15,15 +15,18 @@ public class PlansController : ControllerBase
     private readonly ApplicationDbContext _context;
     private readonly IPlanDraftingService _planDraftingService;
     private readonly IPlanExecutionService _planExecutionService;
+    private readonly PlanTransitionLock _transitionLock;
 
     public PlansController(
         ApplicationDbContext context,
         IPlanDraftingService planDraftingService,
-        IPlanExecutionService planExecutionService)
+        IPlanExecutionService planExecutionService,
+        PlanTransitionLock transitionLock)
     {
         _context = context;
         _planDraftingService = planDraftingService;
         _planExecutionService = planExecutionService;
+        _transitionLock = transitionLock;
     }
 
     [HttpGet]
@@ -114,16 +117,13 @@ public class PlansController : ControllerBase
     [HttpPost("{id}/approve")]
     public async Task<ActionResult<ProposedPlanDto>> Approve(int id)
     {
-        var plan = await _context.ProposedPlans.FindAsync(id);
-        if (plan == null)
-            return NotFound();
+        var (plan, error) = await TryClaimAwaitingApprovalAsync(id, "approved");
+        if (error != null)
+            return error;
 
-        if (plan.Status != PlanStatus.AwaitingApproval)
-            return Conflict(new { message = $"Plan {id} cannot be approved (status: {plan.Status})" });
+        var outcome = await _planExecutionService.ExecuteAsync(plan!);
 
-        var outcome = await _planExecutionService.ExecuteAsync(plan);
-
-        plan.Status = outcome.Success ? PlanStatus.Executed : PlanStatus.Failed;
+        plan!.Status = outcome.Success ? PlanStatus.Executed : PlanStatus.Failed;
         plan.ExecutionResultJson = JsonSerializer.Serialize(outcome.Results);
         plan.SourceEmailText = null;
         await _context.SaveChangesAsync();
@@ -138,18 +138,47 @@ public class PlansController : ControllerBase
     [HttpPost("{id}/reject")]
     public async Task<ActionResult<ProposedPlanDto>> Reject(int id)
     {
-        var plan = await _context.ProposedPlans.FindAsync(id);
-        if (plan == null)
-            return NotFound();
+        var (plan, error) = await TryClaimAwaitingApprovalAsync(id, "rejected");
+        if (error != null)
+            return error;
 
-        if (plan.Status != PlanStatus.AwaitingApproval)
-            return Conflict(new { message = $"Plan {id} cannot be rejected (status: {plan.Status})" });
-
-        plan.Status = PlanStatus.Rejected;
+        plan!.Status = PlanStatus.Rejected;
         plan.SourceEmailText = null;
         await _context.SaveChangesAsync();
 
         return Ok(ToDto(plan));
+    }
+
+    /// <summary>
+    /// Atomically claims a plan for a status transition (Approve/Reject), preventing the
+    /// TOCTOU race where two near-simultaneous requests both read Status == AwaitingApproval,
+    /// both pass the check, and both proceed to execute/reject the same plan.
+    ///
+    /// Under <see cref="PlanTransitionLock"/>, reads the plan, checks it's still
+    /// AwaitingApproval, and — if so — flips it to Processing (a transient "claimed" marker,
+    /// see <see cref="PlanStatus"/>) and saves, all before releasing the lock. A concurrent
+    /// caller blocked on the lock will, once it acquires it, see Status == Processing (or
+    /// whatever terminal status the winner already reached) and is turned away with 409,
+    /// never proceeding to execute/reject. The lock is released before the caller goes on to
+    /// do the (potentially slow) OSM execution, so unrelated plans' claim steps aren't blocked.
+    /// See <see cref="PlanTransitionLock"/> for why a lock rather than a DB-level atomic
+    /// conditional update (e.g. ExecuteUpdateAsync) is used here.
+    /// </summary>
+    private async Task<(ProposedPlan? Plan, ActionResult? Error)> TryClaimAwaitingApprovalAsync(int id, string actionDescription)
+    {
+        using var _ = await _transitionLock.AcquireAsync();
+
+        var plan = await _context.ProposedPlans.FindAsync(id);
+        if (plan == null)
+            return (null, NotFound());
+
+        if (plan.Status != PlanStatus.AwaitingApproval)
+            return (null, Conflict(new { message = $"Plan {id} cannot be {actionDescription} (status: {plan.Status})" }));
+
+        plan.Status = PlanStatus.Processing;
+        await _context.SaveChangesAsync();
+
+        return (plan, null);
     }
 
     private static ProposedPlanDto ToDto(ProposedPlan plan) => new()

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -16,17 +16,20 @@ public class PlansController : ControllerBase
     private readonly IPlanDraftingService _planDraftingService;
     private readonly IPlanExecutionService _planExecutionService;
     private readonly PlanTransitionLock _transitionLock;
+    private readonly ILogger<PlansController> _logger;
 
     public PlansController(
         ApplicationDbContext context,
         IPlanDraftingService planDraftingService,
         IPlanExecutionService planExecutionService,
-        PlanTransitionLock transitionLock)
+        PlanTransitionLock transitionLock,
+        ILogger<PlansController> logger)
     {
         _context = context;
         _planDraftingService = planDraftingService;
         _planExecutionService = planExecutionService;
         _transitionLock = transitionLock;
+        _logger = logger;
     }
 
     [HttpGet]
@@ -72,7 +75,10 @@ public class PlansController : ControllerBase
     /// Drafts a new action plan from a customer email via the LLM. A ProposedPlan row is
     /// persisted immediately (before drafting runs) so there's always a record, even if
     /// drafting fails. On success the row is updated with the validated actions JSON,
-    /// staying AwaitingApproval; on failure (both LLM attempts invalid) it becomes Failed.
+    /// staying AwaitingApproval; on failure — both LLM attempts invalid, or DraftPlanAsync
+    /// itself throwing (e.g. a network failure or non-2xx from Open WebUI) — it becomes
+    /// Failed and SourceEmailText is purged, since Failed plans have no Approve/Reject path
+    /// to purge it later (see PII inventory in CLAUDE.md).
     /// </summary>
     [HttpPost]
     public async Task<ActionResult<ProposedPlanDto>> Create([FromBody] CreatePlanRequest request)
@@ -90,17 +96,28 @@ public class PlansController : ControllerBase
         _context.ProposedPlans.Add(plan);
         await _context.SaveChangesAsync();
 
-        var draftResult = await _planDraftingService.DraftPlanAsync(request.SourceEmailText, request.OsmBookingId);
-        if (draftResult.Success)
+        PlanDraftResult? draftResult = null;
+        try
+        {
+            draftResult = await _planDraftingService.DraftPlanAsync(request.SourceEmailText, request.OsmBookingId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "Plan drafting: DraftPlanAsync threw for plan {PlanId}; marking Failed", plan.Id);
+        }
+
+        if (draftResult is { Success: true })
         {
             plan.ActionsJson = draftResult.ActionsJson;
         }
         else
         {
             plan.Status = PlanStatus.Failed;
-            // Drafting failed permanently (both LLM attempts invalid), and Failed plans have
-            // no Approve/Reject path to purge this later — purge now so raw customer email
-            // text never lingers past a failed drafting attempt (see PII inventory in CLAUDE.md).
+            // Drafting failed permanently (both LLM attempts invalid, or DraftPlanAsync
+            // threw), and Failed plans have no Approve/Reject path to purge this later —
+            // purge now so raw customer email text never lingers past a failed drafting
+            // attempt (see PII inventory in CLAUDE.md).
             plan.SourceEmailText = null;
         }
         await _context.SaveChangesAsync();

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -1,6 +1,7 @@
 using BookingsAssistant.Api.Data;
 using BookingsAssistant.Api.Data.Entities;
 using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
 
@@ -11,10 +12,12 @@ namespace BookingsAssistant.Api.Controllers;
 public class PlansController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
+    private readonly IPlanDraftingService _planDraftingService;
 
-    public PlansController(ApplicationDbContext context)
+    public PlansController(ApplicationDbContext context, IPlanDraftingService planDraftingService)
     {
         _context = context;
+        _planDraftingService = planDraftingService;
     }
 
     [HttpGet]
@@ -52,14 +55,52 @@ public class PlansController : ControllerBase
         if (plan == null)
             return NotFound();
 
-        return Ok(new ProposedPlanDto
-        {
-            Id = plan.Id,
-            Status = plan.Status.ToString(),
-            SourceEmailText = plan.SourceEmailText,
-            OsmBookingId = plan.OsmBookingId,
-            ActionsJson = plan.ActionsJson,
-            CreatedAt = plan.CreatedAt
-        });
+        return Ok(ToDto(plan));
     }
+
+    /// <summary>
+    /// Drafts a new action plan from a customer email via the LLM. A ProposedPlan row is
+    /// persisted immediately (before drafting runs) so there's always a record, even if
+    /// drafting fails. On success the row is updated with the validated actions JSON,
+    /// staying AwaitingApproval; on failure (both LLM attempts invalid) it becomes Failed.
+    /// </summary>
+    [HttpPost]
+    public async Task<ActionResult<ProposedPlanDto>> Create([FromBody] CreatePlanRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.SourceEmailText))
+            return BadRequest(new { message = "sourceEmailText is required" });
+
+        var plan = new ProposedPlan
+        {
+            Status = PlanStatus.AwaitingApproval,
+            SourceEmailText = request.SourceEmailText,
+            OsmBookingId = request.OsmBookingId,
+            CreatedAt = DateTime.UtcNow
+        };
+        _context.ProposedPlans.Add(plan);
+        await _context.SaveChangesAsync();
+
+        var draftResult = await _planDraftingService.DraftPlanAsync(request.SourceEmailText, request.OsmBookingId);
+        if (draftResult.Success)
+        {
+            plan.ActionsJson = draftResult.ActionsJson;
+        }
+        else
+        {
+            plan.Status = PlanStatus.Failed;
+        }
+        await _context.SaveChangesAsync();
+
+        return CreatedAtAction(nameof(GetById), new { id = plan.Id }, ToDto(plan));
+    }
+
+    private static ProposedPlanDto ToDto(ProposedPlan plan) => new()
+    {
+        Id = plan.Id,
+        Status = plan.Status.ToString(),
+        SourceEmailText = plan.SourceEmailText,
+        OsmBookingId = plan.OsmBookingId,
+        ActionsJson = plan.ActionsJson,
+        CreatedAt = plan.CreatedAt
+    };
 }

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -95,6 +95,10 @@ public class PlansController : ControllerBase
         else
         {
             plan.Status = PlanStatus.Failed;
+            // Drafting failed permanently (both LLM attempts invalid), and Failed plans have
+            // no Approve/Reject path to purge this later — purge now so raw customer email
+            // text never lingers past a failed drafting attempt (see PII inventory in CLAUDE.md).
+            plan.SourceEmailText = null;
         }
         await _context.SaveChangesAsync();
 

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -1,4 +1,5 @@
 using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
 using BookingsAssistant.Api.Models;
 using Microsoft.AspNetCore.Mvc;
 using Microsoft.EntityFrameworkCore;
@@ -17,9 +18,19 @@ public class PlansController : ControllerBase
     }
 
     [HttpGet]
-    public async Task<ActionResult<List<ProposedPlanDto>>> GetAll()
+    public async Task<ActionResult<List<ProposedPlanDto>>> GetAll([FromQuery] string? status = null)
     {
-        var plans = await _context.ProposedPlans
+        var query = _context.ProposedPlans.AsQueryable();
+
+        if (!string.IsNullOrEmpty(status))
+        {
+            if (!Enum.TryParse<PlanStatus>(status, ignoreCase: true, out var parsedStatus))
+                return BadRequest(new { message = $"Invalid status '{status}'. Valid values: {string.Join(", ", Enum.GetNames<PlanStatus>())}" });
+
+            query = query.Where(p => p.Status == parsedStatus);
+        }
+
+        var plans = await query
             .Select(p => new ProposedPlanDto
             {
                 Id = p.Id,

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -1,3 +1,4 @@
+using System.Text.Json;
 using BookingsAssistant.Api.Data;
 using BookingsAssistant.Api.Data.Entities;
 using BookingsAssistant.Api.Models;
@@ -13,11 +14,16 @@ public class PlansController : ControllerBase
 {
     private readonly ApplicationDbContext _context;
     private readonly IPlanDraftingService _planDraftingService;
+    private readonly IPlanExecutionService _planExecutionService;
 
-    public PlansController(ApplicationDbContext context, IPlanDraftingService planDraftingService)
+    public PlansController(
+        ApplicationDbContext context,
+        IPlanDraftingService planDraftingService,
+        IPlanExecutionService planExecutionService)
     {
         _context = context;
         _planDraftingService = planDraftingService;
+        _planExecutionService = planExecutionService;
     }
 
     [HttpGet]
@@ -41,6 +47,7 @@ public class PlansController : ControllerBase
                 SourceEmailText = p.SourceEmailText,
                 OsmBookingId = p.OsmBookingId,
                 ActionsJson = p.ActionsJson,
+                ExecutionResultJson = p.ExecutionResultJson,
                 CreatedAt = p.CreatedAt
             })
             .ToListAsync();
@@ -94,6 +101,53 @@ public class PlansController : ControllerBase
         return CreatedAtAction(nameof(GetById), new { id = plan.Id }, ToDto(plan));
     }
 
+    /// <summary>
+    /// Approves an AwaitingApproval plan and executes its actions against OSM, in order,
+    /// stopping at the first failure. Sets Status to Executed (all actions succeeded/no-op)
+    /// or Failed (an action failed), records per-action results in ExecutionResultJson, and
+    /// purges SourceEmailText since it's no longer needed and carries PII.
+    /// </summary>
+    [HttpPost("{id}/approve")]
+    public async Task<ActionResult<ProposedPlanDto>> Approve(int id)
+    {
+        var plan = await _context.ProposedPlans.FindAsync(id);
+        if (plan == null)
+            return NotFound();
+
+        if (plan.Status != PlanStatus.AwaitingApproval)
+            return Conflict(new { message = $"Plan {id} cannot be approved (status: {plan.Status})" });
+
+        var outcome = await _planExecutionService.ExecuteAsync(plan);
+
+        plan.Status = outcome.Success ? PlanStatus.Executed : PlanStatus.Failed;
+        plan.ExecutionResultJson = JsonSerializer.Serialize(outcome.Results);
+        plan.SourceEmailText = null;
+        await _context.SaveChangesAsync();
+
+        return Ok(ToDto(plan));
+    }
+
+    /// <summary>
+    /// Rejects an AwaitingApproval plan. No OSM calls are made; the plan is marked Rejected
+    /// and SourceEmailText is purged since it's no longer needed and carries PII.
+    /// </summary>
+    [HttpPost("{id}/reject")]
+    public async Task<ActionResult<ProposedPlanDto>> Reject(int id)
+    {
+        var plan = await _context.ProposedPlans.FindAsync(id);
+        if (plan == null)
+            return NotFound();
+
+        if (plan.Status != PlanStatus.AwaitingApproval)
+            return Conflict(new { message = $"Plan {id} cannot be rejected (status: {plan.Status})" });
+
+        plan.Status = PlanStatus.Rejected;
+        plan.SourceEmailText = null;
+        await _context.SaveChangesAsync();
+
+        return Ok(ToDto(plan));
+    }
+
     private static ProposedPlanDto ToDto(ProposedPlan plan) => new()
     {
         Id = plan.Id,
@@ -101,6 +155,7 @@ public class PlansController : ControllerBase
         SourceEmailText = plan.SourceEmailText,
         OsmBookingId = plan.OsmBookingId,
         ActionsJson = plan.ActionsJson,
+        ExecutionResultJson = plan.ExecutionResultJson,
         CreatedAt = plan.CreatedAt
     };
 }

--- a/BookingsAssistant.Api/Data/ApplicationDbContext.cs
+++ b/BookingsAssistant.Api/Data/ApplicationDbContext.cs
@@ -14,6 +14,7 @@ public class ApplicationDbContext : DbContext
     public DbSet<OsmBooking> OsmBookings { get; set; }
     public DbSet<OsmComment> OsmComments { get; set; }
     public DbSet<SiteDuty> SiteDuties { get; set; }
+    public DbSet<ProposedPlan> ProposedPlans { get; set; }
 
     protected override void OnModelCreating(ModelBuilder modelBuilder)
     {
@@ -35,5 +36,18 @@ public class ApplicationDbContext : DbContext
             .HasForeignKey(c => c.OsmBookingId)
             .HasPrincipalKey(b => b.OsmBookingId)
             .OnDelete(DeleteBehavior.Cascade);
+
+        // Store PlanStatus enum as its string name for readability in the DB
+        modelBuilder.Entity<ProposedPlan>()
+            .Property(p => p.Status)
+            .HasConversion<string>()
+            .HasMaxLength(50);
+
+        modelBuilder.Entity<ProposedPlan>()
+            .HasOne(p => p.Booking)
+            .WithMany()
+            .HasForeignKey(p => p.OsmBookingId)
+            .HasPrincipalKey(b => b.OsmBookingId)
+            .OnDelete(DeleteBehavior.SetNull);
     }
 }

--- a/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
+++ b/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
@@ -6,6 +6,17 @@ namespace BookingsAssistant.Api.Data.Entities;
 public enum PlanStatus
 {
     AwaitingApproval,
+
+    /// <summary>
+    /// Transient state used only as an atomic "claim" marker: Approve/Reject conditionally
+    /// transition AwaitingApproval → Processing in a single ExecuteUpdateAsync round-trip
+    /// before doing any work, so two concurrent requests for the same plan can't both pass
+    /// the status check and double-execute. Always immediately followed by a terminal status
+    /// (Executed/Failed/Rejected) within the same request. Stored as a string column
+    /// (see ApplicationDbContext), so adding this value needs no schema migration.
+    /// </summary>
+    Processing,
+
     Executed,
     Rejected,
     Failed

--- a/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
+++ b/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
@@ -1,0 +1,36 @@
+using System.ComponentModel.DataAnnotations;
+using System.ComponentModel.DataAnnotations.Schema;
+
+namespace BookingsAssistant.Api.Data.Entities;
+
+public enum PlanStatus
+{
+    AwaitingApproval,
+    Executed,
+    Rejected,
+    Failed
+}
+
+[Table("ProposedPlans")]
+public class ProposedPlan
+{
+    [Key]
+    public int Id { get; set; }
+
+    [Required]
+    public PlanStatus Status { get; set; } = PlanStatus.AwaitingApproval;
+
+    public string? SourceEmailText { get; set; }
+
+    [MaxLength(50)]
+    public string? OsmBookingId { get; set; }
+
+    public string? ActionsJson { get; set; }
+
+    [Required]
+    public DateTime CreatedAt { get; set; }
+
+    // Navigation property
+    [ForeignKey(nameof(OsmBookingId))]
+    public OsmBooking? Booking { get; set; }
+}

--- a/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
+++ b/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
@@ -27,6 +27,14 @@ public class ProposedPlan
 
     public string? ActionsJson { get; set; }
 
+    /// <summary>
+    /// Per-action execution outcomes, set once the plan has been approved and executed
+    /// (or the attempt failed partway through). JSON array of objects shaped like
+    /// { type, status, reason? } — one entry per action in ActionsJson, in the same order.
+    /// Null until the plan has been approved.
+    /// </summary>
+    public string? ExecutionResultJson { get; set; }
+
     [Required]
     public DateTime CreatedAt { get; set; }
 

--- a/BookingsAssistant.Api/Data/StalePlanRecovery.cs
+++ b/BookingsAssistant.Api/Data/StalePlanRecovery.cs
@@ -1,0 +1,50 @@
+using BookingsAssistant.Api.Data.Entities;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Logging;
+
+namespace BookingsAssistant.Api.Data;
+
+/// <summary>
+/// One-time startup sweep (see Program.cs) that recovers <see cref="ProposedPlan"/> rows left
+/// stuck in <see cref="PlanStatus.Processing"/> by a crash or unhandled error between
+/// PlansController's atomic "claim" step (AwaitingApproval -> Processing, see
+/// <see cref="Services.PlanTransitionLock"/>) and the terminal status write that normally
+/// follows immediately after (Executed/Failed/Rejected).
+///
+/// Processing is documented as a transient, in-request-only marker: no request can still
+/// legitimately be "in progress" across a process restart, since the in-process
+/// PlanTransitionLock semaphore and any in-flight request are gone along with the old process.
+/// So on startup, any plan still in Processing is stale by definition and is reset to Failed —
+/// a safe terminal state with no re-execution path, visible in the Triage UI for a human to
+/// investigate, consistent with how every other Failed plan behaves.
+///
+/// SourceEmailText is purged at the same time, consistent with the rule that Failed plans carry
+/// no PII (see PII inventory in CLAUDE.md) — the same purge Approve/Reject/Create already do
+/// whenever a plan reaches a terminal state.
+/// </summary>
+public static class StalePlanRecovery
+{
+    public static async Task<int> RecoverStaleProcessingPlansAsync(ApplicationDbContext context, ILogger logger)
+    {
+        var stalePlans = await context.ProposedPlans
+            .Where(p => p.Status == PlanStatus.Processing)
+            .ToListAsync();
+
+        if (stalePlans.Count == 0)
+            return 0;
+
+        foreach (var plan in stalePlans)
+        {
+            plan.Status = PlanStatus.Failed;
+            plan.SourceEmailText = null;
+        }
+
+        await context.SaveChangesAsync();
+
+        logger.LogWarning(
+            "Startup stale-plan recovery: reset {Count} plan(s) stuck in Processing to Failed",
+            stalePlans.Count);
+
+        return stalePlans.Count;
+    }
+}

--- a/BookingsAssistant.Api/Migrations/20260720084935_AddProposedPlan.Designer.cs
+++ b/BookingsAssistant.Api/Migrations/20260720084935_AddProposedPlan.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BookingsAssistant.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookingsAssistant.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720084935_AddProposedPlan")]
+    partial class AddProposedPlan
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/BookingsAssistant.Api/Migrations/20260720084935_AddProposedPlan.cs
+++ b/BookingsAssistant.Api/Migrations/20260720084935_AddProposedPlan.cs
@@ -1,0 +1,50 @@
+﻿using System;
+using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookingsAssistant.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProposedPlan : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.CreateTable(
+                name: "ProposedPlans",
+                columns: table => new
+                {
+                    Id = table.Column<int>(type: "INTEGER", nullable: false)
+                        .Annotation("Sqlite:Autoincrement", true),
+                    Status = table.Column<string>(type: "TEXT", maxLength: 50, nullable: false),
+                    SourceEmailText = table.Column<string>(type: "TEXT", nullable: true),
+                    OsmBookingId = table.Column<string>(type: "TEXT", maxLength: 50, nullable: true),
+                    ActionsJson = table.Column<string>(type: "TEXT", nullable: true),
+                    CreatedAt = table.Column<DateTime>(type: "TEXT", nullable: false)
+                },
+                constraints: table =>
+                {
+                    table.PrimaryKey("PK_ProposedPlans", x => x.Id);
+                    table.ForeignKey(
+                        name: "FK_ProposedPlans_OsmBookings_OsmBookingId",
+                        column: x => x.OsmBookingId,
+                        principalTable: "OsmBookings",
+                        principalColumn: "OsmBookingId",
+                        onDelete: ReferentialAction.SetNull);
+                });
+
+            migrationBuilder.CreateIndex(
+                name: "IX_ProposedPlans_OsmBookingId",
+                table: "ProposedPlans",
+                column: "OsmBookingId");
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropTable(
+                name: "ProposedPlans");
+        }
+    }
+}

--- a/BookingsAssistant.Api/Migrations/20260720091242_AddProposedPlanExecutionResultJson.Designer.cs
+++ b/BookingsAssistant.Api/Migrations/20260720091242_AddProposedPlanExecutionResultJson.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BookingsAssistant.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookingsAssistant.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260720091242_AddProposedPlanExecutionResultJson")]
+    partial class AddProposedPlanExecutionResultJson
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/BookingsAssistant.Api/Migrations/20260720091242_AddProposedPlanExecutionResultJson.cs
+++ b/BookingsAssistant.Api/Migrations/20260720091242_AddProposedPlanExecutionResultJson.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookingsAssistant.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProposedPlanExecutionResultJson : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "ExecutionResultJson",
+                table: "ProposedPlans",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "ExecutionResultJson",
+                table: "ProposedPlans");
+        }
+    }
+}

--- a/BookingsAssistant.Api/Models/CreatePlanRequest.cs
+++ b/BookingsAssistant.Api/Models/CreatePlanRequest.cs
@@ -1,0 +1,7 @@
+namespace BookingsAssistant.Api.Models;
+
+public class CreatePlanRequest
+{
+    public string SourceEmailText { get; set; } = string.Empty;
+    public string? OsmBookingId { get; set; }
+}

--- a/BookingsAssistant.Api/Models/PlanActionExecutionResult.cs
+++ b/BookingsAssistant.Api/Models/PlanActionExecutionResult.cs
@@ -1,0 +1,28 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// String constants for PlanActionExecutionResult.Status.
+/// </summary>
+public static class PlanActionExecutionStatus
+{
+    public const string Succeeded = "succeeded";
+    public const string Failed = "failed";
+    public const string NotAttempted = "not_attempted";
+}
+
+/// <summary>
+/// The outcome of executing a single action from a ProposedPlan's ActionsJson. One of these
+/// is recorded per action, in order, whether or not the action was actually attempted
+/// (actions after the first failure are recorded as "not_attempted").
+/// </summary>
+public class PlanActionExecutionResult
+{
+    /// <summary>The action's "type" field (e.g. "postComment", "moveDates").</summary>
+    public string Type { get; set; } = string.Empty;
+
+    /// <summary>One of: "succeeded", "failed", "not_attempted". See <see cref="PlanActionExecutionStatus"/>.</summary>
+    public string Status { get; set; } = string.Empty;
+
+    /// <summary>Present when Status is "failed" — a human-readable explanation.</summary>
+    public string? Reason { get; set; }
+}

--- a/BookingsAssistant.Api/Models/ProposedPlanDto.cs
+++ b/BookingsAssistant.Api/Models/ProposedPlanDto.cs
@@ -7,5 +7,6 @@ public class ProposedPlanDto
     public string? SourceEmailText { get; set; }
     public string? OsmBookingId { get; set; }
     public string? ActionsJson { get; set; }
+    public string? ExecutionResultJson { get; set; }
     public DateTime CreatedAt { get; set; }
 }

--- a/BookingsAssistant.Api/Models/ProposedPlanDto.cs
+++ b/BookingsAssistant.Api/Models/ProposedPlanDto.cs
@@ -1,0 +1,11 @@
+namespace BookingsAssistant.Api.Models;
+
+public class ProposedPlanDto
+{
+    public int Id { get; set; }
+    public string Status { get; set; } = string.Empty;
+    public string? SourceEmailText { get; set; }
+    public string? OsmBookingId { get; set; }
+    public string? ActionsJson { get; set; }
+    public DateTime CreatedAt { get; set; }
+}

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -32,6 +32,11 @@ builder.Services.AddHttpClient<IOsmService, OsmService>();
 // Add booking mutation service (scoped — depends on IOsmService which is per-request via HttpClient)
 builder.Services.AddScoped<IBookingMutationService, BookingMutationService>();
 
+// Add booking item action service (scoped — depends on ApplicationDbContext and IOsmService).
+// Shared dispatch for move-activity/change-site/move-dates, used by both BookingActionsController
+// and the plan-execution path.
+builder.Services.AddScoped<IBookingItemActionService, BookingItemActionService>();
+
 // Add Open WebUI client (LLM plan drafting) with HttpClient
 builder.Services.AddHttpClient<IOpenWebUiClient, OpenWebUiClient>();
 

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -83,6 +83,14 @@ using (var scope = app.Services.CreateScope())
         await context.Database.MigrateAsync();
     await DbSeeder.SeedAsync(context);
 
+    // Recover any ProposedPlan rows left stuck in Processing by a crash or unhandled error
+    // between the atomic claim step and the terminal status write that normally follows it
+    // immediately (see PlansController.TryClaimAwaitingApprovalAsync and PlanStatus.Processing's
+    // doc comment). No request can still legitimately be "in progress" across a process
+    // restart, so any such row is stale by definition.
+    var startupLogger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
+    await StalePlanRecovery.RecoverStaleProcessingPlansAsync(context, startupLogger);
+
     // If OSM tokens are already stored (e.g. after addon update), sync on startup
     try
     {
@@ -91,8 +99,7 @@ using (var scope = app.Services.CreateScope())
         if (!isAuthenticated)
             throw new InvalidOperationException("Not authenticated");
 
-        var logger = scope.ServiceProvider.GetRequiredService<ILogger<Program>>();
-        logger.LogInformation("OSM tokens found — running startup sync...");
+        startupLogger.LogInformation("OSM tokens found — running startup sync...");
         var tasks = await Task.WhenAll(
             osmService.GetBookingsAsync("provisional"),
             osmService.GetBookingsAsync("confirmed"),
@@ -133,7 +140,7 @@ using (var scope = app.Services.CreateScope())
         }
 
         await context.SaveChangesAsync();
-        logger.LogInformation("Startup OSM sync complete: {Count} bookings", allBookings.Count);
+        startupLogger.LogInformation("Startup OSM sync complete: {Count} bookings", allBookings.Count);
     }
     catch (Exception)
     {

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -48,6 +48,11 @@ builder.Services.AddScoped<IPlanDraftingService, PlanDraftingService>();
 // allowed to mutate OSM state on the LLM's behalf.
 builder.Services.AddScoped<IPlanExecutionService, PlanExecutionService>();
 
+// Add plan transition lock (singleton — shared across every PlansController instance, same
+// reasoning as OsmRateLimitCooldown above). Serializes Approve/Reject's claim step so two
+// concurrent requests for the same plan can't both execute/reject it.
+builder.Services.AddSingleton<PlanTransitionLock>();
+
 // Add hosted services
 builder.Services.AddHostedService<GateCodeService>();
 

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -43,6 +43,11 @@ builder.Services.AddHttpClient<IOpenWebUiClient, OpenWebUiClient>();
 // Add plan drafting service (scoped — depends on ApplicationDbContext and IOsmService)
 builder.Services.AddScoped<IPlanDraftingService, PlanDraftingService>();
 
+// Add plan execution service (scoped — depends on IOsmService and IBookingItemActionService).
+// Only invoked after a human approves a plan (PlansController.Approve) — the sole place
+// allowed to mutate OSM state on the LLM's behalf.
+builder.Services.AddScoped<IPlanExecutionService, PlanExecutionService>();
+
 // Add hosted services
 builder.Services.AddHostedService<GateCodeService>();
 

--- a/BookingsAssistant.Api/Program.cs
+++ b/BookingsAssistant.Api/Program.cs
@@ -32,6 +32,12 @@ builder.Services.AddHttpClient<IOsmService, OsmService>();
 // Add booking mutation service (scoped — depends on IOsmService which is per-request via HttpClient)
 builder.Services.AddScoped<IBookingMutationService, BookingMutationService>();
 
+// Add Open WebUI client (LLM plan drafting) with HttpClient
+builder.Services.AddHttpClient<IOpenWebUiClient, OpenWebUiClient>();
+
+// Add plan drafting service (scoped — depends on ApplicationDbContext and IOsmService)
+builder.Services.AddScoped<IPlanDraftingService, PlanDraftingService>();
+
 // Add hosted services
 builder.Services.AddHostedService<GateCodeService>();
 

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -94,7 +94,7 @@ public class BookingItemActionService : IBookingItemActionService
         if (result.Status != BookingActionStatus.Completed && result.Status != BookingActionStatus.CompletedWithWarnings)
             return;
 
-        Models.CommentDto? posted;
+        CommentDto? posted;
         try
         {
             posted = await _osmService.PostCommentAsync(osmBookingId, summary);

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -1,0 +1,129 @@
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Models;
+
+namespace BookingsAssistant.Api.Services;
+
+/// <inheritdoc cref="IBookingItemActionService"/>
+public class BookingItemActionService : IBookingItemActionService
+{
+    private readonly ApplicationDbContext _context;
+    private readonly IOsmService _osmService;
+    private readonly IBookingMutationService _mutationService;
+    private readonly ILogger<BookingItemActionService> _logger;
+
+    public BookingItemActionService(
+        ApplicationDbContext context,
+        IOsmService osmService,
+        IBookingMutationService mutationService,
+        ILogger<BookingItemActionService> logger)
+    {
+        _context = context;
+        _osmService = osmService;
+        _mutationService = mutationService;
+        _logger = logger;
+    }
+
+    public async Task<BookingActionResult> MoveActivityAsync(string osmBookingId, MoveActivityRequest request)
+    {
+        var items = await _osmService.GetBookingItemsAsync(osmBookingId);
+        var item = items.FirstOrDefault(i => i.ItemId == request.ItemId)
+            ?? throw new BookingItemNotFoundException(request.ItemId, osmBookingId);
+
+        var replacement = new ItemReplacement
+        {
+            Original = item,
+            NewStartDate = request.NewStartDate,
+            NewStartTime = request.NewStartTime,
+            NewEndTime = request.NewEndTime
+        };
+
+        var result = await _mutationService.ReplaceItemsAsync(osmBookingId, new[] { replacement });
+        var summary = BookingActionCommentComposer.ComposeMoveActivitySummary(item, request);
+        await PostAuditCommentAsync(osmBookingId, result, summary);
+        return result;
+    }
+
+    public async Task<BookingActionResult> ChangeSiteAsync(string osmBookingId, ChangeSiteRequest request)
+    {
+        var items = await _osmService.GetBookingItemsAsync(osmBookingId);
+        var item = items.FirstOrDefault(i => i.ItemId == request.ItemId)
+            ?? throw new BookingItemNotFoundException(request.ItemId, osmBookingId);
+
+        var replacement = new ItemReplacement
+        {
+            Original = item,
+            NewSiteId = request.NewSiteId
+        };
+
+        var result = await _mutationService.ReplaceItemsAsync(osmBookingId, new[] { replacement });
+        var summary = BookingActionCommentComposer.ComposeChangeSiteSummary(item, request);
+        await PostAuditCommentAsync(osmBookingId, result, summary);
+        return result;
+    }
+
+    public async Task<BookingActionResult> MoveDatesAsync(string osmBookingId, MoveDatesRequest request)
+    {
+        var items = await _osmService.GetBookingItemsAsync(osmBookingId);
+
+        var replacements = items.Select(item => new ItemReplacement
+        {
+            Original = item,
+            NewStartDate = item.StartDate.HasValue
+                ? item.StartDate.Value.AddDays(request.DayShift)
+                : null,
+            NewEndDate = item.EndDate.HasValue
+                ? item.EndDate.Value.AddDays(request.DayShift)
+                : null
+            // StartTime and EndTime are preserved (not overridden)
+        }).ToList();
+
+        var result = await _mutationService.ReplaceItemsAsync(osmBookingId, replacements);
+        var summary = BookingActionCommentComposer.ComposeMoveDatesSummary(request);
+        await PostAuditCommentAsync(osmBookingId, result, summary);
+        return result;
+    }
+
+    // ── Audit-trail comment posting ───────────────────────────────────────────
+    // Runs after a mutation completes. Posts the given summary as an OSM comment and
+    // persists it locally (same shape as BookingsController.PostComment) so it shows up
+    // immediately. Only Completed/CompletedWithWarnings results get a comment — a rolled
+    // back or failed move has nothing to summarize. A failed comment post never fails the
+    // request; it downgrades the result to CompletedWithWarnings instead.
+    private async Task PostAuditCommentAsync(string osmBookingId, BookingActionResult result, string summary)
+    {
+        if (result.Status != BookingActionStatus.Completed && result.Status != BookingActionStatus.CompletedWithWarnings)
+            return;
+
+        Models.CommentDto? posted;
+        try
+        {
+            posted = await _osmService.PostCommentAsync(osmBookingId, summary);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "PostAuditCommentAsync: failed to post audit comment for booking {BookingId}",
+                osmBookingId);
+            posted = null;
+        }
+
+        if (posted == null)
+        {
+            result.Status = BookingActionStatus.CompletedWithWarnings;
+            result.Message += "; audit comment failed to post";
+            return;
+        }
+
+        _context.OsmComments.Add(new Data.Entities.OsmComment
+        {
+            OsmBookingId = osmBookingId,
+            OsmCommentId = posted.OsmCommentId,
+            AuthorName = posted.AuthorName,
+            TextPreview = posted.TextPreview,
+            CreatedDate = posted.CreatedDate,
+            IsNew = false,
+            LastFetched = DateTime.UtcNow
+        });
+        await _context.SaveChangesAsync();
+    }
+}

--- a/BookingsAssistant.Api/Services/BookingItemNotFoundException.cs
+++ b/BookingsAssistant.Api/Services/BookingItemNotFoundException.cs
@@ -1,0 +1,15 @@
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Thrown by <see cref="IBookingItemActionService"/> when a requested ItemId isn't present
+/// in the booking's current item list. Callers map this to whatever "not found" response
+/// makes sense for their context (e.g. BookingActionsController maps it to a 404; plan
+/// execution maps it to a failed-with-reason action result).
+/// </summary>
+public class BookingItemNotFoundException : Exception
+{
+    public BookingItemNotFoundException(string itemId, string osmBookingId)
+        : base($"Item '{itemId}' not found in booking {osmBookingId}")
+    {
+    }
+}

--- a/BookingsAssistant.Api/Services/IBookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/IBookingItemActionService.cs
@@ -1,0 +1,27 @@
+using BookingsAssistant.Api.Models;
+
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Reusable dispatch for the three OSM item-mutation actions (move-activity, change-site,
+/// move-dates): resolves the target item(s) from the booking's current item list, delegates
+/// the actual mutation to <see cref="IBookingMutationService"/>, and posts an audit-trail
+/// comment summarising what changed.
+///
+/// Shared by <c>BookingActionsController</c> (human-triggered, via the REST endpoints) and
+/// the plan-execution path (LLM-drafted, human-approved). Both callers own their own
+/// request validation and error-to-HTTP-status mapping — this service only throws
+/// <see cref="BookingItemNotFoundException"/> for an unresolvable ItemId; any other failure
+/// propagates as-is (typically from the underlying OSM calls).
+/// </summary>
+public interface IBookingItemActionService
+{
+    /// <summary>Reschedules a single activity item. Throws <see cref="BookingItemNotFoundException"/> if ItemId isn't in the booking.</summary>
+    Task<BookingActionResult> MoveActivityAsync(string osmBookingId, MoveActivityRequest request);
+
+    /// <summary>Moves a single site item to a different site. Throws <see cref="BookingItemNotFoundException"/> if ItemId isn't in the booking.</summary>
+    Task<BookingActionResult> ChangeSiteAsync(string osmBookingId, ChangeSiteRequest request);
+
+    /// <summary>Shifts every item in the booking by the given number of days.</summary>
+    Task<BookingActionResult> MoveDatesAsync(string osmBookingId, MoveDatesRequest request);
+}

--- a/BookingsAssistant.Api/Services/IOpenWebUiClient.cs
+++ b/BookingsAssistant.Api/Services/IOpenWebUiClient.cs
@@ -1,0 +1,16 @@
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Thin client for Open WebUI's OpenAI-compatible chat completions endpoint.
+/// Mirrors the <see cref="IOsmService"/> pattern: registered via AddHttpClient,
+/// one call in, one string out — no retry/validation logic lives here (that's
+/// <see cref="IPlanDraftingService"/>'s job).
+/// </summary>
+public interface IOpenWebUiClient
+{
+    /// <summary>
+    /// Sends a single system/user message pair to the configured model and returns
+    /// the raw text content of the model's reply (choices[0].message.content).
+    /// </summary>
+    Task<string> GetCompletionAsync(string systemPrompt, string userPrompt);
+}

--- a/BookingsAssistant.Api/Services/IPlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/IPlanDraftingService.cs
@@ -1,0 +1,31 @@
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Drafts a structured action plan from a raw customer email (and, optionally,
+/// booking context) by calling the configured LLM via <see cref="IOpenWebUiClient"/>.
+/// </summary>
+public interface IPlanDraftingService
+{
+    /// <summary>
+    /// Builds a prompt from the email text (and booking context, if <paramref name="osmBookingId"/>
+    /// is given), asks the LLM to draft a plan, and validates the response against the actions
+    /// schema. Retries once on validation failure; never throws — a failure after the retry is
+    /// reported via <see cref="PlanDraftResult.Success"/> being false.
+    /// </summary>
+    Task<PlanDraftResult> DraftPlanAsync(string sourceEmailText, string? osmBookingId);
+}
+
+/// <summary>
+/// Outcome of a plan-drafting attempt. On success, <see cref="ActionsJson"/> holds the validated
+/// `actions` JSON array (ready to store on <c>ProposedPlan.ActionsJson</c>). On failure,
+/// <see cref="FailureReason"/> describes why the LLM's response(s) could not be used.
+/// </summary>
+public class PlanDraftResult
+{
+    public bool Success { get; init; }
+    public string? ActionsJson { get; init; }
+    public string? FailureReason { get; init; }
+
+    public static PlanDraftResult Ok(string actionsJson) => new() { Success = true, ActionsJson = actionsJson };
+    public static PlanDraftResult Fail(string reason) => new() { Success = false, FailureReason = reason };
+}

--- a/BookingsAssistant.Api/Services/IPlanExecutionService.cs
+++ b/BookingsAssistant.Api/Services/IPlanExecutionService.cs
@@ -1,0 +1,31 @@
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Executes the actions of an approved <see cref="ProposedPlan"/> against OSM. This is the
+/// only place in the system allowed to mutate OSM state on the LLM's behalf, and only ever
+/// runs after a human has approved the plan (see PlansController.Approve).
+/// </summary>
+public interface IPlanExecutionService
+{
+    /// <summary>
+    /// Executes each action in <paramref name="plan"/>.ActionsJson, in order, stopping at the
+    /// first failure. Does not mutate <paramref name="plan"/> or touch the database — the
+    /// caller (PlansController) is responsible for applying the resulting status and
+    /// persisting it.
+    /// </summary>
+    Task<PlanExecutionOutcome> ExecuteAsync(ProposedPlan plan);
+}
+
+/// <summary>
+/// Result of executing a plan's actions: whether every action succeeded (or was a no-op),
+/// and the per-action results (one per action, in order — including "not_attempted" entries
+/// for actions after the first failure).
+/// </summary>
+public class PlanExecutionOutcome
+{
+    public bool Success { get; init; }
+    public List<PlanActionExecutionResult> Results { get; init; } = new();
+}

--- a/BookingsAssistant.Api/Services/OpenWebUiClient.cs
+++ b/BookingsAssistant.Api/Services/OpenWebUiClient.cs
@@ -1,0 +1,83 @@
+using System.Net.Http.Headers;
+using System.Net.Http.Json;
+using System.Text.Json;
+using System.Text.Json.Serialization;
+
+namespace BookingsAssistant.Api.Services;
+
+internal class OpenWebUiClient : IOpenWebUiClient
+{
+    private readonly HttpClient _httpClient;
+    private readonly ILogger<OpenWebUiClient> _logger;
+    private readonly string _model;
+
+    public OpenWebUiClient(HttpClient httpClient, IConfiguration configuration, ILogger<OpenWebUiClient> logger)
+    {
+        _httpClient = httpClient;
+        _logger = logger;
+
+        // Follows the Osm:* convention: `??` only catches a missing config key, not an
+        // empty string, so the checked-in appsettings.json placeholder ("") is a valid
+        // "not yet configured" value that doesn't throw at startup. We still guard the
+        // Uri/Authorization-header setup below so an empty BaseUrl/ApiKey never blows up
+        // construction (it just means calls will fail later, once actually attempted).
+        var baseUrl = configuration["OpenWebUi:BaseUrl"] ?? throw new InvalidOperationException("OpenWebUi BaseUrl not configured");
+        var apiKey = configuration["OpenWebUi:ApiKey"] ?? throw new InvalidOperationException("OpenWebUi ApiKey not configured");
+        _model = configuration["OpenWebUi:Model"] ?? throw new InvalidOperationException("OpenWebUi Model not configured");
+
+        if (!string.IsNullOrEmpty(baseUrl))
+            _httpClient.BaseAddress = new Uri(baseUrl);
+
+        if (!string.IsNullOrEmpty(apiKey))
+            _httpClient.DefaultRequestHeaders.Authorization = new AuthenticationHeaderValue("Bearer", apiKey);
+    }
+
+    public async Task<string> GetCompletionAsync(string systemPrompt, string userPrompt)
+    {
+        var requestBody = new
+        {
+            model = _model,
+            messages = new[]
+            {
+                new { role = "system", content = systemPrompt },
+                new { role = "user", content = userPrompt }
+            }
+        };
+
+        _logger.LogInformation("Calling Open WebUI chat completions endpoint (model: {Model})", _model);
+
+        var response = await _httpClient.PostAsJsonAsync("/api/chat/completions", requestBody);
+        response.EnsureSuccessStatusCode();
+
+        var content = await response.Content.ReadAsStringAsync();
+        var parsed = JsonSerializer.Deserialize<ChatCompletionResponse>(content, new JsonSerializerOptions
+        {
+            PropertyNameCaseInsensitive = true
+        });
+
+        var text = parsed?.Choices?.FirstOrDefault()?.Message?.Content;
+        if (string.IsNullOrEmpty(text))
+            throw new InvalidOperationException("Open WebUI response contained no message content");
+
+        return text;
+    }
+
+    // Only the fields we need from the OpenAI-compatible chat completions response shape.
+    private class ChatCompletionResponse
+    {
+        [JsonPropertyName("choices")]
+        public List<ChatCompletionChoice>? Choices { get; set; }
+    }
+
+    private class ChatCompletionChoice
+    {
+        [JsonPropertyName("message")]
+        public ChatCompletionMessage? Message { get; set; }
+    }
+
+    private class ChatCompletionMessage
+    {
+        [JsonPropertyName("content")]
+        public string? Content { get; set; }
+    }
+}

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -1,0 +1,250 @@
+using System.Text;
+using System.Text.Json;
+using BookingsAssistant.Api.Data;
+using Microsoft.EntityFrameworkCore;
+
+namespace BookingsAssistant.Api.Services;
+
+internal class PlanDraftingService : IPlanDraftingService
+{
+    // The six action types the LLM is allowed to propose. Kept in sync with the schema
+    // described in the system prompt below and with chunk 3 (execution), which will map
+    // these onto BookingActionsController's move-activity / change-site / move-dates DTOs.
+    private static readonly HashSet<string> KnownActionTypes = new(StringComparer.OrdinalIgnoreCase)
+    {
+        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity"
+    };
+
+    private const string SystemPrompt =
+        "You are an assistant that drafts action plans for a Scout campsite bookings team. " +
+        "Given a customer's email (and, if available, context about their existing booking), " +
+        "respond with ONLY a JSON object of the shape:\n" +
+        "{ \"actions\": [ { \"type\": \"<one of the types below>\", ...type-specific fields } ] }\n\n" +
+        "Valid action types and their fields (all fields are flat, alongside \"type\" — not nested):\n" +
+        "- draftEmailReply: { \"text\": string } — a suggested reply to send back to the customer\n" +
+        "- postComment: { \"text\": string } — an internal note to post as an OSM comment on the booking\n" +
+        "- sendTemplateEmail: {} — sends the booking's standard template email (no extra fields; the booking is already known)\n" +
+        "- moveDates: { \"dayShift\": number, \"note\"?: string } — shifts every item in the booking by this many days\n" +
+        "- changeSite: { \"itemId\": string, \"newSiteId\": string, \"newSiteName\"?: string, \"note\"?: string } — moves a site item to a different site\n" +
+        "- moveActivity: { \"itemId\": string, \"newStartDate\"?: string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"note\"?: string } — reschedules an activity item\n\n" +
+        "Choose whichever actions (and however many, including zero if none apply) best address the email. " +
+        "You decide the order — e.g. draftEmailReply can come first, last, or be omitted entirely. " +
+        "Return JSON only: no prose, no markdown code fences, no explanation.";
+
+    private readonly IOpenWebUiClient _client;
+    private readonly ApplicationDbContext _context;
+    private readonly IOsmService _osmService;
+    private readonly ILogger<PlanDraftingService> _logger;
+
+    public PlanDraftingService(
+        IOpenWebUiClient client,
+        ApplicationDbContext context,
+        IOsmService osmService,
+        ILogger<PlanDraftingService> logger)
+    {
+        _client = client;
+        _context = context;
+        _osmService = osmService;
+        _logger = logger;
+    }
+
+    public async Task<PlanDraftResult> DraftPlanAsync(string sourceEmailText, string? osmBookingId)
+    {
+        var userPrompt = await BuildUserPromptAsync(sourceEmailText, osmBookingId);
+
+        var firstResponse = await _client.GetCompletionAsync(SystemPrompt, userPrompt);
+        if (TryValidate(firstResponse, out var actionsJson, out var reason))
+            return PlanDraftResult.Ok(actionsJson);
+
+        _logger.LogWarning("Plan drafting: first LLM response was invalid ({Reason}); retrying once", reason);
+
+        var retryPrompt = userPrompt +
+            $"\n\nYour previous response was invalid: {reason}. Return valid JSON only, matching the schema exactly.";
+        var retryResponse = await _client.GetCompletionAsync(SystemPrompt, retryPrompt);
+        if (TryValidate(retryResponse, out actionsJson, out reason))
+            return PlanDraftResult.Ok(actionsJson);
+
+        _logger.LogWarning("Plan drafting: retry LLM response was also invalid ({Reason}); giving up", reason);
+        return PlanDraftResult.Fail(reason ?? "LLM response invalid after retry");
+    }
+
+    private async Task<string> BuildUserPromptAsync(string sourceEmailText, string? osmBookingId)
+    {
+        var sb = new StringBuilder();
+
+        var bookingContext = await BuildBookingContextAsync(osmBookingId);
+        if (bookingContext != null)
+        {
+            sb.AppendLine("Booking context:");
+            sb.AppendLine(bookingContext);
+            sb.AppendLine();
+        }
+
+        sb.AppendLine("Customer email:");
+        sb.AppendLine(sourceEmailText);
+
+        return sb.ToString();
+    }
+
+    /// <summary>
+    /// Pulls the booking's core fields from the DB and its site/activity line-items from OSM
+    /// (best-effort — a failed OSM fetch, e.g. no auth yet, just omits the items section rather
+    /// than failing the whole drafting attempt). Returns null if no booking id was given or the
+    /// booking isn't known locally.
+    /// </summary>
+    private async Task<string?> BuildBookingContextAsync(string? osmBookingId)
+    {
+        if (string.IsNullOrWhiteSpace(osmBookingId))
+            return null;
+
+        var booking = await _context.OsmBookings
+            .FirstOrDefaultAsync(b => b.OsmBookingId == osmBookingId);
+        if (booking == null)
+            return null;
+
+        var sb = new StringBuilder();
+        sb.AppendLine($"- Customer: {booking.CustomerName}");
+        sb.AppendLine($"- Dates: {booking.StartDate:yyyy-MM-dd} to {booking.EndDate:yyyy-MM-dd}");
+        sb.AppendLine($"- Status: {booking.Status}");
+
+        try
+        {
+            var items = await _osmService.GetBookingItemsAsync(osmBookingId);
+            foreach (var item in items)
+            {
+                var when = item.StartDate.HasValue
+                    ? $", {item.StartDate:yyyy-MM-dd}" +
+                      (item.StartTime != null ? $" {item.StartTime}-{item.EndTime}" : string.Empty)
+                    : string.Empty;
+                sb.AppendLine($"- Item [{item.ItemId}] ({item.Type}): {item.Label}{when}");
+            }
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex, "Plan drafting: failed to fetch booking items for {BookingId}; omitting from prompt", osmBookingId);
+        }
+
+        return sb.ToString().TrimEnd();
+    }
+
+    private static bool TryValidate(string llmResponse, out string actionsJson, out string? failureReason)
+    {
+        actionsJson = string.Empty;
+        failureReason = null;
+
+        JsonDocument doc;
+        try
+        {
+            doc = JsonDocument.Parse(ExtractJsonPayload(llmResponse));
+        }
+        catch (JsonException ex)
+        {
+            failureReason = $"response was not valid JSON ({ex.Message})";
+            return false;
+        }
+
+        using (doc)
+        {
+            if (doc.RootElement.ValueKind != JsonValueKind.Object ||
+                !doc.RootElement.TryGetProperty("actions", out var actionsEl) ||
+                actionsEl.ValueKind != JsonValueKind.Array ||
+                actionsEl.GetArrayLength() == 0)
+            {
+                failureReason = "response must be a JSON object with a non-empty \"actions\" array";
+                return false;
+            }
+
+            foreach (var action in actionsEl.EnumerateArray())
+            {
+                if (action.ValueKind != JsonValueKind.Object ||
+                    !action.TryGetProperty("type", out var typeEl) ||
+                    typeEl.ValueKind != JsonValueKind.String)
+                {
+                    failureReason = "each action must be an object with a string \"type\"";
+                    return false;
+                }
+
+                var type = typeEl.GetString()!;
+                if (!KnownActionTypes.Contains(type))
+                {
+                    failureReason = $"unknown action type \"{type}\"";
+                    return false;
+                }
+
+                if (!HasRequiredParams(type, action, out failureReason))
+                    return false;
+            }
+
+            actionsJson = actionsEl.GetRawText();
+            return true;
+        }
+    }
+
+    private static bool HasRequiredParams(string type, JsonElement action, out string? reason)
+    {
+        // Returns null if `prop` is present as a non-empty string on `action`; otherwise
+        // returns the failure message. A local function can't capture the outer `out`
+        // parameter, so this returns the reason instead of assigning it directly.
+        string? MissingNonEmptyString(string prop)
+        {
+            if (!action.TryGetProperty(prop, out var el) ||
+                el.ValueKind != JsonValueKind.String ||
+                string.IsNullOrWhiteSpace(el.GetString()))
+            {
+                return $"action \"{type}\" requires a non-empty string \"{prop}\"";
+            }
+            return null;
+        }
+
+        switch (type.ToLowerInvariant())
+        {
+            case "draftemailreply":
+            case "postcomment":
+                reason = MissingNonEmptyString("text");
+                return reason == null;
+
+            case "sendtemplateemail":
+                // No extra fields — the booking id comes from the plan itself.
+                reason = null;
+                return true;
+
+            case "movedates":
+                if (!action.TryGetProperty("dayShift", out var dayShiftEl) || dayShiftEl.ValueKind != JsonValueKind.Number)
+                {
+                    reason = "action \"moveDates\" requires a numeric \"dayShift\"";
+                    return false;
+                }
+                reason = null;
+                return true;
+
+            case "changesite":
+                reason = MissingNonEmptyString("itemId") ?? MissingNonEmptyString("newSiteId");
+                return reason == null;
+
+            case "moveactivity":
+                reason = MissingNonEmptyString("itemId");
+                return reason == null;
+
+            default:
+                reason = $"unknown action type \"{type}\"";
+                return false;
+        }
+    }
+
+    /// <summary>
+    /// LLMs frequently wrap JSON replies in ```json fences despite being told not to.
+    /// Strips a single leading/trailing fence if present; otherwise returns the input trimmed.
+    /// </summary>
+    private static string ExtractJsonPayload(string raw)
+    {
+        var trimmed = raw.Trim();
+        if (!trimmed.StartsWith("```"))
+            return trimmed;
+
+        var firstNewline = trimmed.IndexOf('\n');
+        var withoutOpeningFence = firstNewline >= 0 ? trimmed[(firstNewline + 1)..] : trimmed;
+        var closingFenceIndex = withoutOpeningFence.LastIndexOf("```", StringComparison.Ordinal);
+        var unfenced = closingFenceIndex >= 0 ? withoutOpeningFence[..closingFenceIndex] : withoutOpeningFence;
+        return unfenced.Trim();
+    }
+}

--- a/BookingsAssistant.Api/Services/PlanExecutionService.cs
+++ b/BookingsAssistant.Api/Services/PlanExecutionService.cs
@@ -1,0 +1,189 @@
+using System.Text.Json;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+
+namespace BookingsAssistant.Api.Services;
+
+/// <inheritdoc cref="IPlanExecutionService"/>
+public class PlanExecutionService : IPlanExecutionService
+{
+    private readonly IOsmService _osmService;
+    private readonly IBookingItemActionService _itemActionService;
+    private readonly ILogger<PlanExecutionService> _logger;
+
+    public PlanExecutionService(
+        IOsmService osmService,
+        IBookingItemActionService itemActionService,
+        ILogger<PlanExecutionService> logger)
+    {
+        _osmService = osmService;
+        _itemActionService = itemActionService;
+        _logger = logger;
+    }
+
+    public async Task<PlanExecutionOutcome> ExecuteAsync(ProposedPlan plan)
+    {
+        var actions = ParseActions(plan.ActionsJson);
+        var results = new List<PlanActionExecutionResult>();
+        var stopped = false;
+
+        foreach (var action in actions)
+        {
+            var type = action.TryGetProperty("type", out var typeEl) && typeEl.ValueKind == JsonValueKind.String
+                ? typeEl.GetString()!
+                : "unknown";
+
+            if (stopped)
+            {
+                results.Add(new PlanActionExecutionResult { Type = type, Status = PlanActionExecutionStatus.NotAttempted });
+                continue;
+            }
+
+            try
+            {
+                await ExecuteActionAsync(type, action, plan.OsmBookingId);
+                results.Add(new PlanActionExecutionResult { Type = type, Status = PlanActionExecutionStatus.Succeeded });
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Plan execution: action '{Type}' failed for plan {PlanId}; stopping remaining actions",
+                    type, plan.Id);
+                results.Add(new PlanActionExecutionResult
+                {
+                    Type = type,
+                    Status = PlanActionExecutionStatus.Failed,
+                    Reason = ex.Message
+                });
+                stopped = true;
+            }
+        }
+
+        return new PlanExecutionOutcome
+        {
+            Success = !stopped,
+            Results = results
+        };
+    }
+
+    private async Task ExecuteActionAsync(string type, JsonElement action, string? osmBookingId)
+    {
+        switch (type.ToLowerInvariant())
+        {
+            case "draftemailreply":
+                // Purely informational — nothing to execute against OSM.
+                return;
+
+            case "postcomment":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var text = RequireString(action, "text", type);
+                var posted = await _osmService.PostCommentAsync(bookingId, text);
+                if (posted == null)
+                    throw new InvalidOperationException($"Failed to post comment to OSM for booking {bookingId}");
+                return;
+            }
+
+            case "sendtemplateemail":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var sent = await _osmService.SendBookingTemplateEmailAsync(bookingId);
+                if (!sent)
+                    throw new InvalidOperationException($"Failed to send template email for booking {bookingId}");
+                return;
+            }
+
+            case "movedates":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                if (!action.TryGetProperty("dayShift", out var dayShiftEl) || dayShiftEl.ValueKind != JsonValueKind.Number)
+                    throw new InvalidOperationException("Action \"moveDates\" requires a numeric \"dayShift\"");
+
+                var request = new MoveDatesRequest
+                {
+                    DayShift = dayShiftEl.GetInt32(),
+                    Note = OptionalString(action, "note")
+                };
+                var result = await _itemActionService.MoveDatesAsync(bookingId, request);
+                ThrowIfNotSuccessful(result);
+                return;
+            }
+
+            case "changesite":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var request = new ChangeSiteRequest
+                {
+                    ItemId = RequireString(action, "itemId", type),
+                    NewSiteId = RequireString(action, "newSiteId", type),
+                    NewSiteName = OptionalString(action, "newSiteName"),
+                    Note = OptionalString(action, "note")
+                };
+                var result = await _itemActionService.ChangeSiteAsync(bookingId, request);
+                ThrowIfNotSuccessful(result);
+                return;
+            }
+
+            case "moveactivity":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var request = new MoveActivityRequest
+                {
+                    ItemId = RequireString(action, "itemId", type),
+                    NewStartDate = OptionalDate(action, "newStartDate"),
+                    NewStartTime = OptionalString(action, "newStartTime"),
+                    NewEndTime = OptionalString(action, "newEndTime"),
+                    Note = OptionalString(action, "note")
+                };
+                var result = await _itemActionService.MoveActivityAsync(bookingId, request);
+                ThrowIfNotSuccessful(result);
+                return;
+            }
+
+            default:
+                throw new InvalidOperationException($"Unknown action type \"{type}\"");
+        }
+    }
+
+    private static void ThrowIfNotSuccessful(BookingActionResult result)
+    {
+        if (result.Status != BookingActionStatus.Completed && result.Status != BookingActionStatus.CompletedWithWarnings)
+            throw new InvalidOperationException(result.Message);
+    }
+
+    private static string RequireBookingId(string? osmBookingId, string type)
+    {
+        if (string.IsNullOrWhiteSpace(osmBookingId))
+            throw new InvalidOperationException($"Action \"{type}\" requires a booking, but the plan has no OsmBookingId");
+        return osmBookingId;
+    }
+
+    private static string RequireString(JsonElement action, string prop, string type)
+    {
+        if (!action.TryGetProperty(prop, out var el) || el.ValueKind != JsonValueKind.String || string.IsNullOrWhiteSpace(el.GetString()))
+            throw new InvalidOperationException($"Action \"{type}\" requires a non-empty string \"{prop}\"");
+        return el.GetString()!;
+    }
+
+    private static string? OptionalString(JsonElement action, string prop)
+        => action.TryGetProperty(prop, out var el) && el.ValueKind == JsonValueKind.String ? el.GetString() : null;
+
+    private static DateTime? OptionalDate(JsonElement action, string prop)
+    {
+        var raw = OptionalString(action, prop);
+        return raw != null && DateTime.TryParse(raw, out var parsed) ? parsed : null;
+    }
+
+    private static List<JsonElement> ParseActions(string? actionsJson)
+    {
+        if (string.IsNullOrWhiteSpace(actionsJson))
+            return new List<JsonElement>();
+
+        using var doc = JsonDocument.Parse(actionsJson);
+        if (doc.RootElement.ValueKind != JsonValueKind.Array)
+            return new List<JsonElement>();
+
+        // Clone each element since `doc` is disposed at the end of this method.
+        return doc.RootElement.EnumerateArray().Select(e => e.Clone()).ToList();
+    }
+}

--- a/BookingsAssistant.Api/Services/PlanTransitionLock.cs
+++ b/BookingsAssistant.Api/Services/PlanTransitionLock.cs
@@ -1,0 +1,53 @@
+namespace BookingsAssistant.Api.Services;
+
+/// <summary>
+/// Serializes the "claim" step of Approve/Reject (read the plan's current status, then flip
+/// AwaitingApproval -> Processing) across all plans, closing the TOCTOU window where two
+/// near-simultaneous requests for the same plan id could both read Status == AwaitingApproval
+/// before either writes back, and both go on to execute/reject the same plan.
+///
+/// Registered as a singleton (see Program.cs) so the same lock instance is shared across the
+/// per-request scoped PlansController/ApplicationDbContext instances — mirrors the existing
+/// <see cref="OsmRateLimitCooldown"/> pattern for state that must be shared across per-request
+/// service resolution.
+///
+/// Deliberately a single process-wide lock, not one keyed per plan id: Approve/Reject are
+/// human-triggered, low-frequency actions, so briefly serializing unrelated plans' claim steps
+/// costs nothing in practice, and a per-id lock dictionary would add complexity (eviction,
+/// growth) for no real benefit at this scale. The lock is only held for the fast claim
+/// read+write, not for the (potentially slow) OSM execution that follows, so it never blocks
+/// concurrent requests for other plans for long.
+///
+/// This only guards a single application instance — the deployed topology (see CLAUDE.md) is
+/// one Home Assistant addon container, so that's sufficient. It would NOT prevent a
+/// double-execution race across multiple horizontally-scaled instances sharing one database;
+/// that would need a database-level atomic conditional update (e.g. EF Core's
+/// ExecuteUpdateAsync), which was ruled out here because the EF Core InMemory provider used by
+/// this project's test suite does not support it (throws at runtime), making it impossible to
+/// exercise via the existing WebApplicationFactory-based integration tests.
+/// </summary>
+public class PlanTransitionLock
+{
+    private readonly SemaphoreSlim _semaphore = new(1, 1);
+
+    public async Task<IDisposable> AcquireAsync()
+    {
+        await _semaphore.WaitAsync();
+        return new Releaser(_semaphore);
+    }
+
+    private sealed class Releaser : IDisposable
+    {
+        private readonly SemaphoreSlim _semaphore;
+        private bool _released;
+
+        public Releaser(SemaphoreSlim semaphore) => _semaphore = semaphore;
+
+        public void Dispose()
+        {
+            if (_released) return;
+            _released = true;
+            _semaphore.Release();
+        }
+    }
+}

--- a/BookingsAssistant.Api/appsettings.json
+++ b/BookingsAssistant.Api/appsettings.json
@@ -41,5 +41,10 @@
     "ClientId": "",
     "ClientSecret": "",
     "Scopes": "section:campsite_bookings:read section:campsite_bookings:write"
+  },
+  "OpenWebUi": {
+    "BaseUrl": "",
+    "ApiKey": "",
+    "Model": ""
   }
 }

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -1,0 +1,322 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public PlanApprovalTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_PlanApproval_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    // ── Helpers ──────────────────────────────────────────────────────────────
+
+    private async Task<string> SeedBookingAsync(string osmBookingId = "77500")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.OsmBookings.Add(new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "1st Anytown Scouts",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Confirmed"
+        });
+        await db.SaveChangesAsync();
+        return osmBookingId;
+    }
+
+    private async Task<int> SeedPlanAsync(
+        string actionsJson,
+        string? osmBookingId,
+        PlanStatus status = PlanStatus.AwaitingApproval,
+        string? sourceEmailText = "Please note this on the booking")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var plan = new ProposedPlan
+        {
+            Status = status,
+            SourceEmailText = sourceEmailText,
+            OsmBookingId = osmBookingId,
+            ActionsJson = actionsJson,
+            CreatedAt = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc)
+        };
+        db.ProposedPlans.Add(plan);
+        await db.SaveChangesAsync();
+        return plan.Id;
+    }
+
+    private static BookingItemDto MakeSiteItem(string itemId = "site-item-1") => new()
+    {
+        ItemId = itemId,
+        Type = "site",
+        SiteId = "site-42",
+        Label = "Pitch A",
+        StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+        EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc)
+    };
+
+    private async Task<ProposedPlan?> GetPlanFromDbAsync(int id)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        return await db.ProposedPlans.FindAsync(id);
+    }
+
+    // ── Approve ─────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Approve_SinglePostCommentSucceeds_MarksExecuted_PostsComment_PurgesSourceEmailText()
+    {
+        var bookingId = await SeedBookingAsync("77501");
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = bookingId,
+            OsmCommentId = "cmt-approve-1",
+            AuthorName = "Site Manager",
+            TextPreview = "noted",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"postComment\",\"text\":\"Customer will arrive late\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Executed", result.Status);
+        Assert.Null(result.SourceEmailText);
+
+        var (postedBookingId, comment) = Assert.Single(_fakeOsm.CommentsPosted);
+        Assert.Equal(bookingId, postedBookingId);
+        Assert.Equal("Customer will arrive late", comment);
+
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Executed, stored.Status);
+        Assert.Null(stored.SourceEmailText);
+        Assert.NotNull(stored.ExecutionResultJson);
+        Assert.Contains("succeeded", stored.ExecutionResultJson);
+    }
+
+    [Fact]
+    public async Task Approve_StopsAfterFirstFailure_MarksFailed_RecordsPerActionResults()
+    {
+        var bookingId = await SeedBookingAsync("77502");
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = bookingId,
+            OsmCommentId = "cmt-approve-2",
+            AuthorName = "Site Manager",
+            TextPreview = "noted",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+        // moveDates will fail: an item exists, but the create call throws.
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeSiteItem() };
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("OSM create failed"));
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"postComment\",\"text\":\"noted\"},{\"type\":\"moveDates\",\"dayShift\":1}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.SourceEmailText);
+
+        // postComment did run (its own action succeeded) before moveDates failed.
+        Assert.Single(_fakeOsm.CommentsPosted);
+
+        Assert.NotNull(result.ExecutionResultJson);
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        Assert.Equal(2, results.Count);
+        Assert.Equal("postComment", results[0].Type);
+        Assert.Equal(PlanActionExecutionStatus.Succeeded, results[0].Status);
+        Assert.Equal("moveDates", results[1].Type);
+        Assert.Equal(PlanActionExecutionStatus.Failed, results[1].Status);
+        Assert.NotNull(results[1].Reason);
+
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Failed, stored.Status);
+        Assert.Null(stored.SourceEmailText);
+    }
+
+    [Fact]
+    public async Task Approve_RecordsNotAttempted_ForActionsAfterFirstFailure()
+    {
+        var bookingId = await SeedBookingAsync("77503");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeSiteItem() };
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("OSM create failed"));
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"moveDates\",\"dayShift\":1},{\"type\":\"sendTemplateEmail\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        Assert.Equal(2, results.Count);
+        Assert.Equal(PlanActionExecutionStatus.Failed, results[0].Status);
+        Assert.Equal("sendTemplateEmail", results[1].Type);
+        Assert.Equal(PlanActionExecutionStatus.NotAttempted, results[1].Status);
+
+        // sendTemplateEmail was never attempted.
+        Assert.Empty(_fakeOsm.EmailsSent);
+    }
+
+    [Fact]
+    public async Task Approve_OnlyDraftEmailReply_MarksExecuted_MakesNoOsmCalls()
+    {
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"draftEmailReply\",\"text\":\"Thanks, we'll sort this.\"}]",
+            osmBookingId: null);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Executed", result.Status);
+        Assert.Null(result.SourceEmailText);
+
+        // Zero OSM calls of any kind.
+        Assert.Empty(_fakeOsm.CommentsPosted);
+        Assert.Empty(_fakeOsm.EmailsSent);
+        Assert.Empty(_fakeOsm.CapturedSpecs);
+        Assert.Empty(_fakeOsm.DeletedItems);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal(PlanActionExecutionStatus.Succeeded, single.Status);
+    }
+
+    [Fact]
+    public async Task Approve_ReturnsConflict_WhenPlanNotAwaitingApproval()
+    {
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"draftEmailReply\",\"text\":\"already done\"}]",
+            osmBookingId: null,
+            status: PlanStatus.Executed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+
+        // No re-execution happened — status is untouched.
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Executed, stored.Status);
+    }
+
+    [Fact]
+    public async Task Approve_ReturnsNotFound_WhenPlanMissing()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync("/api/plans/999999/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // ── Reject ──────────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task Reject_AwaitingApprovalPlan_MarksRejected_PurgesSourceEmailText_MakesNoOsmCalls()
+    {
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"postComment\",\"text\":\"noted\"}]",
+            osmBookingId: "77504");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/reject", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Rejected", result.Status);
+        Assert.Null(result.SourceEmailText);
+
+        Assert.Empty(_fakeOsm.CommentsPosted);
+        Assert.Empty(_fakeOsm.EmailsSent);
+        Assert.Empty(_fakeOsm.CapturedSpecs);
+
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Rejected, stored.Status);
+        Assert.Null(stored.SourceEmailText);
+    }
+
+    [Fact]
+    public async Task Reject_ReturnsConflict_WhenPlanNotAwaitingApproval()
+    {
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"draftEmailReply\",\"text\":\"already done\"}]",
+            osmBookingId: null,
+            status: PlanStatus.Rejected);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/reject", content: null);
+
+        Assert.Equal(HttpStatusCode.Conflict, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Reject_ReturnsNotFound_WhenPlanMissing()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync("/api/plans/999999/reject", content: null);
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -269,6 +269,45 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
     }
 
+    [Fact]
+    public async Task Approve_ConcurrentRequestsForSamePlan_OnlyOneSucceeds_OsmActionRunsOnce()
+    {
+        // Regression test for a TOCTOU race: without an atomic claim step, two
+        // near-simultaneous /approve calls for the same plan could both read
+        // Status == AwaitingApproval before either wrote back, and both would go on to post
+        // the OSM comment — a double-execution bug. PlanTransitionLock (a process-wide async
+        // lock, shared across requests via DI singleton — see its doc comment) serializes the
+        // claim step so only one request ever wins.
+        var bookingId = await SeedBookingAsync("77510");
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = bookingId,
+            OsmCommentId = "cmt-race-1",
+            AuthorName = "Site Manager",
+            TextPreview = "noted",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"postComment\",\"text\":\"noted\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+
+        var task1 = client.PostAsync($"/api/plans/{planId}/approve", content: null);
+        var task2 = client.PostAsync($"/api/plans/{planId}/approve", content: null);
+        var responses = await Task.WhenAll(task1, task2);
+
+        var statusCodes = responses.Select(r => r.StatusCode).OrderBy(s => s).ToList();
+        Assert.Equal(new[] { HttpStatusCode.OK, HttpStatusCode.Conflict }, statusCodes);
+
+        // The OSM side effect happened exactly once — not twice.
+        Assert.Single(_fakeOsm.CommentsPosted);
+
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Executed, stored.Status);
+    }
+
     // ── Reject ──────────────────────────────────────────────────────────────
 
     [Fact]
@@ -318,5 +357,27 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
         var response = await client.PostAsync("/api/plans/999999/reject", content: null);
 
         Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Reject_ConcurrentRequestsForSamePlan_OnlyOneSucceeds()
+    {
+        // Same TOCTOU concern as the Approve race test above, applied to Reject.
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"postComment\",\"text\":\"noted\"}]",
+            osmBookingId: "77505");
+
+        var client = _factory.CreateClient();
+
+        var task1 = client.PostAsync($"/api/plans/{planId}/reject", content: null);
+        var task2 = client.PostAsync($"/api/plans/{planId}/reject", content: null);
+        var responses = await Task.WhenAll(task1, task2);
+
+        var statusCodes = responses.Select(r => r.StatusCode).OrderBy(s => s).ToList();
+        Assert.Equal(new[] { HttpStatusCode.OK, HttpStatusCode.Conflict }, statusCodes);
+
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Rejected, stored.Status);
     }
 }

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -215,6 +215,43 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Approve_BookingRequiredAction_FailsCleanly_WhenOsmBookingIdIsNull()
+    {
+        // Plan created without a linked booking (e.g. a general enquiry), but the LLM drafted
+        // a booking-required action anyway. This must produce a clean Failed action result
+        // with a clear reason -- not an unhandled exception -- and stop before any later
+        // actions run.
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"postComment\",\"text\":\"noted\"},{\"type\":\"sendTemplateEmail\"}]",
+            osmBookingId: null);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        Assert.Equal(2, results.Count);
+        Assert.Equal("postComment", results[0].Type);
+        Assert.Equal(PlanActionExecutionStatus.Failed, results[0].Status);
+        Assert.NotNull(results[0].Reason);
+        Assert.Contains("requires a booking", results[0].Reason, StringComparison.OrdinalIgnoreCase);
+        Assert.Equal("sendTemplateEmail", results[1].Type);
+        Assert.Equal(PlanActionExecutionStatus.NotAttempted, results[1].Status);
+
+        // No OSM calls of any kind were made.
+        Assert.Empty(_fakeOsm.CommentsPosted);
+        Assert.Empty(_fakeOsm.EmailsSent);
+
+        var stored = await GetPlanFromDbAsync(planId);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Failed, stored.Status);
+    }
+
+    [Fact]
     public async Task Approve_OnlyDraftEmailReply_MarksExecuted_MakesNoOsmCalls()
     {
         var planId = await SeedPlanAsync(

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -146,6 +146,37 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_ReturnsFailedStatus_AndPurgesSourceEmailText_WhenDraftingServiceThrows()
+    {
+        // Simulates a network failure / non-2xx from Open WebUI propagating as an exception
+        // out of DraftPlanAsync. Create must not let this become an unhandled 500 leaving the
+        // plan stuck at AwaitingApproval with no ActionsJson forever -- it should deterministically
+        // reach a terminal, PII-free Failed state, same as a validation failure.
+        _fakeLlm.ExceptionToThrow = new HttpRequestException("Open WebUI unreachable");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you cancel our pitch?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+        Assert.Null(result.SourceEmailText);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var stored = await db.ProposedPlans.FindAsync(result.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Failed, stored.Status);
+        Assert.Null(stored.SourceEmailText);
+        Assert.Null(stored.ActionsJson);
+    }
+
+    [Fact]
     public async Task Create_ReturnsFailedStatus_WhenLlmReturnsUnknownActionType()
     {
         // Both attempts return an unknown action type — invalid on the first try, and the

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -118,6 +118,34 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_PurgesSourceEmailText_WhenLlmReturnsMalformedJsonOnBothAttempts()
+    {
+        // A Failed plan has no Approve/Reject path (both require AwaitingApproval), so the
+        // raw customer email must be purged right here or it would never be purged at all.
+        _fakeLlm.ResponsesToReturn.Enqueue("this is not json at all");
+        _fakeLlm.ResponsesToReturn.Enqueue("{ also not json");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you cancel our pitch? My email is jane@example.com"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.SourceEmailText);
+
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var stored = await db.ProposedPlans.FindAsync(result.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Failed, stored.Status);
+        Assert.Null(stored.SourceEmailText);
+    }
+
+    [Fact]
     public async Task Create_ReturnsFailedStatus_WhenLlmReturnsUnknownActionType()
     {
         // Both attempts return an unknown action type — invalid on the first try, and the

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -49,7 +49,10 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
         });
     }
 
-    private async Task<string> SeedBookingAsync(string osmBookingId = "88001")
+    private async Task<string> SeedBookingAsync(
+        string osmBookingId = "88001",
+        DateTime? startDate = null,
+        DateTime? endDate = null)
     {
         using var scope = _factory.Services.CreateScope();
         var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
@@ -57,8 +60,8 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
         {
             OsmBookingId = osmBookingId,
             CustomerName = "1st Anytown Scouts",
-            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
-            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            StartDate = startDate ?? new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = endDate ?? new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
             Status = "Confirmed"
         });
         await db.SaveChangesAsync();
@@ -272,5 +275,46 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
         });
 
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsNotFound_WhenOsmBookingIdDoesNotExist()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you move our booking?",
+            OsmBookingId = "no-such-booking"
+        });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+
+        // No plan row, no LLM call — rejected before either happens.
+        Assert.Empty(_fakeLlm.Calls);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        Assert.Empty(db.ProposedPlans);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsBadRequest_WhenBookingHasAlreadyEnded()
+    {
+        var bookingId = await SeedBookingAsync(
+            startDate: DateTime.UtcNow.Date.AddDays(-10),
+            endDate: DateTime.UtcNow.Date.AddDays(-8));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you move our booking?",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+
+        Assert.Empty(_fakeLlm.Calls);
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        Assert.Empty(db.ProposedPlans);
     }
 }

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -1,0 +1,217 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+    private readonly FakeOpenWebUiClient _fakeLlm;
+
+    public PlanCreateTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_PlanCreate_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _fakeLlm = new FakeOpenWebUiClient();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+
+                services.RemoveAll<IOpenWebUiClient>();
+                services.AddSingleton<IOpenWebUiClient>(_fakeLlm);
+            });
+        });
+    }
+
+    private async Task<string> SeedBookingAsync(string osmBookingId = "88001")
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        db.OsmBookings.Add(new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "1st Anytown Scouts",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Confirmed"
+        });
+        await db.SaveChangesAsync();
+        return osmBookingId;
+    }
+
+    [Fact]
+    public async Task Create_ReturnsAwaitingApprovalWithActionsJson_WhenLlmReturnsValidJson()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"draftEmailReply\",\"text\":\"Thanks, we'll move your dates.\"}," +
+            "{\"type\":\"moveDates\",\"dayShift\":1}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Please could you move our booking one day later?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("draftEmailReply", result.ActionsJson);
+        Assert.Contains("moveDates", result.ActionsJson);
+
+        // Persisted, not just returned in the response.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var stored = await db.ProposedPlans.FindAsync(result.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.AwaitingApproval, stored.Status);
+        Assert.NotNull(stored.ActionsJson);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsMalformedJsonOnBothAttempts()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue("this is not json at all");
+        _fakeLlm.ResponsesToReturn.Enqueue("{ also not json");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you cancel our pitch?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+
+        // Two attempts were made (initial + one retry).
+        Assert.Equal(2, _fakeLlm.Calls.Count);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsUnknownActionType()
+    {
+        // Both attempts return an unknown action type — invalid on the first try, and the
+        // retry (which the service always attempts once) is still invalid.
+        _fakeLlm.ResponsesToReturn.Enqueue("{\"actions\":[{\"type\":\"launchRocket\",\"text\":\"go\"}]}");
+        _fakeLlm.ResponsesToReturn.Enqueue("{\"actions\":[{\"type\":\"launchRocket\",\"text\":\"go\"}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Please do something unusual."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+        Assert.Equal(2, _fakeLlm.Calls.Count);
+
+        // The retry prompt should mention the failure so the LLM can self-correct.
+        Assert.Contains("invalid", _fakeLlm.Calls[1].UserPrompt, StringComparison.OrdinalIgnoreCase);
+    }
+
+    [Fact]
+    public async Task Create_IncludesBookingContextInPrompt_WhenOsmBookingIdProvided()
+    {
+        var bookingId = await SeedBookingAsync();
+        _fakeLlm.ResponsesToReturn.Enqueue("{\"actions\":[{\"type\":\"postComment\",\"text\":\"noted\"}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you note that we'll arrive late?",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        Assert.Single(_fakeLlm.Calls);
+        Assert.Contains("1st Anytown Scouts", _fakeLlm.Calls[0].UserPrompt);
+        Assert.Contains("2026-08-01", _fakeLlm.Calls[0].UserPrompt);
+    }
+
+    [Fact]
+    public async Task Create_Succeeds_WhenOsmBookingIdOmitted()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue("{\"actions\":[{\"type\":\"draftEmailReply\",\"text\":\"Sure thing!\"}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "General enquiry, no specific booking."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.Null(result.OsmBookingId);
+
+        Assert.Single(_fakeLlm.Calls);
+        Assert.DoesNotContain("Booking context", _fakeLlm.Calls[0].UserPrompt);
+    }
+
+    [Fact]
+    public async Task Create_Succeeds_WhenFirstAttemptInvalidButRetrySucceeds()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue("not json");
+        _fakeLlm.ResponsesToReturn.Enqueue("{\"actions\":[{\"type\":\"postComment\",\"text\":\"noted\"}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Please note this on the booking."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("postComment", result.ActionsJson);
+        Assert.Equal(2, _fakeLlm.Calls.Count);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsBadRequest_WhenSourceEmailTextMissing()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = ""
+        });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/PlanDetailTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanDetailTests.cs
@@ -1,0 +1,86 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class PlanDetailTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PlanDetailTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_PlanDetail_" + Guid.NewGuid();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(new FakeOsmService());
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsPlan_WhenExists()
+    {
+        int planId;
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            var plan = new ProposedPlan
+            {
+                Status = PlanStatus.AwaitingApproval,
+                SourceEmailText = "Please add an extra night",
+                OsmBookingId = "77001",
+                ActionsJson = "[{\"type\":\"MoveDates\"}]",
+                CreatedAt = new DateTime(2026, 7, 5, 9, 0, 0, DateTimeKind.Utc)
+            };
+            db.ProposedPlans.Add(plan);
+            await db.SaveChangesAsync();
+            planId = plan.Id;
+        }
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync($"/api/plans/{planId}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal(planId, result.Id);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.Equal("Please add an extra night", result.SourceEmailText);
+        Assert.Equal("77001", result.OsmBookingId);
+        Assert.Equal("[{\"type\":\"MoveDates\"}]", result.ActionsJson);
+    }
+
+    [Fact]
+    public async Task GetById_ReturnsNotFound_WhenMissing()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/plans/99999");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/PlanListTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanListTests.cs
@@ -1,0 +1,56 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class PlanListTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+
+    public PlanListTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_PlanList_" + Guid.NewGuid();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(new FakeOsmService());
+            });
+        });
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsEmptyList_WhenNoPlans()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/plans");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<ProposedPlanDto>>();
+        Assert.NotNull(result);
+        Assert.Empty(result);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/PlanListTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanListTests.cs
@@ -91,4 +91,47 @@ public class PlanListTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.Contains(result, p => p.Status == "AwaitingApproval" && p.SourceEmailText == "Please move our booking a day later");
         Assert.Contains(result, p => p.Status == "Executed" && p.SourceEmailText == "Cancel our pitch please");
     }
+
+    [Fact]
+    public async Task GetAll_FiltersByStatus()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.ProposedPlans.AddRange(
+                new ProposedPlan
+                {
+                    Status = PlanStatus.AwaitingApproval,
+                    SourceEmailText = "Awaiting one",
+                    CreatedAt = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc)
+                },
+                new ProposedPlan
+                {
+                    Status = PlanStatus.Rejected,
+                    SourceEmailText = "Rejected one",
+                    CreatedAt = new DateTime(2026, 7, 2, 9, 0, 0, DateTimeKind.Utc)
+                }
+            );
+            await db.SaveChangesAsync();
+        }
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/plans?status=Rejected");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<ProposedPlanDto>>();
+        Assert.NotNull(result);
+        Assert.Single(result);
+        Assert.Equal("Rejected", result[0].Status);
+        Assert.Equal("Rejected one", result[0].SourceEmailText);
+    }
+
+    [Fact]
+    public async Task GetAll_ReturnsBadRequest_ForInvalidStatus()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/plans?status=NotARealStatus");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
 }

--- a/BookingsAssistant.Tests/Controllers/PlanListTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanListTests.cs
@@ -53,4 +53,42 @@ public class PlanListTests : IClassFixture<WebApplicationFactory<Program>>
         Assert.NotNull(result);
         Assert.Empty(result);
     }
+
+    [Fact]
+    public async Task GetAll_ReturnsAllPlans_WhenNoStatusFilter()
+    {
+        using (var scope = _factory.Services.CreateScope())
+        {
+            var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+            db.ProposedPlans.AddRange(
+                new ProposedPlan
+                {
+                    Status = PlanStatus.AwaitingApproval,
+                    SourceEmailText = "Please move our booking a day later",
+                    OsmBookingId = null,
+                    ActionsJson = "[{\"type\":\"MoveDates\"}]",
+                    CreatedAt = new DateTime(2026, 7, 1, 9, 0, 0, DateTimeKind.Utc)
+                },
+                new ProposedPlan
+                {
+                    Status = PlanStatus.Executed,
+                    SourceEmailText = "Cancel our pitch please",
+                    OsmBookingId = null,
+                    ActionsJson = "[{\"type\":\"Cancel\"}]",
+                    CreatedAt = new DateTime(2026, 7, 2, 9, 0, 0, DateTimeKind.Utc)
+                }
+            );
+            await db.SaveChangesAsync();
+        }
+
+        var client = _factory.CreateClient();
+        var response = await client.GetAsync("/api/plans");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<List<ProposedPlanDto>>();
+        Assert.NotNull(result);
+        Assert.Equal(2, result.Count);
+        Assert.Contains(result, p => p.Status == "AwaitingApproval" && p.SourceEmailText == "Please move our booking a day later");
+        Assert.Contains(result, p => p.Status == "Executed" && p.SourceEmailText == "Cancel our pitch please");
+    }
 }

--- a/BookingsAssistant.Tests/Controllers/PlanStaleRecoveryTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanStaleRecoveryTests.cs
@@ -1,0 +1,163 @@
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+public class PlanStaleRecoveryTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _baseFactory;
+
+    public PlanStaleRecoveryTests(WebApplicationFactory<Program> factory)
+    {
+        _baseFactory = factory;
+    }
+
+    /// <summary>
+    /// Regression test for plans that crash mid-approval: if the process dies (or a
+    /// SaveChangesAsync fails) between PlansController's atomic claim step
+    /// (AwaitingApproval -> Processing) and the terminal status write that normally follows
+    /// immediately, a plan is left stuck in Processing with no Approve/Reject path to recover
+    /// it (both only accept AwaitingApproval). Program.cs's startup sweep
+    /// (StalePlanRecovery.RecoverStaleProcessingPlansAsync) must reset any such row to Failed
+    /// and purge SourceEmailText, since Processing can never legitimately persist across a
+    /// process restart.
+    /// </summary>
+    [Fact]
+    public async Task StartupSweep_ResetsPlansStuckInProcessing_ToFailed_AndPurgesSourceEmailText()
+    {
+        var dbName = "TestDb_StalePlanRecovery_" + Guid.NewGuid();
+
+        // Seed a "crash-left-behind" Processing plan directly against the named in-memory
+        // database, BEFORE the host is built, so it's already present when Program.cs's
+        // startup sweep runs — simulating a plan that got stuck mid-approval across a process
+        // restart (rather than one created via the normal API, which would never leave it in
+        // Processing outside a crash).
+        var seedOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        int planId;
+        using (var seedContext = new ApplicationDbContext(seedOptions))
+        {
+            var plan = new ProposedPlan
+            {
+                Status = PlanStatus.Processing,
+                SourceEmailText = "Customer email with PII that must not linger past a Failed plan",
+                OsmBookingId = "77600",
+                ActionsJson = "[{\"type\":\"postComment\",\"text\":\"noted\"}]",
+                CreatedAt = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc)
+            };
+            seedContext.ProposedPlans.Add(plan);
+            await seedContext.SaveChangesAsync();
+            planId = plan.Id;
+        }
+
+        var fakeOsm = new FakeOsmService();
+        var factory = _baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(fakeOsm);
+            });
+        });
+
+        // Accessing .Services triggers the host to build, which runs Program.cs's top-level
+        // migrate/seed/sweep/sync block — including the stale-plan recovery sweep — before this
+        // call returns. No separate "trigger" step is needed: the sweep has already run by the
+        // time we read the plan back below.
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var stored = await context.ProposedPlans.FindAsync(planId);
+
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.Failed, stored.Status);
+        Assert.Null(stored.SourceEmailText);
+    }
+
+    [Fact]
+    public async Task StartupSweep_LeavesOtherStatuses_Untouched()
+    {
+        var dbName = "TestDb_StalePlanRecovery_Untouched_" + Guid.NewGuid();
+
+        var seedOptions = new DbContextOptionsBuilder<ApplicationDbContext>()
+            .UseInMemoryDatabase(dbName)
+            .Options;
+        int awaitingId, executedId;
+        using (var seedContext = new ApplicationDbContext(seedOptions))
+        {
+            var awaiting = new ProposedPlan
+            {
+                Status = PlanStatus.AwaitingApproval,
+                SourceEmailText = "Still pending review",
+                OsmBookingId = "77601",
+                ActionsJson = "[{\"type\":\"postComment\",\"text\":\"noted\"}]",
+                CreatedAt = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc)
+            };
+            var executed = new ProposedPlan
+            {
+                Status = PlanStatus.Executed,
+                SourceEmailText = null,
+                OsmBookingId = "77602",
+                ActionsJson = "[{\"type\":\"postComment\",\"text\":\"noted\"}]",
+                CreatedAt = new DateTime(2026, 7, 20, 9, 0, 0, DateTimeKind.Utc)
+            };
+            seedContext.ProposedPlans.AddRange(awaiting, executed);
+            await seedContext.SaveChangesAsync();
+            awaitingId = awaiting.Id;
+            executedId = executed.Id;
+        }
+
+        var fakeOsm = new FakeOsmService();
+        var factory = _baseFactory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?>
+                {
+                    ["Hashing:Iterations"] = "1"
+                }));
+
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(options =>
+                    options.UseInMemoryDatabase(dbName));
+
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(fakeOsm);
+            });
+        });
+
+        using var scope = factory.Services.CreateScope();
+        var context = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+
+        var storedAwaiting = await context.ProposedPlans.FindAsync(awaitingId);
+        Assert.NotNull(storedAwaiting);
+        Assert.Equal(PlanStatus.AwaitingApproval, storedAwaiting.Status);
+        Assert.Equal("Still pending review", storedAwaiting.SourceEmailText);
+
+        var storedExecuted = await context.ProposedPlans.FindAsync(executedId);
+        Assert.NotNull(storedExecuted);
+        Assert.Equal(PlanStatus.Executed, storedExecuted.Status);
+    }
+}

--- a/BookingsAssistant.Tests/Fakes/FakeOpenWebUiClient.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOpenWebUiClient.cs
@@ -14,9 +14,18 @@ public class FakeOpenWebUiClient : IOpenWebUiClient
     public Queue<string> ResponsesToReturn { get; } = new();
     public string DefaultResponse { get; set; } = "{\"actions\":[]}";
 
+    /// <summary>
+    /// If set, GetCompletionAsync throws this instead of returning a response — simulates
+    /// DraftPlanAsync's underlying HTTP call failing (network error, non-2xx, etc.).
+    /// </summary>
+    public Exception? ExceptionToThrow { get; set; }
+
     public Task<string> GetCompletionAsync(string systemPrompt, string userPrompt)
     {
         Calls.Add((systemPrompt, userPrompt));
+        if (ExceptionToThrow != null)
+            throw ExceptionToThrow;
+
         var response = ResponsesToReturn.Count > 0 ? ResponsesToReturn.Dequeue() : DefaultResponse;
         return Task.FromResult(response);
     }

--- a/BookingsAssistant.Tests/Fakes/FakeOpenWebUiClient.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOpenWebUiClient.cs
@@ -1,0 +1,23 @@
+using BookingsAssistant.Api.Services;
+
+namespace BookingsAssistant.Tests.Fakes;
+
+/// <summary>
+/// Test double for <see cref="IOpenWebUiClient"/>. Captures every (systemPrompt, userPrompt)
+/// pair it's called with (so tests can assert on booking context being included) and returns
+/// canned responses in order — one entry per call, falling back to <see cref="DefaultResponse"/>
+/// once the queue is exhausted (e.g. for the plan-drafting service's single retry).
+/// </summary>
+public class FakeOpenWebUiClient : IOpenWebUiClient
+{
+    public List<(string SystemPrompt, string UserPrompt)> Calls { get; } = new();
+    public Queue<string> ResponsesToReturn { get; } = new();
+    public string DefaultResponse { get; set; } = "{\"actions\":[]}";
+
+    public Task<string> GetCompletionAsync(string systemPrompt, string userPrompt)
+    {
+        Calls.Add((systemPrompt, userPrompt));
+        var response = ResponsesToReturn.Count > 0 ? ResponsesToReturn.Dequeue() : DefaultResponse;
+        return Task.FromResult(response);
+    }
+}

--- a/BookingsAssistant.Tests/Services/OpenWebUiClientTests.cs
+++ b/BookingsAssistant.Tests/Services/OpenWebUiClientTests.cs
@@ -1,0 +1,98 @@
+using System.Net;
+using BookingsAssistant.Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Direct coverage for <see cref="OpenWebUiClient"/> itself (the HTTP call, JSON response
+/// parsing, EnsureSuccessStatusCode, empty-message-content handling) — everything else in the
+/// plan-drafting tests goes through <see cref="Fakes.FakeOpenWebUiClient"/>, which never
+/// exercises this class. Mirrors the fake-HttpMessageHandler pattern already used for
+/// OsmService in OsmRateLimitCooldownTests.
+/// </summary>
+public class OpenWebUiClientTests
+{
+    private static IConfiguration BuildConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["OpenWebUi:BaseUrl"] = "https://openwebui.example.test",
+                ["OpenWebUi:ApiKey"] = "test-api-key",
+                ["OpenWebUi:Model"] = "test-model"
+            })
+            .Build();
+
+    private class StubHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public StubHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+            => Task.FromResult(_response);
+    }
+
+    private static OpenWebUiClient CreateClient(HttpResponseMessage response)
+    {
+        var httpClient = new HttpClient(new StubHandler(response));
+        return new OpenWebUiClient(httpClient, BuildConfig(), NullLogger<OpenWebUiClient>.Instance);
+    }
+
+    [Fact]
+    public async Task GetCompletionAsync_ReturnsMessageContent_OnSuccessfulResponse()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"choices":[{"message":{"content":"{\"actions\":[]}"}}]}""")
+        };
+        var client = CreateClient(response);
+
+        var result = await client.GetCompletionAsync("system prompt", "user prompt");
+
+        Assert.Equal("{\"actions\":[]}", result);
+    }
+
+    [Fact]
+    public async Task GetCompletionAsync_Throws_WhenResponseIsNonSuccessStatusCode()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError)
+        {
+            Content = new StringContent("upstream error")
+        };
+        var client = CreateClient(response);
+
+        await Assert.ThrowsAsync<HttpRequestException>(
+            () => client.GetCompletionAsync("system prompt", "user prompt"));
+    }
+
+    [Fact]
+    public async Task GetCompletionAsync_Throws_WhenMessageContentIsEmpty()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent(
+                """{"choices":[{"message":{"content":""}}]}""")
+        };
+        var client = CreateClient(response);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetCompletionAsync("system prompt", "user prompt"));
+        Assert.Contains("no message content", ex.Message);
+    }
+
+    [Fact]
+    public async Task GetCompletionAsync_Throws_WhenChoicesArrayIsMissing()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK)
+        {
+            Content = new StringContent("""{"id":"some-id"}""")
+        };
+        var client = CreateClient(response);
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => client.GetCompletionAsync("system prompt", "user prompt"));
+        Assert.Contains("no message content", ex.Message);
+    }
+}

--- a/BookingsAssistant.Web/src/App.tsx
+++ b/BookingsAssistant.Web/src/App.tsx
@@ -2,6 +2,7 @@ import { Routes, Route } from 'react-router-dom';
 import Dashboard from './components/Dashboard';
 import BookingDetail from './components/BookingDetail';
 import BookingList from './components/BookingList';
+import Triage from './components/Triage';
 
 function App() {
   return (
@@ -10,6 +11,7 @@ function App() {
         <Route path="/" element={<Dashboard />} />
         <Route path="/bookings" element={<BookingList />} />
         <Route path="/bookings/:id" element={<BookingDetail />} />
+        <Route path="/triage" element={<Triage />} />
       </Routes>
     </div>
   );

--- a/BookingsAssistant.Web/src/components/Dashboard.tsx
+++ b/BookingsAssistant.Web/src/components/Dashboard.tsx
@@ -174,9 +174,12 @@ export default function Dashboard() {
         />
       </div>
 
-      {/* Browse link — always visible once loading is done */}
+      {/* Browse / triage links — always visible once loading is done */}
       {!loading && (
-        <div className="mt-6 text-right">
+        <div className="mt-6 flex justify-end gap-4">
+          <Link to="/triage" className="text-sm text-blue-600 hover:underline">
+            Triage customer emails →
+          </Link>
           <Link to="/bookings" className="text-sm text-blue-600 hover:underline">
             Browse all bookings →
           </Link>

--- a/BookingsAssistant.Web/src/components/Triage.test.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.test.tsx
@@ -1,0 +1,225 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import Triage from './Triage';
+import { plansApi } from '../services/apiClient';
+import type { ProposedPlan } from '../types';
+
+vi.mock('../services/apiClient', () => ({
+  plansApi: {
+    create: vi.fn(),
+    list: vi.fn(),
+    getById: vi.fn(),
+    approve: vi.fn(),
+    reject: vi.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const api = plansApi as any;
+
+// The plan's status also appears as filter-button text, so status-badge assertions must be
+// scoped to the <span> badge rather than matching any element with that text.
+function getStatusBadge(text: string | RegExp) {
+  const matches = screen.getAllByText(text);
+  const badge = matches.find((el) => el.tagName === 'SPAN');
+  if (!badge) throw new Error(`No <span> status badge found matching ${text}`);
+  return badge;
+}
+
+function renderTriage() {
+  return render(
+    <MemoryRouter initialEntries={['/triage']}>
+      <Routes><Route path="/triage" element={<Triage />} /></Routes>
+    </MemoryRouter>
+  );
+}
+
+const draftReplyPlan: ProposedPlan = {
+  id: 1,
+  status: 'AwaitingApproval',
+  sourceEmailText: 'Can I move my visit to next week?',
+  osmBookingId: '179743',
+  actionsJson: JSON.stringify([
+    { type: 'draftEmailReply', text: 'Sure, we can move your visit — confirming the new dates now.' },
+    { type: 'moveDates', dayShift: 7, note: 'Requested by customer' },
+  ]),
+  executionResultJson: null,
+  createdAt: '2026-07-20T09:00:00Z',
+};
+
+const executedPlan: ProposedPlan = {
+  id: 2,
+  status: 'Executed',
+  sourceEmailText: null,
+  osmBookingId: '179744',
+  actionsJson: JSON.stringify([
+    { type: 'postComment', text: 'Customer confirmed arrival time' },
+    { type: 'sendTemplateEmail' },
+  ]),
+  executionResultJson: JSON.stringify([
+    { type: 'postComment', status: 'succeeded' },
+    { type: 'sendTemplateEmail', status: 'succeeded' },
+  ]),
+  createdAt: '2026-07-19T09:00:00Z',
+};
+
+const partiallyFailedPlan: ProposedPlan = {
+  id: 3,
+  status: 'Failed',
+  sourceEmailText: null,
+  osmBookingId: '179745',
+  actionsJson: JSON.stringify([
+    { type: 'postComment', text: 'Noting the request' },
+    { type: 'changeSite', itemId: '411467', newSiteId: '1404', newSiteName: 'Birch' },
+    { type: 'sendTemplateEmail' },
+  ]),
+  executionResultJson: JSON.stringify([
+    { type: 'postComment', status: 'succeeded' },
+    { type: 'changeSite', status: 'failed', reason: 'Site 1404 is not available' },
+    { type: 'sendTemplateEmail', status: 'not_attempted' },
+  ]),
+  createdAt: '2026-07-18T09:00:00Z',
+};
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.list.mockResolvedValue([]);
+});
+
+describe('drafting a plan', () => {
+  it('submits the pasted email and displays the resulting plan', async () => {
+    api.create.mockResolvedValue(draftReplyPlan);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.type(screen.getByLabelText(/customer email/i), 'Can I move my visit to next week?');
+    await user.type(screen.getByLabelText(/booking id/i), '179743');
+    await user.click(screen.getByRole('button', { name: /draft plan/i }));
+
+    await waitFor(() =>
+      expect(api.create).toHaveBeenCalledWith('Can I move my visit to next week?', '179743')
+    );
+    expect(await screen.findByText(/plan #1/i)).toBeInTheDocument();
+    expect(getStatusBadge(/awaitingapproval/i)).toBeInTheDocument();
+  });
+
+  it('shows an error if drafting fails', async () => {
+    api.create.mockRejectedValue(new Error('boom'));
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.type(screen.getByLabelText(/customer email/i), 'Hello');
+    await user.click(screen.getByRole('button', { name: /draft plan/i }));
+
+    expect(await screen.findByText(/failed to draft plan/i)).toBeInTheDocument();
+  });
+});
+
+describe('plan list', () => {
+  it('fetches and renders plans, refetching by status when a filter is chosen', async () => {
+    api.list.mockResolvedValue([draftReplyPlan, executedPlan]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await waitFor(() => expect(api.list).toHaveBeenCalledWith(undefined));
+    expect(await screen.findByText(/plan #1/i)).toBeInTheDocument();
+    expect(screen.getByText(/plan #2/i)).toBeInTheDocument();
+
+    api.list.mockResolvedValue([executedPlan]);
+    await user.click(screen.getByRole('button', { name: /^executed$/i }));
+
+    await waitFor(() => expect(api.list).toHaveBeenCalledWith('Executed'));
+  });
+
+  it('opens a plan detail view when a plan row is selected', async () => {
+    api.list.mockResolvedValue([executedPlan]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    const row = await screen.findByRole('button', { name: /plan #2/i });
+    await user.click(row);
+
+    expect(await screen.findByText(/post comment: customer confirmed arrival time/i)).toBeInTheDocument();
+  });
+});
+
+describe('plan detail actions', () => {
+  it('approves an AwaitingApproval plan and updates the displayed status', async () => {
+    api.create.mockResolvedValue(draftReplyPlan);
+    api.approve.mockResolvedValue({ ...draftReplyPlan, status: 'Executed', sourceEmailText: null });
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.type(screen.getByLabelText(/customer email/i), 'Hi');
+    await user.click(screen.getByRole('button', { name: /draft plan/i }));
+    await screen.findByText(/plan #1/i);
+
+    await user.click(screen.getByRole('button', { name: /^approve$/i }));
+
+    await waitFor(() => expect(api.approve).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(getStatusBadge(/^executed$/i)).toBeInTheDocument());
+  });
+
+  it('rejects an AwaitingApproval plan and updates the displayed status', async () => {
+    api.create.mockResolvedValue(draftReplyPlan);
+    api.reject.mockResolvedValue({ ...draftReplyPlan, status: 'Rejected', sourceEmailText: null });
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.type(screen.getByLabelText(/customer email/i), 'Hi');
+    await user.click(screen.getByRole('button', { name: /draft plan/i }));
+    await screen.findByText(/plan #1/i);
+
+    await user.click(screen.getByRole('button', { name: /^reject$/i }));
+
+    await waitFor(() => expect(api.reject).toHaveBeenCalledWith(1));
+    await waitFor(() => expect(getStatusBadge(/^rejected$/i)).toBeInTheDocument());
+  });
+
+  it('does not show Approve/Reject for a plan that is not AwaitingApproval', async () => {
+    api.list.mockResolvedValue([executedPlan]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #2/i }));
+
+    await screen.findByText(/post comment: customer confirmed arrival time/i);
+    expect(screen.queryByRole('button', { name: /^approve$/i })).not.toBeInTheDocument();
+    expect(screen.queryByRole('button', { name: /^reject$/i })).not.toBeInTheDocument();
+  });
+});
+
+describe('action rendering', () => {
+  it('renders a draftEmailReply action as copyable text and an OSM action as a readable description', async () => {
+    api.create.mockResolvedValue(draftReplyPlan);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.type(screen.getByLabelText(/customer email/i), 'Hi');
+    await user.click(screen.getByRole('button', { name: /draft plan/i }));
+    await screen.findByText(/plan #1/i);
+
+    expect(screen.getByText(/sure, we can move your visit/i)).toBeInTheDocument();
+    expect(screen.getByRole('button', { name: /copy/i })).toBeInTheDocument();
+    expect(screen.getByText(/move dates by 7 day\(s\)/i)).toBeInTheDocument();
+  });
+
+  it('distinguishes succeeded, failed, and not_attempted actions in a partial-failure result', async () => {
+    api.list.mockResolvedValue([partiallyFailedPlan]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #3/i }));
+
+    const commentRow = (await screen.findByText(/post comment: noting the request/i)).closest('div')!.parentElement!;
+    expect(within(commentRow).getByText(/succeeded/i)).toBeInTheDocument();
+
+    const changeSiteRow = screen.getByText(/change site/i).closest('div')!.parentElement!;
+    expect(within(changeSiteRow).getByText(/failed/i)).toBeInTheDocument();
+    expect(within(changeSiteRow).getByText(/site 1404 is not available/i)).toBeInTheDocument();
+
+    const templateEmailRow = screen.getByText(/send template email/i).closest('div')!.parentElement!;
+    expect(within(templateEmailRow).getByText(/not_attempted/i)).toBeInTheDocument();
+  });
+});

--- a/BookingsAssistant.Web/src/components/Triage.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.tsx
@@ -1,0 +1,341 @@
+import { useState, useEffect, useCallback } from 'react';
+import { plansApi } from '../services/apiClient';
+import type { PlanAction, PlanActionExecutionResult, PlanStatusValue, ProposedPlan } from '../types';
+
+const STATUS_FILTERS: Array<PlanStatusValue | 'All'> = ['All', 'AwaitingApproval', 'Executed', 'Rejected', 'Failed'];
+
+function parseActions(actionsJson?: string | null): PlanAction[] {
+  if (!actionsJson) return [];
+  try {
+    const parsed = JSON.parse(actionsJson);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+function parseResults(executionResultJson?: string | null): PlanActionExecutionResult[] {
+  if (!executionResultJson) return [];
+  try {
+    const parsed = JSON.parse(executionResultJson);
+    return Array.isArray(parsed) ? parsed : [];
+  } catch {
+    return [];
+  }
+}
+
+// Renders each action type as a short human-readable label. draftEmailReply is handled
+// separately by PlanActionRow (shown as a copyable text block) so it isn't described here.
+function describeAction(action: PlanAction): string {
+  switch (action.type) {
+    case 'postComment':
+      return `Post comment: ${action.text ?? ''}`;
+    case 'sendTemplateEmail':
+      return 'Send template email';
+    case 'moveDates':
+      return `Move dates by ${action.dayShift ?? '?'} day(s)${action.note ? ` — ${action.note}` : ''}`;
+    case 'changeSite':
+      return `Change site for item ${action.itemId} to ${action.newSiteName ?? action.newSiteId}`;
+    case 'moveActivity': {
+      const when = [action.newStartDate, action.newStartTime].filter(Boolean).join(' ');
+      return `Move activity ${action.itemId}${when ? ` to ${when}` : ''}`;
+    }
+    default:
+      return `Unknown action: ${action.type}`;
+  }
+}
+
+function resultBadgeClass(status: string): string {
+  switch (status) {
+    case 'succeeded': return 'bg-green-100 text-green-800';
+    case 'failed': return 'bg-red-100 text-red-800';
+    default: return 'bg-gray-100 text-gray-600'; // not_attempted
+  }
+}
+
+function statusBadgeClass(status: string): string {
+  switch (status) {
+    case 'AwaitingApproval': return 'bg-yellow-100 text-yellow-800';
+    case 'Executed': return 'bg-green-100 text-green-800';
+    case 'Rejected': return 'bg-gray-100 text-gray-600';
+    default: return 'bg-red-100 text-red-800'; // Failed
+  }
+}
+
+function PlanActionRow({ action, result }: { action: PlanAction; result?: PlanActionExecutionResult }) {
+  const [copied, setCopied] = useState(false);
+
+  const handleCopy = async () => {
+    try {
+      await navigator.clipboard.writeText(action.text ?? '');
+      setCopied(true);
+      setTimeout(() => setCopied(false), 2000);
+    } catch {
+      // Clipboard API unavailable (e.g. insecure context) — nothing more we can do.
+    }
+  };
+
+  return (
+    <div className="p-3 border border-gray-200 rounded bg-gray-50">
+      {action.type === 'draftEmailReply' ? (
+        <div>
+          <div className="flex items-center justify-between mb-1">
+            <span className="text-sm font-medium text-gray-700">Draft email reply</span>
+            <button
+              onClick={handleCopy}
+              className="text-xs px-2 py-1 bg-blue-600 text-white rounded hover:bg-blue-700"
+            >
+              {copied ? 'Copied!' : 'Copy'}
+            </button>
+          </div>
+          <pre className="whitespace-pre-wrap text-sm text-gray-800 select-all font-sans">{action.text}</pre>
+        </div>
+      ) : (
+        <div className="text-sm text-gray-800">{describeAction(action)}</div>
+      )}
+      {result && (
+        <div className="mt-2">
+          <span className={`inline-block px-2 py-0.5 text-xs rounded ${resultBadgeClass(result.status)}`}>
+            {result.status}
+          </span>
+          {result.reason && <span className="ml-2 text-xs text-red-700">{result.reason}</span>}
+        </div>
+      )}
+    </div>
+  );
+}
+
+interface PlanDetailProps {
+  plan: ProposedPlan;
+  onApprove: () => void;
+  onReject: () => void;
+  busy: boolean;
+}
+
+function PlanDetail({ plan, onApprove, onReject, busy }: PlanDetailProps) {
+  const actions = parseActions(plan.actionsJson);
+  const results = parseResults(plan.executionResultJson);
+
+  return (
+    <div className="bg-white rounded-lg shadow p-6 mb-6">
+      <div className="flex items-center justify-between mb-4">
+        <h2 className="text-lg font-semibold text-gray-800">Plan #{plan.id}</h2>
+        <span className={`px-3 py-1 rounded-full text-sm font-medium ${statusBadgeClass(plan.status)}`}>
+          {plan.status}
+        </span>
+      </div>
+
+      {plan.osmBookingId && (
+        <p className="text-sm text-gray-600 mb-2">Booking: {plan.osmBookingId}</p>
+      )}
+
+      {plan.sourceEmailText && (
+        <div className="mb-4">
+          <h3 className="text-sm font-semibold text-gray-700 mb-1">Source email</h3>
+          <p className="text-sm text-gray-600 whitespace-pre-wrap p-3 bg-gray-50 rounded border border-gray-200">
+            {plan.sourceEmailText}
+          </p>
+        </div>
+      )}
+
+      <div className="space-y-2 mb-4">
+        <h3 className="text-sm font-semibold text-gray-700">Actions</h3>
+        {actions.length === 0 ? (
+          <p className="text-sm text-gray-400">No actions.</p>
+        ) : (
+          actions.map((action, i) => (
+            <PlanActionRow key={i} action={action} result={results[i]} />
+          ))
+        )}
+      </div>
+
+      {plan.status === 'AwaitingApproval' && (
+        <div className="flex gap-2 border-t pt-4">
+          <button
+            onClick={onApprove}
+            disabled={busy}
+            className="px-4 py-2 bg-green-600 text-white rounded hover:bg-green-700 disabled:opacity-50"
+          >
+            {busy ? 'Working…' : 'Approve'}
+          </button>
+          <button
+            onClick={onReject}
+            disabled={busy}
+            className="px-4 py-2 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+          >
+            {busy ? 'Working…' : 'Reject'}
+          </button>
+        </div>
+      )}
+    </div>
+  );
+}
+
+export default function Triage() {
+  const [sourceEmailText, setSourceEmailText] = useState('');
+  const [osmBookingId, setOsmBookingId] = useState('');
+  const [drafting, setDrafting] = useState(false);
+  const [draftError, setDraftError] = useState<string | null>(null);
+
+  const [activePlan, setActivePlan] = useState<ProposedPlan | null>(null);
+  const [busy, setBusy] = useState(false);
+
+  const [plans, setPlans] = useState<ProposedPlan[]>([]);
+  const [statusFilter, setStatusFilter] = useState<PlanStatusValue | 'All'>('All');
+  const [listLoading, setListLoading] = useState(false);
+  const [listError, setListError] = useState<string | null>(null);
+
+  const refreshList = useCallback(async (filter: PlanStatusValue | 'All') => {
+    setListLoading(true);
+    setListError(null);
+    try {
+      const result = await plansApi.list(filter === 'All' ? undefined : filter);
+      setPlans(result);
+    } catch (err) {
+      setListError('Failed to load plans');
+      console.error(err);
+    } finally {
+      setListLoading(false);
+    }
+  }, []);
+
+  useEffect(() => {
+    refreshList(statusFilter);
+  }, [statusFilter, refreshList]);
+
+  const handleDraft = async () => {
+    if (!sourceEmailText.trim()) return;
+    setDrafting(true);
+    setDraftError(null);
+    try {
+      const plan = await plansApi.create(sourceEmailText.trim(), osmBookingId.trim() || undefined);
+      setActivePlan(plan);
+      setSourceEmailText('');
+      setOsmBookingId('');
+      refreshList(statusFilter);
+    } catch (err) {
+      setDraftError('Failed to draft plan');
+      console.error(err);
+    } finally {
+      setDrafting(false);
+    }
+  };
+
+  // Shared by Approve/Reject: both call a plansApi endpoint for the active plan, replace it
+  // with the server's updated copy, and refresh the list — only the endpoint and error copy differ.
+  const runPlanDecision = async (fn: (id: number) => Promise<ProposedPlan>, failureMessage: string) => {
+    if (!activePlan) return;
+    setBusy(true);
+    setDraftError(null);
+    try {
+      const updated = await fn(activePlan.id);
+      setActivePlan(updated);
+      refreshList(statusFilter);
+    } catch (err) {
+      setDraftError(failureMessage);
+      console.error(err);
+    } finally {
+      setBusy(false);
+    }
+  };
+
+  const handleApprove = () => runPlanDecision(plansApi.approve, 'Failed to approve plan');
+  const handleReject = () => runPlanDecision(plansApi.reject, 'Failed to reject plan');
+
+  return (
+    <div className="container mx-auto px-4 py-8 max-w-4xl">
+      <h1 className="text-2xl font-bold text-gray-800 mb-6">Triage</h1>
+
+      {/* Draft form */}
+      <div className="bg-white rounded-lg shadow p-6 mb-6">
+        <h2 className="text-lg font-semibold text-gray-800 mb-4">Draft a plan from a customer email</h2>
+        <div className="mb-3">
+          <label htmlFor="sourceEmailText" className="block text-sm font-medium text-gray-700 mb-1">
+            Customer email
+          </label>
+          <textarea
+            id="sourceEmailText"
+            rows={6}
+            value={sourceEmailText}
+            onChange={(e) => setSourceEmailText(e.target.value)}
+            disabled={drafting}
+            className="w-full p-3 border border-gray-300 rounded resize-none"
+          />
+        </div>
+        <div className="mb-3">
+          <label htmlFor="osmBookingId" className="block text-sm font-medium text-gray-700 mb-1">
+            Booking ID (optional)
+          </label>
+          <input
+            id="osmBookingId"
+            type="text"
+            value={osmBookingId}
+            onChange={(e) => setOsmBookingId(e.target.value)}
+            disabled={drafting}
+            className="w-48 p-2 border border-gray-300 rounded"
+          />
+        </div>
+        {draftError && <div className="text-red-600 text-sm mb-2">{draftError}</div>}
+        <button
+          onClick={handleDraft}
+          disabled={drafting || !sourceEmailText.trim()}
+          className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+        >
+          {drafting ? 'Drafting…' : 'Draft Plan'}
+        </button>
+      </div>
+
+      {/* Detail view for the drafted or selected plan */}
+      {activePlan && (
+        <PlanDetail plan={activePlan} onApprove={handleApprove} onReject={handleReject} busy={busy} />
+      )}
+
+      {/* Plan list */}
+      <div className="bg-white rounded-lg shadow p-6">
+        <div className="flex flex-wrap items-center justify-between gap-2 mb-4">
+          <h2 className="text-lg font-semibold text-gray-800">Plans</h2>
+          <div className="flex flex-wrap gap-2">
+            {STATUS_FILTERS.map((f) => (
+              <button
+                key={f}
+                onClick={() => setStatusFilter(f)}
+                className={`px-3 py-1 text-sm rounded ${
+                  statusFilter === f ? 'bg-blue-600 text-white' : 'bg-gray-100 text-gray-700 hover:bg-gray-200'
+                }`}
+              >
+                {f}
+              </button>
+            ))}
+          </div>
+        </div>
+
+        {listLoading && <p className="text-sm text-gray-400">Loading…</p>}
+        {listError && <div className="text-red-600 text-sm">{listError}</div>}
+        {!listLoading && !listError && plans.length === 0 && (
+          <p className="text-sm text-gray-400">No plans.</p>
+        )}
+        {!listLoading && !listError && plans.length > 0 && (
+          <div className="divide-y divide-gray-100">
+            {plans.map((plan) => (
+              <button
+                key={plan.id}
+                onClick={() => setActivePlan(plan)}
+                className="w-full text-left flex items-center justify-between px-2 py-3 hover:bg-gray-50"
+              >
+                <div>
+                  <span className="font-medium text-gray-800">Plan #{plan.id}</span>
+                  {plan.osmBookingId && (
+                    <span className="ml-2 text-sm text-gray-500">Booking {plan.osmBookingId}</span>
+                  )}
+                </div>
+                <span className={`px-2 py-1 text-xs rounded-full ${statusBadgeClass(plan.status)}`}>
+                  {plan.status}
+                </span>
+              </button>
+            ))}
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -9,6 +9,7 @@ import type {
   BookingStats,
   MoveActivityRequest,
   MoveDatesRequest,
+  ProposedPlan,
 } from '../types';
 
 const apiClient = axios.create({
@@ -93,6 +94,35 @@ export const bookingsApi = {
 
   moveDates: async (id: number, req: MoveDatesRequest): Promise<BookingActionResult> => {
     const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/move-dates`, req);
+    return response.data;
+  },
+};
+
+// Plans API — LLM-drafted action plans awaiting human approval
+export const plansApi = {
+  create: async (sourceEmailText: string, osmBookingId?: string): Promise<ProposedPlan> => {
+    const response = await apiClient.post<ProposedPlan>('/plans', { sourceEmailText, osmBookingId });
+    return response.data;
+  },
+
+  list: async (status?: string): Promise<ProposedPlan[]> => {
+    const params = status ? { status } : {};
+    const response = await apiClient.get<ProposedPlan[]>('/plans', { params });
+    return response.data;
+  },
+
+  getById: async (id: number): Promise<ProposedPlan> => {
+    const response = await apiClient.get<ProposedPlan>(`/plans/${id}`);
+    return response.data;
+  },
+
+  approve: async (id: number): Promise<ProposedPlan> => {
+    const response = await apiClient.post<ProposedPlan>(`/plans/${id}/approve`);
+    return response.data;
+  },
+
+  reject: async (id: number): Promise<ProposedPlan> => {
+    const response = await apiClient.post<ProposedPlan>(`/plans/${id}/reject`);
     return response.data;
   },
 };

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -110,3 +110,50 @@ export interface AvailableSite {
   id: string;
   name: string;
 }
+
+/** Mirrors ProposedPlanDto on the backend. */
+export type PlanStatusValue = 'AwaitingApproval' | 'Executed' | 'Rejected' | 'Failed';
+
+export interface ProposedPlan {
+  id: number;
+  status: PlanStatusValue;
+  sourceEmailText?: string | null;
+  osmBookingId?: string | null;
+  /** JSON-encoded array of PlanAction, in execution order. */
+  actionsJson?: string | null;
+  /** JSON-encoded array of PlanActionExecutionResult, parallel to the actions array. */
+  executionResultJson?: string | null;
+  createdAt: string;
+}
+
+/**
+ * One entry from a ProposedPlan's ActionsJson. Fields are flat alongside "type" (mirrors the
+ * shape the LLM is prompted to produce — see PlanDraftingService on the backend). Only the
+ * fields relevant to `type` are populated; the rest are undefined.
+ */
+export interface PlanAction {
+  type: string;
+  /** draftEmailReply / postComment */
+  text?: string;
+  /** moveDates */
+  dayShift?: number;
+  /** changeSite / moveActivity */
+  itemId?: string;
+  /** changeSite */
+  newSiteId?: string;
+  newSiteName?: string;
+  /** moveActivity */
+  newStartDate?: string;
+  newStartTime?: string;
+  newEndTime?: string;
+  /** moveDates / changeSite / moveActivity */
+  note?: string;
+}
+
+/** Mirrors PlanActionExecutionResult on the backend. One per action, in order. */
+export interface PlanActionExecutionResult {
+  type: string;
+  /** One of: "succeeded", "failed", "not_attempted". */
+  status: 'succeeded' | 'failed' | 'not_attempted';
+  reason?: string | null;
+}

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.10.0
+version: 0.11.0
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper
@@ -25,6 +25,9 @@ options:
   gate_code_from_email: ""
   gate_code_subject: "Gate code"
   api_token: ""
+  open_webui_base_url: ""
+  open_webui_api_key: ""
+  open_webui_model: ""
 schema:
   osm_base_url: url
   osm_campsite_id: str
@@ -37,4 +40,7 @@ schema:
   gate_code_from_email: email
   gate_code_subject: str
   api_token: password
+  open_webui_base_url: url
+  open_webui_api_key: password
+  open_webui_model: str
 image: ghcr.io/piers-williams/bookings-assistant-{arch}

--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -14,6 +14,9 @@ if [ -f /data/options.json ]; then
     export GateCode__FromEmail=$(jq -r '.gate_code_from_email // ""' /data/options.json)
     export GateCode__Subject=$(jq -r '.gate_code_subject // "Gate code"' /data/options.json)
     export Auth__ApiToken=$(jq -r '.api_token // ""' /data/options.json)
+    export OpenWebUi__BaseUrl=$(jq -r '.open_webui_base_url // ""' /data/options.json)
+    export OpenWebUi__ApiKey=$(jq -r '.open_webui_api_key // ""' /data/options.json)
+    export OpenWebUi__Model=$(jq -r '.open_webui_model // ""' /data/options.json)
     echo "Options loaded from /data/options.json"
 else
     echo "No /data/options.json found, using defaults"


### PR DESCRIPTION
## Summary

Support staff currently have to manually read a customer email, decide what to do about it (reply, note it on the booking, move dates, etc.), and carry out each OSM action by hand. This change adds an LLM-assisted "Triage" workflow: paste a customer email in, get back a proposed action plan, and — after a human approves it — have the plan executed against OSM automatically. It turns a multi-step manual process into paste → review → approve.

## Approach

Delivered in four TDD-driven chunks, each independently green before the next started:

1. **plan-model** — `ProposedPlan` entity/migration and a read-only `PlansController` (list with status filter, get-by-id), establishing the state machine (`AwaitingApproval` → `Executed`/`Rejected`/`Failed`) before any LLM code existed.
2. **plan-drafting** — `IOpenWebUiClient` (thin HTTP client for Open WebUI's OpenAI-compatible chat endpoint) and `PlanDraftingService`, which builds a prompt (with optional booking context pulled from the DB/OSM), validates the LLM's JSON response against a fixed action schema, and retries once before giving up.
3. **plan-execution** — before wiring up execution, the shared move-activity/change-site/move-dates dispatch logic was extracted out of `BookingActionsController` into a new `IBookingItemActionService`, so both the human-triggered REST endpoints and the LLM-approved plan path share one mutation/audit-comment code path instead of duplicating it. `PlanExecutionService` maps each drafted action onto that shared service (or directly onto `IOsmService` for comment/email actions), stopping at the first failure and recording a per-action result.
4. **triage-ui** — a new `/triage` page: a draft form, a plan detail view (`draftEmailReply` actions render as copyable text; OSM actions render as human-readable descriptions with per-action success/failure/not-attempted badges), and a status-filterable plan list with approve/reject buttons.

Key tradeoff: the LLM is never allowed to touch OSM directly. `PlanExecutionService` only ever runs after a human clicks Approve, and the drafted actions (plus, for OSM actions, execution outcomes) are always visible before/after execution.

A Final Review pass (quality gate + security review) caught two real issues before merge, both now fixed and re-verified:
- `SourceEmailText` (the raw pasted email) wasn't purged when LLM drafting failed outright, which could retain customer PII indefinitely — fixed, with a regression test.
- A TOCTOU race let `/approve` (or `/reject`) be called twice concurrently and execute a plan's OSM actions twice — fixed with an atomic claim step (`PlanTransitionLock` + a transient `Processing` status), verified with real concurrent-request tests. A follow-up startup sweep also recovers any plan that gets stuck in `Processing` (e.g. after a crash mid-execution) back to a safe `Failed` state.

## Key decisions

- **Human-in-the-loop by construction, not convention** — there is no code path where a drafted plan reaches OSM without a human clicking Approve.
- **Stop-at-first-failure execution** — actions run in order; once one fails, the rest are recorded as `not_attempted` rather than attempting all and reporting a mixed bag, keeping the audit trail easy to reason about.
- **Retry-once on invalid LLM output** — the LLM gets one chance to self-correct (fed back the validation failure reason) before the plan is marked `Failed`.
- **PII minimization via purge-on-resolution** — `SourceEmailText` is nulled out on every path that reaches a terminal plan state (approve success/failure, reject, drafting failure, and the stale-`Processing` recovery sweep).
- **Single-process concurrency guard** — `PlanTransitionLock` is a singleton semaphore, sufficient for this app's single-container Home Assistant addon deployment; not designed for horizontal scaling.
- **Refactor before extending, not alongside** — `IBookingItemActionService` was extracted from `BookingActionsController` in its own commit, verified against the pre-existing test suite before building the execution slice on top of it.

## Testing strategy

- Backend: `WebApplicationFactory`-based integration tests per endpoint group (`PlanListTests`, `PlanDetailTests`, `PlanCreateTests`, `PlanApprovalTests`, `PlanStaleRecoveryTests`, `OpenWebUiClientTests`), using fakes for `IOsmService` and `IOpenWebUiClient` to drive both happy paths and failure modes (malformed JSON, unknown action type, retry-then-succeed, missing booking id, concurrent approve/reject) without any real network calls. Assertions check both the HTTP response and the persisted DB row.
- Frontend: `Triage.test.tsx` drives the whole UI flow through Testing Library — drafting, listing/filtering, opening a plan, approving/rejecting, and rendering both `draftEmailReply` (copyable text) and OSM-action outcomes (including a partial-failure plan with succeeded/failed/not_attempted actions side by side).
- Full backend suite: 184/184 passing (all new + all pre-existing, including the unmodified `BookingActionsController` suite confirming the mutation-logic extraction preserved behavior exactly). Full frontend suite: 44/44 passing, `npm run build` + `npm run lint` clean.

## Review guidance

- **Worth a second look, not blocking:** the action-type schema (fields per action) is independently duplicated across `PlanDraftingService`, `PlanExecutionService`, and the frontend `PlanAction` type — fine at 6 action types today, a maintenance risk as more are added.
- **Trust the tests, verify the config in a real deploy:** the new `OpenWebUi:BaseUrl/ApiKey/Model` HA addon options (wired through `entrypoint.sh`/`config.yaml`) are the one part of this diff with no automated coverage — worth a manual smoke check against a real Open WebUI instance after deploy.
- **Straightforward:** the `BookingActionsController` → `IBookingItemActionService` extraction (mechanical, proven by unchanged existing tests) and the plan-model CRUD slice.

[release-note][/release-note]