### PR TITLE
Expand AI plan actions: add/remove activity, change numbers, check availability

### DIFF
--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -104,6 +104,44 @@ public class BookingActionsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Read-only check of whether a site/activity item-type has an available slot for the
+    /// given date range. Unlike the mutation endpoints below, "not available" is a normal 200
+    /// result (AvailabilityResult.Available = false) — it is not treated as an error.
+    /// </summary>
+    [HttpGet("{id}/availability")]
+    public async Task<ActionResult<AvailabilityResult>> CheckAvailability(
+        int id, [FromQuery] string? activityId, [FromQuery] DateTime? startDate, [FromQuery] DateTime? endDate)
+    {
+        if (string.IsNullOrWhiteSpace(activityId))
+            return BadRequest(new { message = "activityId is required" });
+
+        if (startDate is null)
+            return BadRequest(new { message = "startDate is required" });
+
+        if (endDate is null)
+            return BadRequest(new { message = "endDate is required" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var result = await _osmService.CheckAvailabilityAsync(booking.OsmBookingId, activityId, startDate.Value, endDate.Value);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error checking availability for booking {Id}", id);
+            return StatusCode(502, new { message = "Error checking availability with OSM", detail = ex.Message });
+        }
+    }
+
     // ── Error mapping convention for mutation endpoints ───────────────────────
     // - 400 Bad Request: missing/invalid request parameters (checked before OSM calls)
     // - 404 Not Found: booking not in DB, or item not in booking's current item list

--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -285,4 +285,44 @@ public class BookingActionsController : ControllerBase
             return StatusCode(502, new { message = "Error executing remove-activity", detail = ex.Message });
         }
     }
+
+    /// <summary>
+    /// Changes the headcount (number of people) on an existing item. Uses the same
+    /// clone-then-delete-original engine as move-activity/change-site.
+    /// </summary>
+    [HttpPost("{id}/actions/change-numbers")]
+    public async Task<ActionResult<BookingActionResult>> ChangeNumbers(int id, [FromBody] ChangeNumbersRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ItemId))
+            return BadRequest(new { message = "ItemId is required" });
+
+        // Upper bound intentionally omitted: OSM enforces its own per-site/per-activity
+        // capacity limits, which surface as a 502 (OSM rejected the create) rather than a
+        // client-side guess we can't validate without visibility into pitch capacity.
+        if (request.NewNumberPeople is null or <= 0)
+            return BadRequest(new { message = "NewNumberPeople is required and must be greater than zero" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var result = await _itemActionService.ChangeNumbersAsync(booking.OsmBookingId, request);
+            return Ok(result);
+        }
+        catch (BookingItemNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during change-numbers for booking {Id}", id);
+            return StatusCode(502, new { message = "Error executing change-numbers", detail = ex.Message });
+        }
+    }
 }

--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -251,4 +251,38 @@ public class BookingActionsController : ControllerBase
             return StatusCode(502, new { message = "Error executing add-activity", detail = ex.Message });
         }
     }
+
+    /// <summary>
+    /// Removes (hard-deletes) an existing item — activity or site — from the booking. No
+    /// replacement is created; this is a straight delete of an existing item.
+    /// </summary>
+    [HttpPost("{id}/actions/remove-activity")]
+    public async Task<ActionResult<BookingActionResult>> RemoveActivity(int id, [FromBody] RemoveActivityRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ItemId))
+            return BadRequest(new { message = "ItemId is required" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var result = await _itemActionService.RemoveActivityAsync(booking.OsmBookingId, request);
+            return Ok(result);
+        }
+        catch (BookingItemNotFoundException ex)
+        {
+            return NotFound(new { message = ex.Message });
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during remove-activity for booking {Id}", id);
+            return StatusCode(502, new { message = "Error executing remove-activity", detail = ex.Message });
+        }
+    }
 }

--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -267,8 +267,8 @@ public class BookingActionsController : ControllerBase
         if (request.EndDate is null)
             return BadRequest(new { message = "EndDate is required" });
 
-        if (request.NumberPeople is null)
-            return BadRequest(new { message = "NumberPeople is required" });
+        if (request.NumberPeople is null or <= 0)
+            return BadRequest(new { message = "NumberPeople is required and must be greater than zero" });
 
         var booking = await _context.OsmBookings.FindAsync(id);
         if (booking == null)

--- a/BookingsAssistant.Api/Controllers/BookingActionsController.cs
+++ b/BookingsAssistant.Api/Controllers/BookingActionsController.cs
@@ -78,6 +78,32 @@ public class BookingActionsController : ControllerBase
         }
     }
 
+    /// <summary>
+    /// Lists the bookable activities that could be added to the booking (for add-activity).
+    /// </summary>
+    [HttpGet("{id}/available-activities")]
+    public async Task<ActionResult<List<AvailableSiteDto>>> GetAvailableActivities(int id)
+    {
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var activities = await _osmService.GetAvailableActivitiesAsync(booking.OsmBookingId);
+            return Ok(activities);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error fetching available activities for booking {Id}", id);
+            return StatusCode(502, new { message = "Error fetching activities from OSM", detail = ex.Message });
+        }
+    }
+
     // ── Error mapping convention for mutation endpoints ───────────────────────
     // - 400 Bad Request: missing/invalid request parameters (checked before OSM calls)
     // - 404 Not Found: booking not in DB, or item not in booking's current item list
@@ -184,6 +210,45 @@ public class BookingActionsController : ControllerBase
         {
             _logger.LogError(ex, "Error during move-dates for booking {Id}", id);
             return StatusCode(502, new { message = "Error executing move-dates", detail = ex.Message });
+        }
+    }
+
+    /// <summary>
+    /// Adds a brand-new activity item to the booking (no existing item to clone — the create
+    /// spec is built entirely from the request).
+    /// </summary>
+    [HttpPost("{id}/actions/add-activity")]
+    public async Task<ActionResult<BookingActionResult>> AddActivity(int id, [FromBody] AddActivityRequest request)
+    {
+        if (string.IsNullOrWhiteSpace(request.ActivityId))
+            return BadRequest(new { message = "ActivityId is required" });
+
+        if (request.StartDate is null)
+            return BadRequest(new { message = "StartDate is required" });
+
+        if (request.EndDate is null)
+            return BadRequest(new { message = "EndDate is required" });
+
+        if (request.NumberPeople is null)
+            return BadRequest(new { message = "NumberPeople is required" });
+
+        var booking = await _context.OsmBookings.FindAsync(id);
+        if (booking == null)
+            return NotFound();
+
+        try
+        {
+            var result = await _itemActionService.AddActivityAsync(booking.OsmBookingId, request);
+            return Ok(result);
+        }
+        catch (InvalidOperationException ex) when (ex.Message.Contains("OSM"))
+        {
+            return Unauthorized(new { message = "OSM authentication required", detail = ex.Message });
+        }
+        catch (Exception ex)
+        {
+            _logger.LogError(ex, "Error during add-activity for booking {Id}", id);
+            return StatusCode(502, new { message = "Error executing add-activity", detail = ex.Message });
         }
     }
 }

--- a/BookingsAssistant.Api/Controllers/PlansController.cs
+++ b/BookingsAssistant.Api/Controllers/PlansController.cs
@@ -53,6 +53,7 @@ public class PlansController : ControllerBase
                 SourceEmailText = p.SourceEmailText,
                 OsmBookingId = p.OsmBookingId,
                 ActionsJson = p.ActionsJson,
+                DraftWarning = p.DraftWarning,
                 ExecutionResultJson = p.ExecutionResultJson,
                 CreatedAt = p.CreatedAt
             })
@@ -124,6 +125,7 @@ public class PlansController : ControllerBase
         if (draftResult is { Success: true })
         {
             plan.ActionsJson = draftResult.ActionsJson;
+            plan.DraftWarning = draftResult.Warning;
         }
         else
         {
@@ -219,6 +221,7 @@ public class PlansController : ControllerBase
         SourceEmailText = plan.SourceEmailText,
         OsmBookingId = plan.OsmBookingId,
         ActionsJson = plan.ActionsJson,
+        DraftWarning = plan.DraftWarning,
         ExecutionResultJson = plan.ExecutionResultJson,
         CreatedAt = plan.CreatedAt
     };

--- a/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
+++ b/BookingsAssistant.Api/Data/Entities/ProposedPlan.cs
@@ -39,6 +39,16 @@ public class ProposedPlan
     public string? ActionsJson { get; set; }
 
     /// <summary>
+    /// Set when plan drafting completed successfully but an automatic availability pre-check
+    /// (see PlanDraftingService) found a date-carrying action (currently addActivity) whose
+    /// slot was still unavailable after the one retry the drafting flow allows itself. Drafting
+    /// does not fail in this case — the plan is saved as normal — but a human reviewing it in
+    /// the Triage UI should see this warning before approving. Null when no conflict was found
+    /// (the common case) or the plan predates this field.
+    /// </summary>
+    public string? DraftWarning { get; set; }
+
+    /// <summary>
     /// Per-action execution outcomes, set once the plan has been approved and executed
     /// (or the attempt failed partway through). JSON array of objects shaped like
     /// { type, status, reason? } — one entry per action in ActionsJson, in the same order.

--- a/BookingsAssistant.Api/Migrations/20260725103312_AddProposedPlanDraftWarning.Designer.cs
+++ b/BookingsAssistant.Api/Migrations/20260725103312_AddProposedPlanDraftWarning.Designer.cs
@@ -3,6 +3,7 @@ using System;
 using BookingsAssistant.Api.Data;
 using Microsoft.EntityFrameworkCore;
 using Microsoft.EntityFrameworkCore.Infrastructure;
+using Microsoft.EntityFrameworkCore.Migrations;
 using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 #nullable disable
@@ -10,9 +11,11 @@ using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 namespace BookingsAssistant.Api.Migrations
 {
     [DbContext(typeof(ApplicationDbContext))]
-    partial class ApplicationDbContextModelSnapshot : ModelSnapshot
+    [Migration("20260725103312_AddProposedPlanDraftWarning")]
+    partial class AddProposedPlanDraftWarning
     {
-        protected override void BuildModel(ModelBuilder modelBuilder)
+        /// <inheritdoc />
+        protected override void BuildTargetModel(ModelBuilder modelBuilder)
         {
 #pragma warning disable 612, 618
             modelBuilder.HasAnnotation("ProductVersion", "8.0.11");

--- a/BookingsAssistant.Api/Migrations/20260725103312_AddProposedPlanDraftWarning.cs
+++ b/BookingsAssistant.Api/Migrations/20260725103312_AddProposedPlanDraftWarning.cs
@@ -1,0 +1,28 @@
+﻿using Microsoft.EntityFrameworkCore.Migrations;
+
+#nullable disable
+
+namespace BookingsAssistant.Api.Migrations
+{
+    /// <inheritdoc />
+    public partial class AddProposedPlanDraftWarning : Migration
+    {
+        /// <inheritdoc />
+        protected override void Up(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.AddColumn<string>(
+                name: "DraftWarning",
+                table: "ProposedPlans",
+                type: "TEXT",
+                nullable: true);
+        }
+
+        /// <inheritdoc />
+        protected override void Down(MigrationBuilder migrationBuilder)
+        {
+            migrationBuilder.DropColumn(
+                name: "DraftWarning",
+                table: "ProposedPlans");
+        }
+    }
+}

--- a/BookingsAssistant.Api/Models/AddActivityRequest.cs
+++ b/BookingsAssistant.Api/Models/AddActivityRequest.cs
@@ -1,0 +1,21 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// Adds a brand-new activity item to a booking. Unlike MoveActivityRequest/ChangeSiteRequest
+/// (which clone an existing item), there is no original item here — every field needed to
+/// build the OSM create spec from scratch must be supplied.
+/// </summary>
+public class AddActivityRequest
+{
+    /// <summary>The activity item-TYPE id (OSM campsite_item_id) to add, e.g. from GetAvailableActivitiesAsync.</summary>
+    public string ActivityId { get; set; } = string.Empty;
+
+    public DateTime? StartDate { get; set; }
+    public DateTime? EndDate { get; set; }
+    public string? StartTime { get; set; }
+    public string? EndTime { get; set; }
+    public int? NumberPeople { get; set; }
+
+    /// <summary>Optional free-text note appended to the auto-generated audit comment.</summary>
+    public string? Note { get; set; }
+}

--- a/BookingsAssistant.Api/Models/AvailabilityResult.cs
+++ b/BookingsAssistant.Api/Models/AvailabilityResult.cs
@@ -1,0 +1,17 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// The outcome of a read-only availability check for an item-type (site or activity) over a
+/// date range (the "checkAvailability" action). Unlike every other action in this feature set,
+/// checking availability never creates/modifies/deletes anything in OSM — it only reports what
+/// OSM's availability endpoint says. A false <see cref="Available"/> is a normal, successful
+/// result (see <see cref="Reason"/>), not an error.
+/// </summary>
+public class AvailabilityResult
+{
+    /// <summary>True when a slot covers the requested start/end date window.</summary>
+    public bool Available { get; set; }
+
+    /// <summary>Present when <see cref="Available"/> is false — a human-readable explanation.</summary>
+    public string? Reason { get; set; }
+}

--- a/BookingsAssistant.Api/Models/ChangeNumbersRequest.cs
+++ b/BookingsAssistant.Api/Models/ChangeNumbersRequest.cs
@@ -1,0 +1,16 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// Changes the headcount (number of people) on an existing booking item. Like
+/// MoveActivityRequest/ChangeSiteRequest, this clones the original item (via
+/// IBookingMutationService.ReplaceItemsAsync) with NumberPeople overridden, then deletes
+/// the original — it does not mutate the item in place.
+/// </summary>
+public class ChangeNumbersRequest
+{
+    public string ItemId { get; set; } = string.Empty;
+    public int? NewNumberPeople { get; set; }
+
+    /// <summary>Optional free-text note appended to the auto-generated audit comment.</summary>
+    public string? Note { get; set; }
+}

--- a/BookingsAssistant.Api/Models/ItemReplacement.cs
+++ b/BookingsAssistant.Api/Models/ItemReplacement.cs
@@ -24,4 +24,7 @@ public class ItemReplacement
 
     /// <summary>If set, overrides the EndTime on the cloned item.</summary>
     public string? NewEndTime { get; set; }
+
+    /// <summary>If set, overrides the NumberPeople on the cloned item.</summary>
+    public int? NewNumberPeople { get; set; }
 }

--- a/BookingsAssistant.Api/Models/PlanActionExecutionResult.cs
+++ b/BookingsAssistant.Api/Models/PlanActionExecutionResult.cs
@@ -25,4 +25,11 @@ public class PlanActionExecutionResult
 
     /// <summary>Present when Status is "failed" — a human-readable explanation.</summary>
     public string? Reason { get; set; }
+
+    /// <summary>
+    /// Present for actions that produce a result beyond success/failure (currently only
+    /// "checkAvailability" — e.g. "Available" or "Not available: no slot covers 12-14 Aug").
+    /// Unlike <see cref="Reason"/>, this is populated on a "succeeded" outcome too.
+    /// </summary>
+    public string? Detail { get; set; }
 }

--- a/BookingsAssistant.Api/Models/ProposedPlanDto.cs
+++ b/BookingsAssistant.Api/Models/ProposedPlanDto.cs
@@ -7,6 +7,7 @@ public class ProposedPlanDto
     public string? SourceEmailText { get; set; }
     public string? OsmBookingId { get; set; }
     public string? ActionsJson { get; set; }
+    public string? DraftWarning { get; set; }
     public string? ExecutionResultJson { get; set; }
     public DateTime CreatedAt { get; set; }
 }

--- a/BookingsAssistant.Api/Models/RemoveActivityRequest.cs
+++ b/BookingsAssistant.Api/Models/RemoveActivityRequest.cs
@@ -1,0 +1,14 @@
+namespace BookingsAssistant.Api.Models;
+
+/// <summary>
+/// Removes (hard-deletes) an existing booking item — activity or site. Unlike
+/// MoveActivityRequest/ChangeSiteRequest, there is no replacement item: the original is
+/// resolved by ItemId and deleted directly via IOsmService.DeleteBookingItemAsync.
+/// </summary>
+public class RemoveActivityRequest
+{
+    public string ItemId { get; set; } = string.Empty;
+
+    /// <summary>Optional free-text note appended to the auto-generated audit comment.</summary>
+    public string? Note { get; set; }
+}

--- a/BookingsAssistant.Api/Services/BookingActionCommentComposer.cs
+++ b/BookingsAssistant.Api/Services/BookingActionCommentComposer.cs
@@ -37,6 +37,18 @@ public static class BookingActionCommentComposer
     public static string ComposeMoveDatesSummary(MoveDatesRequest request)
         => AppendNote($"Dates shifted by {request.DayShift} day(s).", request.Note);
 
+    public static string ComposeAddActivitySummary(AddActivityRequest request)
+    {
+        var when = $"{FormatDate(request.StartDate)} → {FormatDate(request.EndDate)}";
+        var time = request.StartTime != null || request.EndTime != null
+            ? $", {request.StartTime ?? "—"}-{request.EndTime ?? "—"}"
+            : string.Empty;
+
+        return AppendNote(
+            $"Added activity (item type {request.ActivityId}): {when}{time}, {request.NumberPeople ?? 0} people.",
+            request.Note);
+    }
+
     private static string FormatDate(DateTime? date)
         => date.HasValue ? date.Value.ToString("d MMM yyyy") : "—";
 

--- a/BookingsAssistant.Api/Services/BookingActionCommentComposer.cs
+++ b/BookingsAssistant.Api/Services/BookingActionCommentComposer.cs
@@ -49,6 +49,9 @@ public static class BookingActionCommentComposer
             request.Note);
     }
 
+    public static string ComposeRemoveActivitySummary(BookingItemDto original, RemoveActivityRequest request)
+        => AppendNote($"Removed '{original.Label}'.", request.Note);
+
     private static string FormatDate(DateTime? date)
         => date.HasValue ? date.Value.ToString("d MMM yyyy") : "—";
 

--- a/BookingsAssistant.Api/Services/BookingActionCommentComposer.cs
+++ b/BookingsAssistant.Api/Services/BookingActionCommentComposer.cs
@@ -52,6 +52,11 @@ public static class BookingActionCommentComposer
     public static string ComposeRemoveActivitySummary(BookingItemDto original, RemoveActivityRequest request)
         => AppendNote($"Removed '{original.Label}'.", request.Note);
 
+    public static string ComposeChangeNumbersSummary(BookingItemDto original, ChangeNumbersRequest request)
+        => AppendNote(
+            $"Number of people changed for '{original.Label}': {original.NumberPeople ?? 0} → {request.NewNumberPeople ?? 0}.",
+            request.Note);
+
     private static string FormatDate(DateTime? date)
         => date.HasValue ? date.Value.ToString("d MMM yyyy") : "—";
 

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -125,6 +125,7 @@ public class BookingItemActionService : IBookingItemActionService
         // return means OSM declined the delete without erroring, which we surface as a Failed
         // result rather than reporting success.
         var deleted = await _osmService.DeleteBookingItemAsync(osmBookingId, item.ItemId);
+        var itemsAfter = await GetItemsSafeAsync(osmBookingId);
 
         var result = deleted
             ? new BookingActionResult
@@ -133,7 +134,7 @@ public class BookingItemActionService : IBookingItemActionService
                 Created = new List<string>(),
                 Deleted = new List<string> { item.ItemId },
                 Message = $"Removed '{item.Label}'.",
-                Items = await GetItemsSafeAsync(osmBookingId)
+                Items = itemsAfter
             }
             : new BookingActionResult
             {
@@ -141,7 +142,7 @@ public class BookingItemActionService : IBookingItemActionService
                 Created = new List<string>(),
                 Deleted = new List<string>(),
                 Message = $"Failed to remove '{item.Label}': OSM declined the delete.",
-                Items = await GetItemsSafeAsync(osmBookingId)
+                Items = itemsAfter
             };
 
         var summary = BookingActionCommentComposer.ComposeRemoveActivitySummary(item, request);

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -150,6 +150,24 @@ public class BookingItemActionService : IBookingItemActionService
         return result;
     }
 
+    public async Task<BookingActionResult> ChangeNumbersAsync(string osmBookingId, ChangeNumbersRequest request)
+    {
+        var items = await _osmService.GetBookingItemsAsync(osmBookingId);
+        var item = items.FirstOrDefault(i => i.ItemId == request.ItemId)
+            ?? throw new BookingItemNotFoundException(request.ItemId, osmBookingId);
+
+        var replacement = new ItemReplacement
+        {
+            Original = item,
+            NewNumberPeople = request.NewNumberPeople
+        };
+
+        var result = await _mutationService.ReplaceItemsAsync(osmBookingId, new[] { replacement });
+        var summary = BookingActionCommentComposer.ComposeChangeNumbersSummary(item, request);
+        await PostAuditCommentAsync(osmBookingId, result, summary);
+        return result;
+    }
+
     /// <summary>Best-effort fetch of the booking's current items; returns empty on failure rather than throwing.</summary>
     private async Task<List<BookingItemDto>> GetItemsSafeAsync(string osmBookingId)
     {

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -178,7 +178,7 @@ public class BookingItemActionService : IBookingItemActionService
         catch (Exception ex)
         {
             _logger.LogWarning(ex,
-                "AddActivityAsync: could not fetch items after operation for booking {BookingId}",
+                "GetItemsSafeAsync: could not fetch items after operation for booking {BookingId}",
                 osmBookingId);
             return new List<BookingItemDto>();
         }

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -83,6 +83,53 @@ public class BookingItemActionService : IBookingItemActionService
         return result;
     }
 
+    public async Task<BookingActionResult> AddActivityAsync(string osmBookingId, AddActivityRequest request)
+    {
+        // No original item here (unlike MoveActivity/ChangeSite/MoveDates, which clone one via
+        // IBookingMutationService) — build the create spec straight from the request and create
+        // it directly. A create failure propagates as-is; there's nothing created yet to roll back.
+        var spec = new BookingItemCreateSpec
+        {
+            CampsiteItemId = request.ActivityId,
+            StartDate = request.StartDate,
+            EndDate = request.EndDate,
+            StartTime = request.StartTime,
+            EndTime = request.EndTime,
+            NumberPeople = request.NumberPeople
+        };
+
+        var newItemId = await _osmService.CreateBookingItemAsync(osmBookingId, spec);
+
+        var result = new BookingActionResult
+        {
+            Status = BookingActionStatus.Completed,
+            Created = new List<string> { newItemId },
+            Deleted = new List<string>(),
+            Message = $"Added new activity item {newItemId}.",
+            Items = await GetItemsSafeAsync(osmBookingId)
+        };
+
+        var summary = BookingActionCommentComposer.ComposeAddActivitySummary(request);
+        await PostAuditCommentAsync(osmBookingId, result, summary);
+        return result;
+    }
+
+    /// <summary>Best-effort fetch of the booking's current items; returns empty on failure rather than throwing.</summary>
+    private async Task<List<BookingItemDto>> GetItemsSafeAsync(string osmBookingId)
+    {
+        try
+        {
+            return await _osmService.GetBookingItemsAsync(osmBookingId);
+        }
+        catch (Exception ex)
+        {
+            _logger.LogWarning(ex,
+                "AddActivityAsync: could not fetch items after operation for booking {BookingId}",
+                osmBookingId);
+            return new List<BookingItemDto>();
+        }
+    }
+
     // ── Audit-trail comment posting ───────────────────────────────────────────
     // Runs after a mutation completes. Posts the given summary as an OSM comment and
     // persists it locally (same shape as BookingsController.PostComment) so it shows up

--- a/BookingsAssistant.Api/Services/BookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/BookingItemActionService.cs
@@ -114,6 +114,41 @@ public class BookingItemActionService : IBookingItemActionService
         return result;
     }
 
+    public async Task<BookingActionResult> RemoveActivityAsync(string osmBookingId, RemoveActivityRequest request)
+    {
+        var items = await _osmService.GetBookingItemsAsync(osmBookingId);
+        var item = items.FirstOrDefault(i => i.ItemId == request.ItemId)
+            ?? throw new BookingItemNotFoundException(request.ItemId, osmBookingId);
+
+        // No replacement created here (unlike MoveActivity/ChangeSite) — a straight delete of an
+        // existing item. A thrown OSM exception (e.g. auth failure) propagates as-is; a `false`
+        // return means OSM declined the delete without erroring, which we surface as a Failed
+        // result rather than reporting success.
+        var deleted = await _osmService.DeleteBookingItemAsync(osmBookingId, item.ItemId);
+
+        var result = deleted
+            ? new BookingActionResult
+            {
+                Status = BookingActionStatus.Completed,
+                Created = new List<string>(),
+                Deleted = new List<string> { item.ItemId },
+                Message = $"Removed '{item.Label}'.",
+                Items = await GetItemsSafeAsync(osmBookingId)
+            }
+            : new BookingActionResult
+            {
+                Status = BookingActionStatus.Failed,
+                Created = new List<string>(),
+                Deleted = new List<string>(),
+                Message = $"Failed to remove '{item.Label}': OSM declined the delete.",
+                Items = await GetItemsSafeAsync(osmBookingId)
+            };
+
+        var summary = BookingActionCommentComposer.ComposeRemoveActivitySummary(item, request);
+        await PostAuditCommentAsync(osmBookingId, result, summary);
+        return result;
+    }
+
     /// <summary>Best-effort fetch of the booking's current items; returns empty on failure rather than throwing.</summary>
     private async Task<List<BookingItemDto>> GetItemsSafeAsync(string osmBookingId)
     {

--- a/BookingsAssistant.Api/Services/BookingMutationService.cs
+++ b/BookingsAssistant.Api/Services/BookingMutationService.cs
@@ -162,7 +162,7 @@ public class BookingMutationService : IBookingMutationService
             EndDate = replacement.NewEndDate ?? original.EndDate,
             StartTime = replacement.NewStartTime ?? original.StartTime,
             EndTime = replacement.NewEndTime ?? original.EndTime,
-            NumberPeople = original.NumberPeople,
+            NumberPeople = replacement.NewNumberPeople ?? original.NumberPeople,
             QuestionAnswers = original.Questions.ToDictionary(q => q.QuestionDefId, q => q.Answer)
         };
     }

--- a/BookingsAssistant.Api/Services/IBookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/IBookingItemActionService.cs
@@ -24,4 +24,11 @@ public interface IBookingItemActionService
 
     /// <summary>Shifts every item in the booking by the given number of days.</summary>
     Task<BookingActionResult> MoveDatesAsync(string osmBookingId, MoveDatesRequest request);
+
+    /// <summary>
+    /// Adds a brand-new activity item to the booking. Unlike the other actions here, there is
+    /// no original item to resolve or clone from — the create spec is built entirely from
+    /// <paramref name="request"/> and created directly via IOsmService.CreateBookingItemAsync.
+    /// </summary>
+    Task<BookingActionResult> AddActivityAsync(string osmBookingId, AddActivityRequest request);
 }

--- a/BookingsAssistant.Api/Services/IBookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/IBookingItemActionService.cs
@@ -31,4 +31,12 @@ public interface IBookingItemActionService
     /// <paramref name="request"/> and created directly via IOsmService.CreateBookingItemAsync.
     /// </summary>
     Task<BookingActionResult> AddActivityAsync(string osmBookingId, AddActivityRequest request);
+
+    /// <summary>
+    /// Removes (hard-deletes) an existing item — activity or site — from the booking. Unlike
+    /// the other actions here, there is no replacement created: the item is resolved via
+    /// ItemId and deleted directly via IOsmService.DeleteBookingItemAsync. Throws
+    /// <see cref="BookingItemNotFoundException"/> if ItemId isn't in the booking.
+    /// </summary>
+    Task<BookingActionResult> RemoveActivityAsync(string osmBookingId, RemoveActivityRequest request);
 }

--- a/BookingsAssistant.Api/Services/IBookingItemActionService.cs
+++ b/BookingsAssistant.Api/Services/IBookingItemActionService.cs
@@ -39,4 +39,11 @@ public interface IBookingItemActionService
     /// <see cref="BookingItemNotFoundException"/> if ItemId isn't in the booking.
     /// </summary>
     Task<BookingActionResult> RemoveActivityAsync(string osmBookingId, RemoveActivityRequest request);
+
+    /// <summary>
+    /// Changes the headcount (number of people) on an existing item. Uses the same
+    /// clone-then-delete-original engine as MoveActivity/ChangeSite. Throws
+    /// <see cref="BookingItemNotFoundException"/> if ItemId isn't in the booking.
+    /// </summary>
+    Task<BookingActionResult> ChangeNumbersAsync(string osmBookingId, ChangeNumbersRequest request);
 }

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -50,6 +50,15 @@ public interface IOsmService
     /// </summary>
     Task<List<AvailableSiteDto>> GetAvailableActivitiesAsync(string osmBookingId);
 
+    /// <summary>
+    /// Read-only check of whether an item-type (site or activity) has an available slot for
+    /// the given date range. Reuses the same per-item availability endpoint and slot-resolution
+    /// logic as <see cref="CreateBookingItemAsync"/>, but never creates anything. A "no slot"
+    /// outcome is reported via <see cref="AvailabilityResult.Available"/> = false, not an
+    /// exception — only OSM/auth failures throw.
+    /// </summary>
+    Task<AvailabilityResult> CheckAvailabilityAsync(string osmBookingId, string campsiteItemId, DateTime startDate, DateTime endDate);
+
     // Auth
     string GetAuthorizationUrl(string redirectUri);
     Task<bool> HandleOAuthCallbackAsync(string code, int userId, string redirectUri);

--- a/BookingsAssistant.Api/Services/IOsmService.cs
+++ b/BookingsAssistant.Api/Services/IOsmService.cs
@@ -44,6 +44,12 @@ public interface IOsmService
     /// </summary>
     Task<List<AvailableSiteDto>> GetAvailableSitesAsync(string osmBookingId);
 
+    /// <summary>
+    /// Lists the bookable activities that can be added to a booking (for add-activity),
+    /// sourced from the same OSM item-type catalogue as <see cref="GetAvailableSitesAsync"/>.
+    /// </summary>
+    Task<List<AvailableSiteDto>> GetAvailableActivitiesAsync(string osmBookingId);
+
     // Auth
     string GetAuthorizationUrl(string redirectUri);
     Task<bool> HandleOAuthCallbackAsync(string code, int userId, string redirectUri);

--- a/BookingsAssistant.Api/Services/IPlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/IPlanDraftingService.cs
@@ -26,6 +26,16 @@ public class PlanDraftResult
     public string? ActionsJson { get; init; }
     public string? FailureReason { get; init; }
 
-    public static PlanDraftResult Ok(string actionsJson) => new() { Success = true, ActionsJson = actionsJson };
+    /// <summary>
+    /// Set on an otherwise-successful result when the automatic availability pre-check found a
+    /// date-carrying action (e.g. addActivity) whose slot was still unavailable after the one
+    /// retry drafting allows itself. Drafting still succeeds (<see cref="Success"/> is true) —
+    /// the caller should copy this onto <c>ProposedPlan.DraftWarning</c> so a human reviewing
+    /// the plan sees it before approving. Null in the common case (no conflict, or not checked).
+    /// </summary>
+    public string? Warning { get; init; }
+
+    public static PlanDraftResult Ok(string actionsJson, string? warning = null) =>
+        new() { Success = true, ActionsJson = actionsJson, Warning = warning };
     public static PlanDraftResult Fail(string reason) => new() { Success = false, FailureReason = reason };
 }

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -329,6 +329,26 @@ internal class OsmService : IOsmService
         return ParseAvailableSites(await response.Content.ReadAsStringAsync());
     }
 
+    public async Task<List<AvailableSiteDto>> GetAvailableActivitiesAsync(string osmBookingId)
+    {
+        // Same catalogue endpoint as GetAvailableSitesAsync, filtered to the "Activities"
+        // category instead. See ParseAvailableActivities.
+        var url = $"/v3/campsites/{_campsiteId}/items?booking_id={Uri.EscapeDataString(osmBookingId)}&mode=booking&audience=venue";
+
+        var response = await SendAuthorizedAsync(HttpMethod.Get, url, null);
+        if (!response.IsSuccessStatusCode)
+        {
+            if (response.StatusCode == System.Net.HttpStatusCode.Unauthorized)
+                throw new InvalidOperationException($"OSM authentication failed fetching activities for booking {osmBookingId}");
+
+            _logger.LogError("OSM catalogue endpoint returned {StatusCode} for booking {BookingId}",
+                response.StatusCode, osmBookingId);
+            return new List<AvailableSiteDto>();
+        }
+
+        return ParseAvailableActivities(await response.Content.ReadAsStringAsync());
+    }
+
     private async Task ReplayQuestionAnswersAsync(string itemId, IReadOnlyDictionary<int, string> answersByDefId)
     {
         try
@@ -624,20 +644,40 @@ internal class OsmService : IOsmService
     /// Pure/static for testing.
     /// </summary>
     internal static List<AvailableSiteDto> ParseAvailableSites(string? catalogueJson)
+        => ParseCatalogueLeaves(catalogueJson, "Campsites", "Indoor Accommodation");
+
+    /// <summary>
+    /// Parses the same OSM item-type catalogue as <see cref="ParseAvailableSites"/> into the bookable
+    /// activities: the leaf item-types under the "Activities" category (e.g. "ACTIVITY - Archery"),
+    /// which ParseAvailableSites deliberately excludes. Category nodes (including activity
+    /// sub-categories such as "Tower") are excluded here too. Pure/static for testing.
+    /// </summary>
+    internal static List<AvailableSiteDto> ParseAvailableActivities(string? catalogueJson)
+        => ParseCatalogueLeaves(catalogueJson, "Activities");
+
+    /// <summary>
+    /// Shared BFS walk over the OSM item-type catalogue tree: finds the category node(s) whose
+    /// name matches one of <paramref name="rootCategoryNames"/>, then walks all descendants,
+    /// returning the leaves (nodes that are not themselves parents of anything) as bookable
+    /// item-types. Category nodes at any depth are excluded — only the requested root(s) named
+    /// and their bookable leaf descendants matter to callers.
+    /// </summary>
+    private static List<AvailableSiteDto> ParseCatalogueLeaves(string? catalogueJson, params string[] rootCategoryNames)
     {
-        var sites = new List<AvailableSiteDto>();
-        if (string.IsNullOrWhiteSpace(catalogueJson)) return sites;
+        var items = new List<AvailableSiteDto>();
+        if (string.IsNullOrWhiteSpace(catalogueJson)) return items;
 
         using var doc = JsonDocument.Parse(catalogueJson);
         if (!doc.RootElement.TryGetProperty("data", out var data) || data.ValueKind != JsonValueKind.Array)
-            return sites;
+            return items;
 
-        // First pass: index nodes by id, group children by parent, find the site category roots
-        // (by name), and record which ids are themselves parents (i.e. categories, not leaves).
+        // First pass: index nodes by id, group children by parent, find the requested category
+        // roots (by name), and record which ids are themselves parents (i.e. categories, not leaves).
         var nameById = new Dictionary<int, string>();
         var childrenByParent = new Dictionary<int, List<int>>();
         var parentIds = new HashSet<int>();
-        var siteCategoryIds = new List<int>();
+        var rootCategoryIds = new List<int>();
+        var rootNames = new HashSet<string>(rootCategoryNames, StringComparer.Ordinal);
         foreach (var node in data.EnumerateArray())
         {
             var id = GetInt(node, "id");
@@ -648,14 +688,14 @@ internal class OsmService : IOsmService
                 parentIds.Add(pid);
                 (childrenByParent.TryGetValue(pid, out var list) ? list : childrenByParent[pid] = new List<int>()).Add(id);
             }
-            if (name is "Campsites" or "Indoor Accommodation")
-                siteCategoryIds.Add(id);
+            if (rootNames.Contains(name))
+                rootCategoryIds.Add(id);
         }
 
-        // Walk all descendants of the site categories; the bookable sites are the leaves
+        // Walk all descendants of the root categories; the bookable item-types are the leaves
         // (nodes that are not themselves parents of anything). Handles arbitrary nesting depth.
-        var queue = new Queue<int>(siteCategoryIds);
-        var seen = new HashSet<int>(siteCategoryIds);
+        var queue = new Queue<int>(rootCategoryIds);
+        var seen = new HashSet<int>(rootCategoryIds);
         while (queue.Count > 0)
         {
             var current = queue.Dequeue();
@@ -666,11 +706,11 @@ internal class OsmService : IOsmService
                 if (parentIds.Contains(child))
                     queue.Enqueue(child);   // sub-category — descend
                 else
-                    sites.Add(new AvailableSiteDto { Id = child.ToString(), Name = nameById[child] });
+                    items.Add(new AvailableSiteDto { Id = child.ToString(), Name = nameById[child] });
             }
         }
 
-        return sites;
+        return items;
     }
 
     /// <summary>Splits an OSM "yyyy-MM-dd HH:mm:ss" timestamp into a date and the "HH:mm" portion of the time.</summary>

--- a/BookingsAssistant.Api/Services/OsmService.cs
+++ b/BookingsAssistant.Api/Services/OsmService.cs
@@ -349,6 +349,27 @@ internal class OsmService : IOsmService
         return ParseAvailableActivities(await response.Content.ReadAsStringAsync());
     }
 
+    public async Task<AvailabilityResult> CheckAvailabilityAsync(
+        string osmBookingId, string campsiteItemId, DateTime startDate, DateTime endDate)
+    {
+        // Same per-item availability endpoint and slot-resolution logic as step 1 of
+        // CreateBookingItemAsync — but purely read-only: no addItem call follows.
+        var availUrl = $"/v3/campsites/items/{Uri.EscapeDataString(campsiteItemId)}/availability?booking_id={Uri.EscapeDataString(osmBookingId)}";
+        var response = await SendAuthorizedAsync(HttpMethod.Get, availUrl, null);
+        if (!response.IsSuccessStatusCode)
+            throw await CreateOsmExceptionAsync(response, $"checking availability for item {campsiteItemId}");
+
+        var json = await response.Content.ReadAsStringAsync();
+        var slotId = ResolveSlotId(json, startDate, endDate);
+        return slotId != null
+            ? new AvailabilityResult { Available = true }
+            : new AvailabilityResult
+            {
+                Available = false,
+                Reason = $"No available slot for {startDate:yyyy-MM-dd} to {endDate:yyyy-MM-dd}"
+            };
+    }
+
     private async Task ReplayQuestionAnswersAsync(string itemId, IReadOnlyDictionary<int, string> answersByDefId)
     {
         try

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -10,10 +10,10 @@ internal class PlanDraftingService : IPlanDraftingService
     // The action types the LLM is allowed to propose. Kept in sync with the schema described
     // in the system prompt below and with PlanExecutionService, which maps these onto
     // BookingActionsController's move-activity / change-site / move-dates / add-activity /
-    // remove-activity DTOs.
+    // remove-activity / change-numbers DTOs.
     private static readonly HashSet<string> KnownActionTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity", "removeActivity"
+        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity", "removeActivity", "changeNumbers"
     };
 
     private const string SystemPrompt =
@@ -30,7 +30,8 @@ internal class PlanDraftingService : IPlanDraftingService
         "- moveActivity: { \"itemId\": string, \"newStartDate\"?: string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"note\"?: string } — " +
         "reschedules an activity item. Omitting newStartDate while supplying newStartTime/newEndTime reschedules only the time, keeping the item's original date\n" +
         "- addActivity: { \"activityId\": string, \"newStartDate\": string, \"newEndDate\": string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"numberPeople\": number, \"note\"?: string } — adds a brand-new activity item to the booking\n" +
-        "- removeActivity: { \"itemId\": string, \"note\"?: string } — permanently removes an existing item (activity or site) from the booking\n\n" +
+        "- removeActivity: { \"itemId\": string, \"note\"?: string } — permanently removes an existing item (activity or site) from the booking\n" +
+        "- changeNumbers: { \"itemId\": string, \"newNumberPeople\": number, \"note\"?: string } — changes the number of people on an existing item\n\n" +
         "Choose whichever actions (and however many, including zero if none apply) best address the email. " +
         "You decide the order — e.g. draftEmailReply can come first, last, or be omitted entirely. " +
         "Return JSON only: no prose, no markdown code fences, no explanation.";
@@ -229,6 +230,18 @@ internal class PlanDraftingService : IPlanDraftingService
             case "removeactivity":
                 reason = MissingNonEmptyString("itemId");
                 return reason == null;
+
+            case "changenumbers":
+                reason = MissingNonEmptyString("itemId");
+                if (reason != null) return false;
+
+                if (!action.TryGetProperty("newNumberPeople", out var newNumberPeopleEl) || newNumberPeopleEl.ValueKind != JsonValueKind.Number)
+                {
+                    reason = "action \"changeNumbers\" requires a numeric \"newNumberPeople\"";
+                    return false;
+                }
+                reason = null;
+                return true;
 
             case "addactivity":
                 reason = MissingNonEmptyString("activityId") ?? MissingNonEmptyString("newStartDate") ?? MissingNonEmptyString("newEndDate");

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -9,10 +9,11 @@ internal class PlanDraftingService : IPlanDraftingService
 {
     // The action types the LLM is allowed to propose. Kept in sync with the schema described
     // in the system prompt below and with PlanExecutionService, which maps these onto
-    // BookingActionsController's move-activity / change-site / move-dates / add-activity DTOs.
+    // BookingActionsController's move-activity / change-site / move-dates / add-activity /
+    // remove-activity DTOs.
     private static readonly HashSet<string> KnownActionTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity"
+        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity", "removeActivity"
     };
 
     private const string SystemPrompt =
@@ -28,7 +29,8 @@ internal class PlanDraftingService : IPlanDraftingService
         "- changeSite: { \"itemId\": string, \"newSiteId\": string, \"newSiteName\"?: string, \"note\"?: string } — moves a site item to a different site\n" +
         "- moveActivity: { \"itemId\": string, \"newStartDate\"?: string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"note\"?: string } — " +
         "reschedules an activity item. Omitting newStartDate while supplying newStartTime/newEndTime reschedules only the time, keeping the item's original date\n" +
-        "- addActivity: { \"activityId\": string, \"newStartDate\": string, \"newEndDate\": string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"numberPeople\": number, \"note\"?: string } — adds a brand-new activity item to the booking\n\n" +
+        "- addActivity: { \"activityId\": string, \"newStartDate\": string, \"newEndDate\": string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"numberPeople\": number, \"note\"?: string } — adds a brand-new activity item to the booking\n" +
+        "- removeActivity: { \"itemId\": string, \"note\"?: string } — permanently removes an existing item (activity or site) from the booking\n\n" +
         "Choose whichever actions (and however many, including zero if none apply) best address the email. " +
         "You decide the order — e.g. draftEmailReply can come first, last, or be omitted entirely. " +
         "Return JSON only: no prose, no markdown code fences, no explanation.";
@@ -224,6 +226,7 @@ internal class PlanDraftingService : IPlanDraftingService
                 return reason == null;
 
             case "moveactivity":
+            case "removeactivity":
                 reason = MissingNonEmptyString("itemId");
                 return reason == null;
 

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -162,8 +162,17 @@ internal class PlanDraftingService : IPlanDraftingService
             }
 
             var activityId = action.GetProperty("activityId").GetString()!;
-            var startDate = DateTime.Parse(action.GetProperty("newStartDate").GetString()!);
-            var endDate = DateTime.Parse(action.GetProperty("newEndDate").GetString()!);
+
+            // HasRequiredParams only checked these are non-empty strings, not that they parse
+            // as dates -- an LLM could still return a malformed-but-non-empty date. Skip the
+            // check for this action rather than throw; a bad date here shouldn't crash the
+            // whole drafting attempt (schema validation, not this pre-check, is responsible for
+            // catching malformed responses, and does so via the normal retry-then-fail path).
+            if (!DateTime.TryParse(action.GetProperty("newStartDate").GetString(), out var startDate) ||
+                !DateTime.TryParse(action.GetProperty("newEndDate").GetString(), out var endDate))
+            {
+                continue;
+            }
 
             AvailabilityResult availability;
             try

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -10,10 +10,10 @@ internal class PlanDraftingService : IPlanDraftingService
     // The action types the LLM is allowed to propose. Kept in sync with the schema described
     // in the system prompt below and with PlanExecutionService, which maps these onto
     // BookingActionsController's move-activity / change-site / move-dates / add-activity /
-    // remove-activity / change-numbers DTOs.
+    // remove-activity / change-numbers / availability DTOs.
     private static readonly HashSet<string> KnownActionTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity", "removeActivity", "changeNumbers"
+        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity", "removeActivity", "changeNumbers", "checkAvailability"
     };
 
     private const string SystemPrompt =
@@ -31,7 +31,10 @@ internal class PlanDraftingService : IPlanDraftingService
         "reschedules an activity item. Omitting newStartDate while supplying newStartTime/newEndTime reschedules only the time, keeping the item's original date\n" +
         "- addActivity: { \"activityId\": string, \"newStartDate\": string, \"newEndDate\": string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"numberPeople\": number, \"note\"?: string } — adds a brand-new activity item to the booking\n" +
         "- removeActivity: { \"itemId\": string, \"note\"?: string } — permanently removes an existing item (activity or site) from the booking\n" +
-        "- changeNumbers: { \"itemId\": string, \"newNumberPeople\": number, \"note\"?: string } — changes the number of people on an existing item\n\n" +
+        "- changeNumbers: { \"itemId\": string, \"newNumberPeople\": number, \"note\"?: string } — changes the number of people on an existing item\n" +
+        "- checkAvailability: { \"activityId\": string, \"newStartDate\": string, \"newEndDate\": string, \"note\"?: string } — " +
+        "read-only check of whether a site/activity item-type has an available slot for the given date range. " +
+        "This is the only action that never creates/modifies/deletes anything — use it to check before proposing addActivity\n\n" +
         "Choose whichever actions (and however many, including zero if none apply) best address the email. " +
         "You decide the order — e.g. draftEmailReply can come first, last, or be omitted entirely. " +
         "Return JSON only: no prose, no markdown code fences, no explanation.";
@@ -254,6 +257,10 @@ internal class PlanDraftingService : IPlanDraftingService
                 }
                 reason = null;
                 return true;
+
+            case "checkavailability":
+                reason = MissingNonEmptyString("activityId") ?? MissingNonEmptyString("newStartDate") ?? MissingNonEmptyString("newEndDate");
+                return reason == null;
 
             default:
                 reason = $"unknown action type \"{type}\"";

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -12,7 +12,7 @@ internal class PlanDraftingService : IPlanDraftingService
     // these onto BookingActionsController's move-activity / change-site / move-dates DTOs.
     private static readonly HashSet<string> KnownActionTypes = new(StringComparer.OrdinalIgnoreCase)
     {
-        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity"
+        "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity"
     };
 
     private const string SystemPrompt =
@@ -26,7 +26,9 @@ internal class PlanDraftingService : IPlanDraftingService
         "- sendTemplateEmail: {} — sends the booking's standard template email (no extra fields; the booking is already known)\n" +
         "- moveDates: { \"dayShift\": number, \"note\"?: string } — shifts every item in the booking by this many days\n" +
         "- changeSite: { \"itemId\": string, \"newSiteId\": string, \"newSiteName\"?: string, \"note\"?: string } — moves a site item to a different site\n" +
-        "- moveActivity: { \"itemId\": string, \"newStartDate\"?: string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"note\"?: string } — reschedules an activity item\n\n" +
+        "- moveActivity: { \"itemId\": string, \"newStartDate\"?: string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"note\"?: string } — " +
+        "reschedules an activity item. Omitting newStartDate while supplying newStartTime/newEndTime reschedules only the time, keeping the item's original date\n" +
+        "- addActivity: { \"activityId\": string, \"newStartDate\": string, \"newEndDate\": string, \"newStartTime\"?: string, \"newEndTime\"?: string, \"numberPeople\": number, \"note\"?: string } — adds a brand-new activity item to the booking\n\n" +
         "Choose whichever actions (and however many, including zero if none apply) best address the email. " +
         "You decide the order — e.g. draftEmailReply can come first, last, or be omitted entirely. " +
         "Return JSON only: no prose, no markdown code fences, no explanation.";
@@ -224,6 +226,18 @@ internal class PlanDraftingService : IPlanDraftingService
             case "moveactivity":
                 reason = MissingNonEmptyString("itemId");
                 return reason == null;
+
+            case "addactivity":
+                reason = MissingNonEmptyString("activityId") ?? MissingNonEmptyString("newStartDate") ?? MissingNonEmptyString("newEndDate");
+                if (reason != null) return false;
+
+                if (!action.TryGetProperty("numberPeople", out var numberPeopleEl) || numberPeopleEl.ValueKind != JsonValueKind.Number)
+                {
+                    reason = "action \"addActivity\" requires a numeric \"numberPeople\"";
+                    return false;
+                }
+                reason = null;
+                return true;
 
             default:
                 reason = $"unknown action type \"{type}\"";

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -1,6 +1,8 @@
+using System.Linq;
 using System.Text;
 using System.Text.Json;
 using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Models;
 using Microsoft.EntityFrameworkCore;
 
 namespace BookingsAssistant.Api.Services;
@@ -56,25 +58,155 @@ internal class PlanDraftingService : IPlanDraftingService
         _logger = logger;
     }
 
+    /// <summary>
+    /// Drafts a plan, allowing itself exactly ONE retry across the whole attempt — shared
+    /// between two different reasons a response might not be usable: failing JSON/schema
+    /// validation (<see cref="TryValidate"/>), or passing validation but proposing a
+    /// date-carrying action (currently only addActivity) for a slot the availability pre-check
+    /// says isn't actually available (<see cref="CheckActionsAvailabilityAsync"/>). Whichever of
+    /// those the first attempt hits, the retry prompt describes it and asks the LLM to
+    /// self-correct; the retry's outcome is then final — a still-invalid retry fails drafting,
+    /// while a still-unavailable retry succeeds anyway with a warning (see
+    /// <see cref="PlanDraftResult.Warning"/>) rather than failing, since an availability
+    /// conflict is something a human can review, not a broken response.
+    /// </summary>
     public async Task<PlanDraftResult> DraftPlanAsync(string sourceEmailText, string? osmBookingId)
     {
         var userPrompt = await BuildUserPromptAsync(sourceEmailText, osmBookingId);
 
         var firstResponse = await _client.GetCompletionAsync(SystemPrompt, userPrompt);
-        if (TryValidate(firstResponse, out var actionsJson, out var reason))
-            return PlanDraftResult.Ok(actionsJson);
+        var firstAttempt = await EvaluateAttemptAsync(firstResponse, osmBookingId);
+        if (firstAttempt.IsClean)
+            return PlanDraftResult.Ok(firstAttempt.ActionsJson!);
 
-        _logger.LogWarning("Plan drafting: first LLM response was invalid ({Reason}); retrying once", reason);
+        var retryFeedback = firstAttempt.ValidationFailureReason != null
+            ? $"Your previous response was invalid: {firstAttempt.ValidationFailureReason}. Return valid JSON only, matching the schema exactly."
+            : BuildConflictFeedback(firstAttempt.Conflicts);
 
-        var retryPrompt = userPrompt +
-            $"\n\nYour previous response was invalid: {reason}. Return valid JSON only, matching the schema exactly.";
+        _logger.LogWarning(
+            "Plan drafting: first attempt was not usable ({Reason}); retrying once",
+            firstAttempt.ValidationFailureReason ?? DescribeConflicts(firstAttempt.Conflicts));
+
+        var retryPrompt = userPrompt + "\n\n" + retryFeedback;
         var retryResponse = await _client.GetCompletionAsync(SystemPrompt, retryPrompt);
-        if (TryValidate(retryResponse, out actionsJson, out reason))
-            return PlanDraftResult.Ok(actionsJson);
+        var retryAttempt = await EvaluateAttemptAsync(retryResponse, osmBookingId);
 
-        _logger.LogWarning("Plan drafting: retry LLM response was also invalid ({Reason}); giving up", reason);
-        return PlanDraftResult.Fail(reason ?? "LLM response invalid after retry");
+        if (retryAttempt.ValidationFailureReason != null)
+        {
+            _logger.LogWarning("Plan drafting: retry LLM response was also invalid ({Reason}); giving up", retryAttempt.ValidationFailureReason);
+            return PlanDraftResult.Fail(retryAttempt.ValidationFailureReason);
+        }
+
+        if (retryAttempt.Conflicts.Count == 0)
+            return PlanDraftResult.Ok(retryAttempt.ActionsJson!);
+
+        // The one retry drafting allows itself is now spent, and a conflict remains. Don't fail
+        // drafting for this -- save the plan with a warning so a human sees it before approving.
+        _logger.LogWarning(
+            "Plan drafting: availability conflict remained after the retry ({Reason}); saving with a warning",
+            DescribeConflicts(retryAttempt.Conflicts));
+        return PlanDraftResult.Ok(retryAttempt.ActionsJson!, BuildWarning(retryAttempt.Conflicts));
     }
+
+    /// <summary>
+    /// One LLM response, evaluated all the way through: JSON/schema validation, then (only if
+    /// that passed) the availability pre-check. <see cref="IsClean"/> is true only when both
+    /// passed, meaning the response is directly usable as a <see cref="PlanDraftResult.Ok"/>.
+    /// </summary>
+    private sealed class DraftAttempt
+    {
+        public string? ActionsJson { get; init; }
+        public string? ValidationFailureReason { get; init; }
+        public List<AvailabilityConflict> Conflicts { get; init; } = new();
+
+        public bool IsClean => ValidationFailureReason == null && Conflicts.Count == 0;
+    }
+
+    /// <summary>One date-carrying action whose availability pre-check found no slot.</summary>
+    private sealed record AvailabilityConflict(string ActionType, string ActivityId, DateTime StartDate, DateTime EndDate, string? Reason);
+
+    private async Task<DraftAttempt> EvaluateAttemptAsync(string llmResponse, string? osmBookingId)
+    {
+        if (!TryValidate(llmResponse, out var actionsJson, out var reason))
+            return new DraftAttempt { ValidationFailureReason = reason };
+
+        var conflicts = await CheckActionsAvailabilityAsync(actionsJson, osmBookingId);
+        return new DraftAttempt { ActionsJson = actionsJson, Conflicts = conflicts };
+    }
+
+    /// <summary>
+    /// Scans the validated actions for any that carry a full date range against a resolvable
+    /// item-type id — currently only addActivity (activityId + newStartDate + newEndDate, both
+    /// required by <see cref="HasRequiredParams"/>). moveActivity is deliberately excluded: its
+    /// schema has no newEndDate, and its itemId refers to an item already on the booking rather
+    /// than the catalogue item-type id CheckAvailabilityAsync needs, so there's no date range to
+    /// meaningfully pre-check there. Returns no conflicts (rather than throwing) when there's no
+    /// known booking to check against, or when the OSM call itself fails — this pre-check is
+    /// best-effort, same as <see cref="BuildBookingContextAsync"/>'s item fetch, not something
+    /// that should make drafting itself brittle.
+    /// </summary>
+    private async Task<List<AvailabilityConflict>> CheckActionsAvailabilityAsync(string actionsJson, string? osmBookingId)
+    {
+        var conflicts = new List<AvailabilityConflict>();
+        if (string.IsNullOrWhiteSpace(osmBookingId))
+            return conflicts;
+
+        using var doc = JsonDocument.Parse(actionsJson);
+        foreach (var action in doc.RootElement.EnumerateArray())
+        {
+            if (!action.TryGetProperty("type", out var typeEl) ||
+                typeEl.ValueKind != JsonValueKind.String ||
+                !string.Equals(typeEl.GetString(), "addActivity", StringComparison.OrdinalIgnoreCase))
+            {
+                continue;
+            }
+
+            var activityId = action.GetProperty("activityId").GetString()!;
+            var startDate = DateTime.Parse(action.GetProperty("newStartDate").GetString()!);
+            var endDate = DateTime.Parse(action.GetProperty("newEndDate").GetString()!);
+
+            AvailabilityResult availability;
+            try
+            {
+                availability = await _osmService.CheckAvailabilityAsync(osmBookingId, activityId, startDate, endDate);
+            }
+            catch (Exception ex)
+            {
+                _logger.LogWarning(ex,
+                    "Plan drafting: availability pre-check failed for addActivity {ActivityId}; skipping the check", activityId);
+                continue;
+            }
+
+            if (!availability.Available)
+                conflicts.Add(new AvailabilityConflict("addActivity", activityId, startDate, endDate, availability.Reason));
+        }
+
+        return conflicts;
+    }
+
+    private static string BuildConflictFeedback(List<AvailabilityConflict> conflicts)
+    {
+        var sb = new StringBuilder();
+        sb.AppendLine("Your previous response was valid JSON, but an availability check found a problem:");
+        foreach (var c in conflicts)
+        {
+            sb.AppendLine(
+                $"- {c.ActionType} for activityId \"{c.ActivityId}\" from {c.StartDate:yyyy-MM-dd} to {c.EndDate:yyyy-MM-dd} " +
+                $"is not available: {c.Reason ?? "no slot"}.");
+        }
+        sb.Append("Propose different dates for the affected action(s), or drop them, and return valid JSON only.");
+        return sb.ToString();
+    }
+
+    private static string BuildWarning(List<AvailabilityConflict> conflicts)
+    {
+        var parts = conflicts.Select(c =>
+            $"{c.ActionType} for activityId \"{c.ActivityId}\" ({c.StartDate:yyyy-MM-dd} to {c.EndDate:yyyy-MM-dd}) is not available: {c.Reason ?? "no slot"}");
+        return "Availability conflict — review before approving: " + string.Join("; ", parts);
+    }
+
+    private static string DescribeConflicts(List<AvailabilityConflict> conflicts) =>
+        string.Join("; ", conflicts.Select(c => $"{c.ActionType}:{c.ActivityId}"));
 
     private async Task<string> BuildUserPromptAsync(string sourceEmailText, string? osmBookingId)
     {

--- a/BookingsAssistant.Api/Services/PlanDraftingService.cs
+++ b/BookingsAssistant.Api/Services/PlanDraftingService.cs
@@ -7,9 +7,9 @@ namespace BookingsAssistant.Api.Services;
 
 internal class PlanDraftingService : IPlanDraftingService
 {
-    // The six action types the LLM is allowed to propose. Kept in sync with the schema
-    // described in the system prompt below and with chunk 3 (execution), which will map
-    // these onto BookingActionsController's move-activity / change-site / move-dates DTOs.
+    // The action types the LLM is allowed to propose. Kept in sync with the schema described
+    // in the system prompt below and with PlanExecutionService, which maps these onto
+    // BookingActionsController's move-activity / change-site / move-dates / add-activity DTOs.
     private static readonly HashSet<string> KnownActionTypes = new(StringComparer.OrdinalIgnoreCase)
     {
         "draftEmailReply", "postComment", "sendTemplateEmail", "moveDates", "changeSite", "moveActivity", "addActivity"

--- a/BookingsAssistant.Api/Services/PlanExecutionService.cs
+++ b/BookingsAssistant.Api/Services/PlanExecutionService.cs
@@ -41,8 +41,8 @@ public class PlanExecutionService : IPlanExecutionService
 
             try
             {
-                await ExecuteActionAsync(type, action, plan.OsmBookingId);
-                results.Add(new PlanActionExecutionResult { Type = type, Status = PlanActionExecutionStatus.Succeeded });
+                var detail = await ExecuteActionAsync(type, action, plan.OsmBookingId);
+                results.Add(new PlanActionExecutionResult { Type = type, Status = PlanActionExecutionStatus.Succeeded, Detail = detail });
             }
             catch (Exception ex)
             {
@@ -66,13 +66,20 @@ public class PlanExecutionService : IPlanExecutionService
         };
     }
 
-    private async Task ExecuteActionAsync(string type, JsonElement action, string? osmBookingId)
+    /// <summary>
+    /// Executes one action. Returns an optional "detail" string that gets attached to the
+    /// action's PlanActionExecutionResult on success — used only by "checkAvailability" (the
+    /// one read-only action in this set) to carry its Available/Reason outcome back to the
+    /// caller; every other action returns null. Failure is always reported by throwing, which
+    /// ExecuteAsync catches and records as a "failed" result.
+    /// </summary>
+    private async Task<string?> ExecuteActionAsync(string type, JsonElement action, string? osmBookingId)
     {
         switch (type.ToLowerInvariant())
         {
             case "draftemailreply":
                 // Purely informational — nothing to execute against OSM.
-                return;
+                return null;
 
             case "postcomment":
             {
@@ -81,7 +88,7 @@ public class PlanExecutionService : IPlanExecutionService
                 var posted = await _osmService.PostCommentAsync(bookingId, text);
                 if (posted == null)
                     throw new InvalidOperationException($"Failed to post comment to OSM for booking {bookingId}");
-                return;
+                return null;
             }
 
             case "sendtemplateemail":
@@ -90,7 +97,7 @@ public class PlanExecutionService : IPlanExecutionService
                 var sent = await _osmService.SendBookingTemplateEmailAsync(bookingId);
                 if (!sent)
                     throw new InvalidOperationException($"Failed to send template email for booking {bookingId}");
-                return;
+                return null;
             }
 
             case "movedates":
@@ -106,7 +113,7 @@ public class PlanExecutionService : IPlanExecutionService
                 };
                 var result = await _itemActionService.MoveDatesAsync(bookingId, request);
                 ThrowIfNotSuccessful(result);
-                return;
+                return null;
             }
 
             case "changesite":
@@ -121,7 +128,7 @@ public class PlanExecutionService : IPlanExecutionService
                 };
                 var result = await _itemActionService.ChangeSiteAsync(bookingId, request);
                 ThrowIfNotSuccessful(result);
-                return;
+                return null;
             }
 
             case "moveactivity":
@@ -137,7 +144,7 @@ public class PlanExecutionService : IPlanExecutionService
                 };
                 var result = await _itemActionService.MoveActivityAsync(bookingId, request);
                 ThrowIfNotSuccessful(result);
-                return;
+                return null;
             }
 
             case "addactivity":
@@ -155,7 +162,7 @@ public class PlanExecutionService : IPlanExecutionService
                 };
                 var result = await _itemActionService.AddActivityAsync(bookingId, request);
                 ThrowIfNotSuccessful(result);
-                return;
+                return null;
             }
 
             case "removeactivity":
@@ -168,7 +175,7 @@ public class PlanExecutionService : IPlanExecutionService
                 };
                 var result = await _itemActionService.RemoveActivityAsync(bookingId, request);
                 ThrowIfNotSuccessful(result);
-                return;
+                return null;
             }
 
             case "changenumbers":
@@ -182,7 +189,19 @@ public class PlanExecutionService : IPlanExecutionService
                 };
                 var result = await _itemActionService.ChangeNumbersAsync(bookingId, request);
                 ThrowIfNotSuccessful(result);
-                return;
+                return null;
+            }
+
+            case "checkavailability":
+            {
+                // The only read-only action: never throws for "no slot available" — that is a
+                // successful query, reported via the returned detail string, not a failure.
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var activityId = RequireString(action, "activityId", type);
+                var startDate = RequireDate(action, "newStartDate", type);
+                var endDate = RequireDate(action, "newEndDate", type);
+                var availability = await _osmService.CheckAvailabilityAsync(bookingId, activityId, startDate, endDate);
+                return availability.Available ? "Available" : $"Not available: {availability.Reason}";
             }
 
             default:

--- a/BookingsAssistant.Api/Services/PlanExecutionService.cs
+++ b/BookingsAssistant.Api/Services/PlanExecutionService.cs
@@ -140,6 +140,24 @@ public class PlanExecutionService : IPlanExecutionService
                 return;
             }
 
+            case "addactivity":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var request = new AddActivityRequest
+                {
+                    ActivityId = RequireString(action, "activityId", type),
+                    StartDate = RequireDate(action, "newStartDate", type),
+                    EndDate = RequireDate(action, "newEndDate", type),
+                    StartTime = OptionalString(action, "newStartTime"),
+                    EndTime = OptionalString(action, "newEndTime"),
+                    NumberPeople = RequireInt(action, "numberPeople", type),
+                    Note = OptionalString(action, "note")
+                };
+                var result = await _itemActionService.AddActivityAsync(bookingId, request);
+                ThrowIfNotSuccessful(result);
+                return;
+            }
+
             default:
                 throw new InvalidOperationException($"Unknown action type \"{type}\"");
         }
@@ -172,6 +190,21 @@ public class PlanExecutionService : IPlanExecutionService
     {
         var raw = OptionalString(action, prop);
         return raw != null && DateTime.TryParse(raw, out var parsed) ? parsed : null;
+    }
+
+    private static DateTime RequireDate(JsonElement action, string prop, string type)
+    {
+        if (!action.TryGetProperty(prop, out var el) || el.ValueKind != JsonValueKind.String ||
+            !DateTime.TryParse(el.GetString(), out var parsed))
+            throw new InvalidOperationException($"Action \"{type}\" requires a valid date \"{prop}\"");
+        return parsed;
+    }
+
+    private static int RequireInt(JsonElement action, string prop, string type)
+    {
+        if (!action.TryGetProperty(prop, out var el) || el.ValueKind != JsonValueKind.Number || !el.TryGetInt32(out var v))
+            throw new InvalidOperationException($"Action \"{type}\" requires a numeric \"{prop}\"");
+        return v;
     }
 
     private static List<JsonElement> ParseActions(string? actionsJson)

--- a/BookingsAssistant.Api/Services/PlanExecutionService.cs
+++ b/BookingsAssistant.Api/Services/PlanExecutionService.cs
@@ -158,6 +158,19 @@ public class PlanExecutionService : IPlanExecutionService
                 return;
             }
 
+            case "removeactivity":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var request = new RemoveActivityRequest
+                {
+                    ItemId = RequireString(action, "itemId", type),
+                    Note = OptionalString(action, "note")
+                };
+                var result = await _itemActionService.RemoveActivityAsync(bookingId, request);
+                ThrowIfNotSuccessful(result);
+                return;
+            }
+
             default:
                 throw new InvalidOperationException($"Unknown action type \"{type}\"");
         }

--- a/BookingsAssistant.Api/Services/PlanExecutionService.cs
+++ b/BookingsAssistant.Api/Services/PlanExecutionService.cs
@@ -171,6 +171,20 @@ public class PlanExecutionService : IPlanExecutionService
                 return;
             }
 
+            case "changenumbers":
+            {
+                var bookingId = RequireBookingId(osmBookingId, type);
+                var request = new ChangeNumbersRequest
+                {
+                    ItemId = RequireString(action, "itemId", type),
+                    NewNumberPeople = RequireInt(action, "newNumberPeople", type),
+                    Note = OptionalString(action, "note")
+                };
+                var result = await _itemActionService.ChangeNumbersAsync(bookingId, request);
+                ThrowIfNotSuccessful(result);
+                return;
+            }
+
             default:
                 throw new InvalidOperationException($"Unknown action type \"{type}\"");
         }

--- a/BookingsAssistant.Tests/Controllers/BookingActionsAddActivityTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsAddActivityTests.cs
@@ -189,6 +189,26 @@ public class BookingActionsAddActivityTests : IClassFixture<WebApplicationFactor
         Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
     }
 
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public async Task AddActivity_Returns400_WhenNumberPeopleNotPositive(int numberPeople)
+    {
+        var bookingId = await SeedBookingAsync("98024");
+        var request = new AddActivityRequest
+        {
+            ActivityId = "4962",
+            StartDate = new DateTime(2026, 8, 2),
+            EndDate = new DateTime(2026, 8, 2),
+            NumberPeople = numberPeople
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
     [Fact]
     public async Task AddActivity_Returns404_WhenBookingNotFound()
     {

--- a/BookingsAssistant.Tests/Controllers/BookingActionsAddActivityTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsAddActivityTests.cs
@@ -215,7 +215,7 @@ public class BookingActionsAddActivityTests : IClassFixture<WebApplicationFactor
     public async Task AddActivity_Returns502_WhenOsmCreateFails()
     {
         var bookingId = await SeedBookingAsync("98031");
-        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("No available OSM slot"));
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("No available slot for the requested window"));
 
         var client = _factory.CreateClient();
         var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", ValidRequest());

--- a/BookingsAssistant.Tests/Controllers/BookingActionsAddActivityTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsAddActivityTests.cs
@@ -1,0 +1,275 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+/// <summary>
+/// Covers POST .../actions/add-activity (builds a BookingItemCreateSpec from scratch — no
+/// original item to clone — via IBookingItemActionService.AddActivityAsync) and
+/// GET .../available-activities (the activity catalogue, mirroring available-sites).
+/// </summary>
+public class BookingActionsAddActivityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsAddActivityTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_AddActivity_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?> { ["Hashing:Iterations"] = "1" }));
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase(dbName));
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    private async Task<int> SeedBookingAsync(string osmBookingId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var booking = new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "Test Group",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Provisional"
+        };
+        db.OsmBookings.Add(booking);
+        await db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    private static AddActivityRequest ValidRequest() => new()
+    {
+        ActivityId = "4962",
+        StartDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+        EndDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+        StartTime = "10:00",
+        EndTime = "12:00",
+        NumberPeople = 8
+    };
+
+    // ── add-activity ───────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task AddActivity_Returns200WithCompletedResult_WhenHappyPath()
+    {
+        var bookingId = await SeedBookingAsync("98010");
+        _fakeOsm.CreatedItemIds = new List<string> { "new-activity-item" };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = "98010",
+            OsmCommentId = "cmt-add-1",
+            AuthorName = "Site Manager",
+            TextPreview = "audit comment",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/add-activity", ValidRequest());
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Contains("new-activity-item", result.Created);
+        Assert.Empty(result.Deleted); // nothing to delete — this is a create-from-scratch, not a replace
+
+        // Built the spec straight from the request — no original item involved.
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
+        Assert.Equal("4962", spec.CampsiteItemId);
+        Assert.Equal(8, spec.NumberPeople);
+        Assert.Equal("10:00", spec.StartTime);
+        Assert.Equal("12:00", spec.EndTime);
+    }
+
+    [Fact]
+    public async Task AddActivity_PostsAuditComment_OnSuccess()
+    {
+        var bookingId = await SeedBookingAsync("98011");
+        _fakeOsm.CreatedItemIds = new List<string> { "new-activity-item" };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = "98011",
+            OsmCommentId = "cmt-add-2",
+            AuthorName = "Site Manager",
+            TextPreview = "Added activity",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", ValidRequest());
+
+        var (postedBookingId, comment) = Assert.Single(_fakeOsm.CommentsPosted);
+        Assert.Equal("98011", postedBookingId);
+        Assert.Contains("4962", comment);
+    }
+
+    [Theory]
+    [InlineData(null, "2026-08-02", "2026-08-02", 8)]
+    public async Task AddActivity_Returns400_WhenActivityIdMissing(string? activityId, string startDate, string endDate, int numberPeople)
+    {
+        var bookingId = await SeedBookingAsync("98020");
+        var request = new AddActivityRequest
+        {
+            ActivityId = activityId ?? string.Empty,
+            StartDate = DateTime.Parse(startDate),
+            EndDate = DateTime.Parse(endDate),
+            NumberPeople = numberPeople
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddActivity_Returns400_WhenStartDateMissing()
+    {
+        var bookingId = await SeedBookingAsync("98021");
+        var request = new AddActivityRequest { ActivityId = "4962", EndDate = new DateTime(2026, 8, 2), NumberPeople = 8 };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddActivity_Returns400_WhenEndDateMissing()
+    {
+        var bookingId = await SeedBookingAsync("98022");
+        var request = new AddActivityRequest { ActivityId = "4962", StartDate = new DateTime(2026, 8, 2), NumberPeople = 8 };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddActivity_Returns400_WhenNumberPeopleMissing()
+    {
+        var bookingId = await SeedBookingAsync("98023");
+        var request = new AddActivityRequest
+        {
+            ActivityId = "4962",
+            StartDate = new DateTime(2026, 8, 2),
+            EndDate = new DateTime(2026, 8, 2)
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", request);
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddActivity_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/bookings/999999/actions/add-activity", ValidRequest());
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddActivity_Returns401_WhenOsmAuthFails()
+    {
+        var bookingId = await SeedBookingAsync("98030");
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("OSM authentication failed creating item"));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", ValidRequest());
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task AddActivity_Returns502_WhenOsmCreateFails()
+    {
+        var bookingId = await SeedBookingAsync("98031");
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("No available OSM slot"));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync($"/api/bookings/{bookingId}/actions/add-activity", ValidRequest());
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
+    // ── available-activities ─────────────────────────────────────────────────
+
+    [Fact]
+    public async Task GetAvailableActivities_Returns200WithList_WhenBookingExists()
+    {
+        var bookingId = await SeedBookingAsync("98040");
+        _fakeOsm.AvailableActivitiesToReturn = new List<AvailableSiteDto>
+        {
+            new() { Id = "4962", Name = "ACTIVITY - Archery" },
+            new() { Id = "4961", Name = "ACTIVITY - Air Rifle Shooting" }
+        };
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-activities");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var activities = await response.Content.ReadFromJsonAsync<List<AvailableSiteDto>>();
+        Assert.NotNull(activities);
+        Assert.Equal(2, activities!.Count);
+        Assert.Contains(activities, a => a.Id == "4962" && a.Name == "ACTIVITY - Archery");
+    }
+
+    [Fact]
+    public async Task GetAvailableActivities_Returns404_WhenBookingNotFound()
+    {
+        var response = await _factory.CreateClient().GetAsync("/api/bookings/999999/available-activities");
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAvailableActivities_Returns401_WhenOsmAuthFails()
+    {
+        var bookingId = await SeedBookingAsync("98041");
+        _fakeOsm.GetActivitiesError = new InvalidOperationException("OSM authentication failed fetching activities");
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-activities");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task GetAvailableActivities_Returns502_WhenOsmErrors()
+    {
+        var bookingId = await SeedBookingAsync("98042");
+        _fakeOsm.GetActivitiesError = new Exception("OSM unreachable");
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/available-activities");
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/BookingActionsAvailabilityTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsAvailabilityTests.cs
@@ -1,0 +1,180 @@
+using System.Net;
+using System.Net.Http.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+/// <summary>
+/// Covers GET .../availability — the sole read-only action in this feature set. Unlike the
+/// mutation endpoints, "not available" is a normal 200 result (Available: false), not an error;
+/// only real OSM/auth/transport failures map to 401/502.
+/// </summary>
+public class BookingActionsAvailabilityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsAvailabilityTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_Availability_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?> { ["Hashing:Iterations"] = "1" }));
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase(dbName));
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    private async Task<int> SeedBookingAsync(string osmBookingId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var booking = new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "Test Group",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Provisional"
+        };
+        db.OsmBookings.Add(booking);
+        await db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    private static string Query(string activityId = "4962", string startDate = "2026-08-02", string endDate = "2026-08-02")
+        => $"?activityId={activityId}&startDate={startDate}&endDate={endDate}";
+
+    [Fact]
+    public async Task CheckAvailability_Returns200Available_WhenSlotExists()
+    {
+        var bookingId = await SeedBookingAsync("99010");
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult { Available = true };
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/availability{Query()}");
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<AvailabilityResult>();
+        Assert.NotNull(result);
+        Assert.True(result!.Available);
+        Assert.Null(result.Reason);
+
+        var call = Assert.Single(_fakeOsm.AvailabilityChecks);
+        Assert.Equal("99010", call.OsmBookingId);
+        Assert.Equal("4962", call.CampsiteItemId);
+        Assert.Equal(new DateTime(2026, 8, 2), call.StartDate);
+        Assert.Equal(new DateTime(2026, 8, 2), call.EndDate);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns200Unavailable_WhenNoSlotExists_NotAnError()
+    {
+        var bookingId = await SeedBookingAsync("99011");
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult
+        {
+            Available = false,
+            Reason = "No available slot for 2026-08-02 to 2026-08-02"
+        };
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/availability{Query()}");
+
+        // "Not available" is still a successful query — 200, not 4xx/5xx.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<AvailabilityResult>();
+        Assert.NotNull(result);
+        Assert.False(result!.Available);
+        Assert.NotNull(result.Reason);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns400_WhenActivityIdMissing()
+    {
+        var bookingId = await SeedBookingAsync("99020");
+
+        var response = await _factory.CreateClient().GetAsync(
+            $"/api/bookings/{bookingId}/availability?startDate=2026-08-02&endDate=2026-08-02");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns400_WhenStartDateMissing()
+    {
+        var bookingId = await SeedBookingAsync("99021");
+
+        var response = await _factory.CreateClient().GetAsync(
+            $"/api/bookings/{bookingId}/availability?activityId=4962&endDate=2026-08-02");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns400_WhenEndDateMissing()
+    {
+        var bookingId = await SeedBookingAsync("99022");
+
+        var response = await _factory.CreateClient().GetAsync(
+            $"/api/bookings/{bookingId}/availability?activityId=4962&startDate=2026-08-02");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns400_WhenDateIsNotAValidDate()
+    {
+        var bookingId = await SeedBookingAsync("99023");
+
+        var response = await _factory.CreateClient().GetAsync(
+            $"/api/bookings/{bookingId}/availability?activityId=4962&startDate=not-a-date&endDate=2026-08-02");
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns404_WhenBookingNotFound()
+    {
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/999999/availability{Query()}");
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns401_WhenOsmAuthFails()
+    {
+        var bookingId = await SeedBookingAsync("99030");
+        _fakeOsm.CheckAvailabilityError = new InvalidOperationException("OSM authentication failed checking availability");
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/availability{Query()}");
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task CheckAvailability_Returns502_WhenOsmFails()
+    {
+        var bookingId = await SeedBookingAsync("99031");
+        _fakeOsm.CheckAvailabilityError = new Exception("OSM unreachable");
+
+        var response = await _factory.CreateClient().GetAsync($"/api/bookings/{bookingId}/availability{Query()}");
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/BookingActionsChangeNumbersTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsChangeNumbersTests.cs
@@ -1,0 +1,230 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+/// <summary>
+/// Covers POST .../actions/change-numbers — a clone-then-delete-original headcount change
+/// (via IBookingItemActionService.ChangeNumbersAsync / IBookingMutationService.ReplaceItemsAsync),
+/// the same engine MoveActivity/ChangeSite use — not a standalone delete or a from-scratch create.
+/// </summary>
+public class BookingActionsChangeNumbersTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsChangeNumbersTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_ChangeNumbers_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?> { ["Hashing:Iterations"] = "1" }));
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase(dbName));
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    private async Task<int> SeedBookingAsync(string osmBookingId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var booking = new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "Test Group",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Provisional"
+        };
+        db.OsmBookings.Add(booking);
+        await db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    private static BookingItemDto MakeActivityItem(string itemId = "act-item-1") => new()
+    {
+        ItemId = itemId,
+        Type = "activity",
+        ActivityId = "act-10",
+        Label = "Archery Session",
+        StartDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+        StartTime = "10:00",
+        EndTime = "12:00",
+        NumberPeople = 4
+    };
+
+    // ── change-numbers ────────────────────────────────────────────────────────
+
+    [Fact]
+    public async Task ChangeNumbers_Returns200WithCompletedResult_WhenHappyPath()
+    {
+        var bookingId = await SeedBookingAsync("97010");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.CreatedItemIds = new List<string> { "act-item-new" };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = "97010",
+            OsmCommentId = "cmt-change-numbers-1",
+            AuthorName = "Site Manager",
+            TextPreview = "audit comment",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = 10 });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Contains("act-item-new", result.Created);
+        Assert.Contains("act-item-1", result.Deleted);
+
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
+        Assert.Equal(10, spec.NumberPeople);
+        // Other fields unchanged from the original
+        Assert.Equal("10:00", spec.StartTime);
+        Assert.Equal("12:00", spec.EndTime);
+    }
+
+    [Fact]
+    public async Task ChangeNumbers_PostsAuditComment_OnSuccess()
+    {
+        var bookingId = await SeedBookingAsync("97011");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.CreatedItemIds = new List<string> { "act-item-new" };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = "97011",
+            OsmCommentId = "cmt-change-numbers-2",
+            AuthorName = "Site Manager",
+            TextPreview = "Number of people changed",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = 10 });
+
+        var (postedBookingId, comment) = Assert.Single(_fakeOsm.CommentsPosted);
+        Assert.Equal("97011", postedBookingId);
+        Assert.Contains("4 → 10", comment);
+    }
+
+    [Fact]
+    public async Task ChangeNumbers_Returns400_WhenItemIdMissing()
+    {
+        var bookingId = await SeedBookingAsync("97012");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "", NewNumberPeople = 10 });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeNumbers_Returns400_WhenNewNumberPeopleMissing()
+    {
+        var bookingId = await SeedBookingAsync("97013");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "act-item-1" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Theory]
+    [InlineData(0)]
+    [InlineData(-3)]
+    public async Task ChangeNumbers_Returns400_WhenNewNumberPeopleNotPositive(int newNumberPeople)
+    {
+        var bookingId = await SeedBookingAsync("97014");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = newNumberPeople });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeNumbers_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/bookings/999999/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = 10 });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task ChangeNumbers_Returns404_WhenItemNotInBooking()
+    {
+        var bookingId = await SeedBookingAsync("97015");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "item-does-not-exist", NewNumberPeople = 10 });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    // Note: unlike add-activity/remove-activity (which call IOsmService directly), change-numbers
+    // goes through IBookingMutationService.ReplaceItemsAsync — same as move-activity/change-site.
+    // ReplaceItemsAsync catches all create-phase failures (including OSM auth errors) internally
+    // and reports them as a RolledBack BookingActionResult (200 OK), rather than letting them
+    // propagate as exceptions for the controller to map to 401/502. So there's no reachable 401
+    // path here via the fake (mirrors MoveActivity/ChangeSite, which have no such test either) —
+    // both an auth failure and any other create failure land on the same RolledBack assertion below.
+
+    [Fact]
+    public async Task ChangeNumbers_ReturnsRolledBack_WhenCreateFails()
+    {
+        var bookingId = await SeedBookingAsync("97017");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("No available slot"));
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/change-numbers",
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = 10 });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.RolledBack, result.Status);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/BookingActionsRemoveActivityTests.cs
+++ b/BookingsAssistant.Tests/Controllers/BookingActionsRemoveActivityTests.cs
@@ -1,0 +1,237 @@
+using System.Net;
+using System.Net.Http.Json;
+using System.Text.Json;
+using BookingsAssistant.Api.Data;
+using BookingsAssistant.Api.Data.Entities;
+using BookingsAssistant.Api.Models;
+using BookingsAssistant.Api.Services;
+using BookingsAssistant.Tests.Fakes;
+using Microsoft.AspNetCore.Mvc.Testing;
+using Microsoft.EntityFrameworkCore;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.DependencyInjection;
+using Microsoft.Extensions.DependencyInjection.Extensions;
+
+namespace BookingsAssistant.Tests.Controllers;
+
+/// <summary>
+/// Covers POST .../actions/remove-activity — a standalone hard delete of an existing item
+/// (site or activity) via IBookingItemActionService.RemoveActivityAsync. Unlike
+/// MoveActivity/ChangeSite (clone-then-delete-original), there is no create step here, so
+/// there's no rolled-back state — only Completed (deleted) or Failed (not deleted).
+/// </summary>
+public class BookingActionsRemoveActivityTests : IClassFixture<WebApplicationFactory<Program>>
+{
+    private readonly WebApplicationFactory<Program> _factory;
+    private readonly FakeOsmService _fakeOsm;
+
+    public BookingActionsRemoveActivityTests(WebApplicationFactory<Program> factory)
+    {
+        var dbName = "TestDb_RemoveActivity_" + Guid.NewGuid();
+        _fakeOsm = new FakeOsmService();
+        _factory = factory.WithWebHostBuilder(builder =>
+        {
+            builder.ConfigureAppConfiguration((_, cfg) =>
+                cfg.AddInMemoryCollection(new Dictionary<string, string?> { ["Hashing:Iterations"] = "1" }));
+            builder.ConfigureServices(services =>
+            {
+                var descriptor = services.SingleOrDefault(
+                    d => d.ServiceType == typeof(DbContextOptions<ApplicationDbContext>));
+                if (descriptor != null) services.Remove(descriptor);
+                services.AddDbContext<ApplicationDbContext>(o => o.UseInMemoryDatabase(dbName));
+                services.RemoveAll<IOsmService>();
+                services.AddSingleton<IOsmService>(_fakeOsm);
+            });
+        });
+    }
+
+    private async Task<int> SeedBookingAsync(string osmBookingId)
+    {
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var booking = new OsmBooking
+        {
+            OsmBookingId = osmBookingId,
+            CustomerName = "Test Group",
+            StartDate = new DateTime(2026, 8, 1, 0, 0, 0, DateTimeKind.Utc),
+            EndDate = new DateTime(2026, 8, 3, 0, 0, 0, DateTimeKind.Utc),
+            Status = "Provisional"
+        };
+        db.OsmBookings.Add(booking);
+        await db.SaveChangesAsync();
+        return booking.Id;
+    }
+
+    private static BookingItemDto MakeActivityItem(string itemId = "act-item-1") => new()
+    {
+        ItemId = itemId,
+        Type = "activity",
+        ActivityId = "act-10",
+        Label = "Archery Session",
+        StartDate = new DateTime(2026, 8, 2, 0, 0, 0, DateTimeKind.Utc),
+        StartTime = "10:00",
+        EndTime = "12:00"
+    };
+
+    [Fact]
+    public async Task RemoveActivity_Returns200WithCompletedResult_WhenHappyPath()
+    {
+        var bookingId = await SeedBookingAsync("98110");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = "98110",
+            OsmCommentId = "cmt-remove-1",
+            AuthorName = "Site Manager",
+            TextPreview = "Removed 'Archery Session'.",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Completed, result.Status);
+        Assert.Contains("act-item-1", result.Deleted);
+        Assert.Empty(result.Created); // nothing created — this is a straight delete, not a replace
+
+        Assert.Contains(("98110", "act-item-1"), _fakeOsm.DeletedItems);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_PostsAuditComment_OnSuccess()
+    {
+        var bookingId = await SeedBookingAsync("98111");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = "98111",
+            OsmCommentId = "cmt-remove-2",
+            AuthorName = "Site Manager",
+            TextPreview = "Removed 'Archery Session'.",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        var (postedBookingId, comment) = Assert.Single(_fakeOsm.CommentsPosted);
+        Assert.Equal("98111", postedBookingId);
+        Assert.Contains("Archery Session", comment);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_Returns400_WhenItemIdMissing()
+    {
+        var bookingId = await SeedBookingAsync("98112");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "" });
+
+        Assert.Equal(HttpStatusCode.BadRequest, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_Returns404_WhenBookingNotFound()
+    {
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            "/api/bookings/999999/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_Returns404_WhenItemNotInBooking()
+    {
+        var bookingId = await SeedBookingAsync("98113");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "item-does-not-exist" });
+
+        Assert.Equal(HttpStatusCode.NotFound, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_Returns401_WhenOsmAuthFails()
+    {
+        var bookingId = await SeedBookingAsync("98114");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.DeleteThrowForIds.Add("act-item-1");
+        _fakeOsm.DeleteThrowException = new InvalidOperationException("OSM authentication failed deleting item");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        Assert.Equal(HttpStatusCode.Unauthorized, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_Returns502_WhenOsmDeleteThrows()
+    {
+        var bookingId = await SeedBookingAsync("98115");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.DeleteThrowForIds.Add("act-item-1");
+        _fakeOsm.DeleteThrowException = new InvalidOperationException("Item is locked and cannot be deleted");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        Assert.Equal(HttpStatusCode.BadGateway, response.StatusCode);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_ReturnsFailedStatus_WhenOsmDeleteReturnsFalse()
+    {
+        var bookingId = await SeedBookingAsync("98116");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.DeleteReturnFalseForIds.Add("act-item-1");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        // A delete that OSM simply refuses (returns false, not an exception) is a legitimate
+        // engine outcome — not a transport failure — so it's 200 with a Failed status, per the
+        // controller's "200 OK for all engine outcomes" convention.
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<BookingActionResult>(
+            new JsonSerializerOptions { PropertyNameCaseInsensitive = true });
+        Assert.NotNull(result);
+        Assert.Equal(BookingActionStatus.Failed, result.Status);
+        Assert.Empty(result.Deleted);
+    }
+
+    [Fact]
+    public async Task RemoveActivity_DoesNotPostAuditComment_WhenOsmDeleteReturnsFalse()
+    {
+        var bookingId = await SeedBookingAsync("98117");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeActivityItem("act-item-1") };
+        _fakeOsm.DeleteReturnFalseForIds.Add("act-item-1");
+
+        var client = _factory.CreateClient();
+        await client.PostAsJsonAsync(
+            $"/api/bookings/{bookingId}/actions/remove-activity",
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        Assert.Empty(_fakeOsm.CommentsPosted);
+    }
+}

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -279,6 +279,67 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Approve_AddActivityActionSucceeds_MarksExecuted_CreatesItemAndPostsComment()
+    {
+        var bookingId = await SeedBookingAsync("77506");
+        _fakeOsm.CreatedItemIds = new List<string> { "new-activity-item" };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = bookingId,
+            OsmCommentId = "cmt-add-activity-1",
+            AuthorName = "Site Manager",
+            TextPreview = "Added activity",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"addActivity\",\"activityId\":\"4962\",\"newStartDate\":\"2026-08-02\"," +
+            "\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Executed", result.Status);
+
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
+        Assert.Equal("4962", spec.CampsiteItemId);
+        Assert.Equal(8, spec.NumberPeople);
+
+        Assert.Single(_fakeOsm.CommentsPosted);
+    }
+
+    [Fact]
+    public async Task Approve_AddActivityActionFails_MarksFailed_WhenOsmCreateFails()
+    {
+        var bookingId = await SeedBookingAsync("77507");
+        _fakeOsm.FailCreateOnCall = (1, new InvalidOperationException("No available slot for the requested window"));
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"addActivity\",\"activityId\":\"4962\",\"newStartDate\":\"2026-08-02\"," +
+            "\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal("addActivity", single.Type);
+        Assert.Equal(PlanActionExecutionStatus.Failed, single.Status);
+        // Must be the OSM create failure surfacing, not a generic "unknown action type" —
+        // proves addActivity actually reached IBookingItemActionService.AddActivityAsync.
+        Assert.Contains("No available slot", single.Reason);
+    }
+
+    [Fact]
     public async Task Approve_ReturnsConflict_WhenPlanNotAwaitingApproval()
     {
         var planId = await SeedPlanAsync(

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -340,6 +340,85 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Approve_RemoveActivityActionSucceeds_MarksExecuted_DeletesItemAndPostsComment()
+    {
+        var bookingId = await SeedBookingAsync("77508");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeSiteItem("site-item-1") };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = bookingId,
+            OsmCommentId = "cmt-remove-activity-1",
+            AuthorName = "Site Manager",
+            TextPreview = "Removed 'Pitch A'.",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"removeActivity\",\"itemId\":\"site-item-1\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Executed", result.Status);
+
+        Assert.Contains((bookingId, "site-item-1"), _fakeOsm.DeletedItems);
+        Assert.Single(_fakeOsm.CommentsPosted);
+    }
+
+    [Fact]
+    public async Task Approve_RemoveActivityActionFails_MarksFailed_WhenItemNotInBooking()
+    {
+        var bookingId = await SeedBookingAsync("77509");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>(); // item-does-not-exist isn't among the booking's items
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"removeActivity\",\"itemId\":\"item-does-not-exist\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal("removeActivity", single.Type);
+        Assert.Equal(PlanActionExecutionStatus.Failed, single.Status);
+    }
+
+    [Fact]
+    public async Task Approve_RemoveActivityActionFailure_StopsSubsequentActions()
+    {
+        var bookingId = await SeedBookingAsync("77510");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>(); // removeActivity's itemId won't be found
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"removeActivity\",\"itemId\":\"item-does-not-exist\"}," +
+            "{\"type\":\"postComment\",\"text\":\"should not run\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        Assert.Equal(2, results.Count);
+        Assert.Equal(PlanActionExecutionStatus.Failed, results[0].Status);
+        Assert.Equal(PlanActionExecutionStatus.NotAttempted, results[1].Status);
+        Assert.Empty(_fakeOsm.CommentsPosted);
+    }
+
+    [Fact]
     public async Task Approve_ReturnsConflict_WhenPlanNotAwaitingApproval()
     {
         var planId = await SeedPlanAsync(

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -501,6 +501,99 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Approve_CheckAvailabilityAvailable_MarksExecuted_StatusSucceeded_DetailSaysAvailable()
+    {
+        // The important behavioral distinction: checkAvailability is read-only, so BOTH the
+        // available and unavailable outcomes are a "succeeded" query -- only real OSM/auth
+        // failures should ever produce "failed" here.
+        var bookingId = await SeedBookingAsync("77514");
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult { Available = true };
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"checkAvailability\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Executed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal("checkAvailability", single.Type);
+        Assert.Equal(PlanActionExecutionStatus.Succeeded, single.Status);
+        Assert.NotNull(single.Detail);
+        Assert.Contains("Available", single.Detail);
+
+        var call = Assert.Single(_fakeOsm.AvailabilityChecks);
+        Assert.Equal(bookingId, call.OsmBookingId);
+        Assert.Equal("4962", call.CampsiteItemId);
+    }
+
+    [Fact]
+    public async Task Approve_CheckAvailabilityUnavailable_StillMarksExecuted_StatusSucceeded_DetailExplainsWhy()
+    {
+        var bookingId = await SeedBookingAsync("77515");
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult
+        {
+            Available = false,
+            Reason = "No available slot for 2026-08-02 to 2026-08-02"
+        };
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"checkAvailability\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        // Not a failure -- the query ran fine, it just reports the slot doesn't exist.
+        Assert.Equal("Executed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal("checkAvailability", single.Type);
+        Assert.Equal(PlanActionExecutionStatus.Succeeded, single.Status);
+        Assert.NotNull(single.Detail);
+        Assert.Contains("No available slot", single.Detail);
+        Assert.Null(single.Reason); // Reason is for actual failures, not this
+    }
+
+    [Fact]
+    public async Task Approve_CheckAvailabilityActionFails_MarksFailed_WhenOsmThrows()
+    {
+        var bookingId = await SeedBookingAsync("77516");
+        _fakeOsm.CheckAvailabilityError = new InvalidOperationException("OSM authentication failed checking availability");
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"checkAvailability\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal("checkAvailability", single.Type);
+        Assert.Equal(PlanActionExecutionStatus.Failed, single.Status);
+        Assert.NotNull(single.Reason);
+    }
+
+    [Fact]
     public async Task Approve_ReturnsConflict_WhenPlanNotAwaitingApproval()
     {
         var planId = await SeedPlanAsync(

--- a/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanApprovalTests.cs
@@ -393,6 +393,88 @@ public class PlanApprovalTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Approve_ChangeNumbersActionSucceeds_MarksExecuted_ReplacesItemAndPostsComment()
+    {
+        var bookingId = await SeedBookingAsync("77511");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto> { MakeSiteItem("site-item-1") };
+        _fakeOsm.CreatedItemIds = new List<string> { "site-item-new" };
+        _fakeOsm.CommentToReturn = new CommentDto
+        {
+            OsmBookingId = bookingId,
+            OsmCommentId = "cmt-change-numbers-1",
+            AuthorName = "Site Manager",
+            TextPreview = "Number of people changed",
+            CreatedDate = new DateTime(2026, 8, 1, 9, 0, 0, DateTimeKind.Utc)
+        };
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"changeNumbers\",\"itemId\":\"site-item-1\",\"newNumberPeople\":10}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Executed", result.Status);
+
+        var spec = Assert.Single(_fakeOsm.CapturedSpecs);
+        Assert.Equal(10, spec.NumberPeople);
+        Assert.Contains("site-item-1", _fakeOsm.DeletedItems.Select(d => d.ItemId));
+        Assert.Single(_fakeOsm.CommentsPosted);
+    }
+
+    [Fact]
+    public async Task Approve_ChangeNumbersActionFails_MarksFailed_WhenItemNotInBooking()
+    {
+        var bookingId = await SeedBookingAsync("77512");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>(); // item-does-not-exist isn't among the booking's items
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"changeNumbers\",\"itemId\":\"item-does-not-exist\",\"newNumberPeople\":10}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        var single = Assert.Single(results);
+        Assert.Equal("changeNumbers", single.Type);
+        Assert.Equal(PlanActionExecutionStatus.Failed, single.Status);
+    }
+
+    [Fact]
+    public async Task Approve_ChangeNumbersActionFailure_StopsSubsequentActions()
+    {
+        var bookingId = await SeedBookingAsync("77513");
+        _fakeOsm.ItemsToReturn = new List<BookingItemDto>(); // changeNumbers' itemId won't be found
+
+        var planId = await SeedPlanAsync(
+            "[{\"type\":\"changeNumbers\",\"itemId\":\"item-does-not-exist\",\"newNumberPeople\":10}," +
+            "{\"type\":\"postComment\",\"text\":\"should not run\"}]",
+            bookingId);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsync($"/api/plans/{planId}/approve", content: null);
+
+        Assert.Equal(HttpStatusCode.OK, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+
+        var results = System.Text.Json.JsonSerializer.Deserialize<List<PlanActionExecutionResult>>(result.ExecutionResultJson!)!;
+        Assert.Equal(2, results.Count);
+        Assert.Equal(PlanActionExecutionStatus.Failed, results[0].Status);
+        Assert.Equal(PlanActionExecutionStatus.NotAttempted, results[1].Status);
+        Assert.Empty(_fakeOsm.CommentsPosted);
+    }
+
+    [Fact]
     public async Task Approve_RemoveActivityActionFailure_StopsSubsequentActions()
     {
         var bookingId = await SeedBookingAsync("77510");

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -431,6 +431,164 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_DraftsAddActivity_WithNoDraftWarning_WhenSlotIsAvailable()
+    {
+        var bookingId = await SeedBookingAsync();
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult { Available = true };
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.Null(result.DraftWarning);
+        Assert.Single(_fakeLlm.Calls);
+
+        var check = Assert.Single(_fakeOsm.AvailabilityChecks);
+        Assert.Equal(bookingId, check.OsmBookingId);
+        Assert.Equal("4962", check.CampsiteItemId);
+        Assert.Equal(new DateTime(2026, 8, 2), check.StartDate);
+        Assert.Equal(new DateTime(2026, 8, 2), check.EndDate);
+    }
+
+    [Fact]
+    public async Task Create_RetriesOnceWithConflictFeedback_WhenAddActivitySlotUnavailable_AndSucceedsWithNoWarning_WhenRetryIsAvailable()
+    {
+        var bookingId = await SeedBookingAsync();
+        _fakeOsm.AvailabilityResultsToReturn = new Queue<AvailabilityResult>(new[]
+        {
+            new AvailabilityResult { Available = false, Reason = "No slots left on 2026-08-02" },
+            new AvailabilityResult { Available = true }
+        });
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]}");
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-03\",\"newEndDate\":\"2026-08-03\",\"numberPeople\":8}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.Null(result.DraftWarning);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("2026-08-03", result.ActionsJson);
+
+        Assert.Equal(2, _fakeLlm.Calls.Count);
+        Assert.Equal(2, _fakeOsm.AvailabilityChecks.Count);
+
+        // The retry prompt should name the specific conflict so the LLM can self-correct.
+        Assert.Contains("4962", _fakeLlm.Calls[1].UserPrompt);
+        Assert.Contains("No slots left on 2026-08-02", _fakeLlm.Calls[1].UserPrompt);
+    }
+
+    [Fact]
+    public async Task Create_SavesWithDraftWarning_WhenAddActivityStillUnavailableAfterRetry()
+    {
+        var bookingId = await SeedBookingAsync();
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult { Available = false, Reason = "Fully booked" };
+        var sameResponse = "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+                            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]}";
+        _fakeLlm.ResponsesToReturn.Enqueue(sameResponse);
+        _fakeLlm.ResponsesToReturn.Enqueue(sameResponse);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        // Drafting does not fail just because the slot is still unavailable after the retry.
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.NotNull(result.DraftWarning);
+        Assert.Contains("4962", result.DraftWarning);
+        Assert.Contains("Fully booked", result.DraftWarning);
+        Assert.Equal(2, _fakeLlm.Calls.Count);
+
+        // Persisted, not just returned in the response.
+        using var scope = _factory.Services.CreateScope();
+        var db = scope.ServiceProvider.GetRequiredService<ApplicationDbContext>();
+        var stored = await db.ProposedPlans.FindAsync(result.Id);
+        Assert.NotNull(stored);
+        Assert.Equal(PlanStatus.AwaitingApproval, stored.Status);
+        Assert.NotNull(stored.DraftWarning);
+    }
+
+    [Fact]
+    public async Task Create_SavesWithDraftWarning_AfterSingleRetry_WhenFirstResponseInvalidJson_AndRetryHasAvailabilityConflict()
+    {
+        // The first response is invalid JSON (consuming drafting's one retry) and the retry's
+        // response is valid JSON but has an availability conflict. That must NOT trigger a
+        // second, independent retry -- only one retry total is allowed across the whole attempt.
+        var bookingId = await SeedBookingAsync();
+        _fakeOsm.AvailabilityResultToReturn = new AvailabilityResult { Available = false, Reason = "Fully booked" };
+        _fakeLlm.ResponsesToReturn.Enqueue("not json");
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.NotNull(result.DraftWarning);
+        Assert.Equal(2, _fakeLlm.Calls.Count);
+    }
+
+    [Fact]
+    public async Task Create_DoesNotCheckAvailability_ForActionsWithoutDateRange()
+    {
+        var bookingId = await SeedBookingAsync();
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"postComment\",\"text\":\"noted\"}," +
+            "{\"type\":\"changeNumbers\",\"itemId\":\"act-item-1\",\"newNumberPeople\":10}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Two more people are joining, and please note it.",
+            OsmBookingId = bookingId
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.Null(result.DraftWarning);
+        Assert.Empty(_fakeOsm.AvailabilityChecks);
+    }
+
+    [Fact]
     public async Task Create_IncludesBookingContextInPrompt_WhenOsmBookingIdProvided()
     {
         var bookingId = await SeedBookingAsync();

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -268,6 +268,46 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_ReturnsAwaitingApprovalWithActionsJson_WhenLlmReturnsValidRemoveActivity()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"removeActivity\",\"itemId\":\"act-item-1\",\"note\":\"customer cancelled\"}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Please cancel our archery session."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("removeActivity", result.ActionsJson);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsRemoveActivityMissingItemId()
+    {
+        var malformed = "{\"actions\":[{\"type\":\"removeActivity\"}]}";
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Please cancel our archery session."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
     public async Task Create_IncludesBookingContextInPrompt_WhenOsmBookingIdProvided()
     {
         var bookingId = await SeedBookingAsync();

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -388,6 +388,49 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_ReturnsAwaitingApprovalWithActionsJson_WhenLlmReturnsValidCheckAvailability()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"checkAvailability\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\"}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Is archery available on the 2nd?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("checkAvailability", result.ActionsJson);
+    }
+
+    [Theory]
+    [InlineData("{\"actions\":[{\"type\":\"checkAvailability\",\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\"}]}")]
+    [InlineData("{\"actions\":[{\"type\":\"checkAvailability\",\"activityId\":\"4962\",\"newEndDate\":\"2026-08-02\"}]}")]
+    [InlineData("{\"actions\":[{\"type\":\"checkAvailability\",\"activityId\":\"4962\",\"newStartDate\":\"2026-08-02\"}]}")]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsCheckAvailabilityMissingRequiredField(string malformed)
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Is archery available on the 2nd?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
     public async Task Create_IncludesBookingContextInPrompt_WhenOsmBookingIdProvided()
     {
         var bookingId = await SeedBookingAsync();

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -205,6 +205,69 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_ReturnsAwaitingApprovalWithActionsJson_WhenLlmReturnsValidAddActivity()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+            "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\",\"numberPeople\":8}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("addActivity", result.ActionsJson);
+    }
+
+    [Theory]
+    [InlineData("{\"actions\":[{\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\",\"numberPeople\":8,\"type\":\"addActivity\"}]}")]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsAddActivityMissingActivityId(string malformedFirstAttempt)
+    {
+        // Both attempts omit activityId — invalid on the first try and the retry.
+        _fakeLlm.ResponsesToReturn.Enqueue(malformedFirstAttempt);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformedFirstAttempt);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsAddActivityMissingNumberPeople()
+    {
+        var malformed = "{\"actions\":[{\"type\":\"addActivity\",\"activityId\":\"4962\"," +
+                         "\"newStartDate\":\"2026-08-02\",\"newEndDate\":\"2026-08-02\"}]}";
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Can you add an archery session for our group?"
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
     public async Task Create_IncludesBookingContextInPrompt_WhenOsmBookingIdProvided()
     {
         var bookingId = await SeedBookingAsync();

--- a/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
+++ b/BookingsAssistant.Tests/Controllers/PlanCreateTests.cs
@@ -308,6 +308,86 @@ public class PlanCreateTests : IClassFixture<WebApplicationFactory<Program>>
     }
 
     [Fact]
+    public async Task Create_ReturnsAwaitingApprovalWithActionsJson_WhenLlmReturnsValidChangeNumbers()
+    {
+        _fakeLlm.ResponsesToReturn.Enqueue(
+            "{\"actions\":[{\"type\":\"changeNumbers\",\"itemId\":\"act-item-1\",\"newNumberPeople\":10}]}");
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Two more people are joining our archery session."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("AwaitingApproval", result.Status);
+        Assert.NotNull(result.ActionsJson);
+        Assert.Contains("changeNumbers", result.ActionsJson);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsChangeNumbersMissingItemId()
+    {
+        var malformed = "{\"actions\":[{\"type\":\"changeNumbers\",\"newNumberPeople\":10}]}";
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Two more people are joining our archery session."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsChangeNumbersMissingNewNumberPeople()
+    {
+        var malformed = "{\"actions\":[{\"type\":\"changeNumbers\",\"itemId\":\"act-item-1\"}]}";
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Two more people are joining our archery session."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
+    public async Task Create_ReturnsFailedStatus_WhenLlmReturnsChangeNumbersWithNonNumericNewNumberPeople()
+    {
+        var malformed = "{\"actions\":[{\"type\":\"changeNumbers\",\"itemId\":\"act-item-1\",\"newNumberPeople\":\"ten\"}]}";
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+        _fakeLlm.ResponsesToReturn.Enqueue(malformed);
+
+        var client = _factory.CreateClient();
+        var response = await client.PostAsJsonAsync("/api/plans", new CreatePlanRequest
+        {
+            SourceEmailText = "Two more people are joining our archery session."
+        });
+
+        Assert.Equal(HttpStatusCode.Created, response.StatusCode);
+        var result = await response.Content.ReadFromJsonAsync<ProposedPlanDto>();
+        Assert.NotNull(result);
+        Assert.Equal("Failed", result.Status);
+        Assert.Null(result.ActionsJson);
+    }
+
+    [Fact]
     public async Task Create_IncludesBookingContextInPrompt_WhenOsmBookingIdProvided()
     {
         var bookingId = await SeedBookingAsync();

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -135,6 +135,22 @@ public class FakeOsmService : IOsmService
         return Task.FromResult(!DeleteReturnFalseForIds.Contains(itemId));
     }
 
+    // Availability — configurable for checkAvailability tests
+    public AvailabilityResult AvailabilityResultToReturn { get; set; } = new() { Available = true };
+
+    /// <summary>If set, CheckAvailabilityAsync throws this (to exercise the controller's 401/502 paths).</summary>
+    public Exception? CheckAvailabilityError { get; set; }
+
+    /// <summary>Captures each call to CheckAvailabilityAsync, in order.</summary>
+    public List<(string OsmBookingId, string CampsiteItemId, DateTime StartDate, DateTime EndDate)> AvailabilityChecks { get; } = new();
+
+    public Task<AvailabilityResult> CheckAvailabilityAsync(string osmBookingId, string campsiteItemId, DateTime startDate, DateTime endDate)
+    {
+        AvailabilityChecks.Add((osmBookingId, campsiteItemId, startDate, endDate));
+        if (CheckAvailabilityError != null) throw CheckAvailabilityError;
+        return Task.FromResult(AvailabilityResultToReturn);
+    }
+
     public string GetAuthorizationUrl(string redirectUri)
     {
         return string.Empty;

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -60,6 +60,17 @@ public class FakeOsmService : IOsmService
         return Task.FromResult(AvailableSitesToReturn);
     }
 
+    public List<AvailableSiteDto> AvailableActivitiesToReturn { get; set; } = new();
+
+    /// <summary>If set, GetAvailableActivitiesAsync throws this (to exercise the controller's 401/502 paths).</summary>
+    public Exception? GetActivitiesError { get; set; }
+
+    public Task<List<AvailableSiteDto>> GetAvailableActivitiesAsync(string osmBookingId)
+    {
+        if (GetActivitiesError != null) throw GetActivitiesError;
+        return Task.FromResult(AvailableActivitiesToReturn);
+    }
+
     // Create / Delete — configurable for mutation service tests
     public List<string> CreatedItemIds { get; set; } = new();
     private int _createCallCount;

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -138,6 +138,13 @@ public class FakeOsmService : IOsmService
     // Availability — configurable for checkAvailability tests
     public AvailabilityResult AvailabilityResultToReturn { get; set; } = new() { Available = true };
 
+    /// <summary>
+    /// If set (and non-empty), each call to CheckAvailabilityAsync dequeues the next result
+    /// instead of returning <see cref="AvailabilityResultToReturn"/> — lets a test simulate a
+    /// slot that's unavailable on the first check and available on a later retry.
+    /// </summary>
+    public Queue<AvailabilityResult>? AvailabilityResultsToReturn { get; set; }
+
     /// <summary>If set, CheckAvailabilityAsync throws this (to exercise the controller's 401/502 paths).</summary>
     public Exception? CheckAvailabilityError { get; set; }
 
@@ -148,7 +155,8 @@ public class FakeOsmService : IOsmService
     {
         AvailabilityChecks.Add((osmBookingId, campsiteItemId, startDate, endDate));
         if (CheckAvailabilityError != null) throw CheckAvailabilityError;
-        return Task.FromResult(AvailabilityResultToReturn);
+        var result = AvailabilityResultsToReturn is { Count: > 0 } queue ? queue.Dequeue() : AvailabilityResultToReturn;
+        return Task.FromResult(result);
     }
 
     public string GetAuthorizationUrl(string redirectUri)

--- a/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
+++ b/BookingsAssistant.Tests/Fakes/FakeOsmService.cs
@@ -106,6 +106,12 @@ public class FakeOsmService : IOsmService
     /// </summary>
     public HashSet<string> DeleteThrowForIds { get; } = new();
 
+    /// <summary>
+    /// The exception thrown for ids in <see cref="DeleteThrowForIds"/>. Defaults to a generic
+    /// error; set to an "OSM authentication..." message to exercise the controller's 401 path.
+    /// </summary>
+    public Exception? DeleteThrowException { get; set; }
+
     public Task<string> CreateBookingItemAsync(string osmBookingId, BookingItemCreateSpec spec)
     {
         _createCallCount++;
@@ -123,7 +129,7 @@ public class FakeOsmService : IOsmService
     public Task<bool> DeleteBookingItemAsync(string osmBookingId, string itemId)
     {
         if (DeleteThrowForIds.Contains(itemId))
-            throw new InvalidOperationException($"Fake: delete forced to throw for item {itemId}");
+            throw DeleteThrowException ?? new InvalidOperationException($"Fake: delete forced to throw for item {itemId}");
         CallLog.Add(("delete", itemId));
         DeletedItems.Add((osmBookingId, itemId));
         return Task.FromResult(!DeleteReturnFalseForIds.Contains(itemId));

--- a/BookingsAssistant.Tests/Services/BookingActionCommentComposerTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingActionCommentComposerTests.cs
@@ -108,6 +108,32 @@ public class BookingActionCommentComposerTests
     }
 
     [Fact]
+    public void ComposeChangeNumbersSummary_DescribesNumberChange()
+    {
+        var activity = MakeActivityItem();
+        activity.NumberPeople = 4;
+
+        var summary = BookingActionCommentComposer.ComposeChangeNumbersSummary(
+            activity,
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = 10 });
+
+        Assert.Equal("Number of people changed for 'Archery Session': 4 → 10.", summary);
+    }
+
+    [Fact]
+    public void ComposeChangeNumbersSummary_AppendsNote_WhenProvided()
+    {
+        var activity = MakeActivityItem();
+        activity.NumberPeople = 4;
+
+        var summary = BookingActionCommentComposer.ComposeChangeNumbersSummary(
+            activity,
+            new ChangeNumbersRequest { ItemId = "act-item-1", NewNumberPeople = 10, Note = "two more joined" });
+
+        Assert.Equal("Number of people changed for 'Archery Session': 4 → 10. Note: two more joined", summary);
+    }
+
+    [Fact]
     public void ComposeMoveDatesSummary_DescribesShift()
     {
         var summary = BookingActionCommentComposer.ComposeMoveDatesSummary(

--- a/BookingsAssistant.Tests/Services/BookingActionCommentComposerTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingActionCommentComposerTests.cs
@@ -88,6 +88,26 @@ public class BookingActionCommentComposerTests
     }
 
     [Fact]
+    public void ComposeRemoveActivitySummary_DescribesRemovedItem()
+    {
+        var summary = BookingActionCommentComposer.ComposeRemoveActivitySummary(
+            MakeActivityItem(),
+            new RemoveActivityRequest { ItemId = "act-item-1" });
+
+        Assert.Equal("Removed 'Archery Session'.", summary);
+    }
+
+    [Fact]
+    public void ComposeRemoveActivitySummary_AppendsNote_WhenProvided()
+    {
+        var summary = BookingActionCommentComposer.ComposeRemoveActivitySummary(
+            MakeActivityItem(),
+            new RemoveActivityRequest { ItemId = "act-item-1", Note = "customer cancelled this session" });
+
+        Assert.Equal("Removed 'Archery Session'. Note: customer cancelled this session", summary);
+    }
+
+    [Fact]
     public void ComposeMoveDatesSummary_DescribesShift()
     {
         var summary = BookingActionCommentComposer.ComposeMoveDatesSummary(

--- a/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
+++ b/BookingsAssistant.Tests/Services/BookingMutationServiceTests.cs
@@ -243,6 +243,56 @@ public class BookingMutationServiceTests
     }
 
     [Fact]
+    public async Task Override_NewNumberPeople_ReflectedInSpec_OtherFieldsUnchanged()
+    {
+        var fake = new FakeOsmService
+        {
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+
+        var original = MakeItem("orig-1", siteId: "site-42", startTime: "09:00", endTime: "17:00");
+        original.NumberPeople = 4;
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = original, NewNumberPeople = 10 }
+        };
+
+        await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        var spec = Assert.Single(fake.CapturedSpecs);
+        Assert.Equal(10, spec.NumberPeople);          // overridden
+        Assert.Equal("site-42", spec.CampsiteItemId); // unchanged
+        Assert.Equal("09:00", spec.StartTime);        // unchanged
+        Assert.Equal("17:00", spec.EndTime);          // unchanged
+    }
+
+    [Fact]
+    public async Task NoNewNumberPeopleOverride_FallsBackToOriginalNumberPeople()
+    {
+        var fake = new FakeOsmService
+        {
+            ItemsToReturn = new List<BookingItemDto>()
+        };
+
+        var original = MakeItem("orig-1");
+        original.NumberPeople = 6;
+
+        var svc = CreateService(fake);
+        var replacements = new List<ItemReplacement>
+        {
+            new() { Original = original }
+            // No NewNumberPeople override
+        };
+
+        await svc.ReplaceItemsAsync("booking-99", replacements);
+
+        var spec = Assert.Single(fake.CapturedSpecs);
+        Assert.Equal(6, spec.NumberPeople);
+    }
+
+    [Fact]
     public async Task BuildSpec_CarriesOriginalQuestionAnswers_KeyedByQuestionDefId()
     {
         var fake = new FakeOsmService { ItemsToReturn = new List<BookingItemDto>() };

--- a/BookingsAssistant.Tests/Services/OsmServiceAvailableActivitiesTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceAvailableActivitiesTests.cs
@@ -1,0 +1,79 @@
+using BookingsAssistant.Api.Services;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Unit tests for OsmService.ParseAvailableActivities against the captured OSM catalogue
+/// fixture. "Activities" are the bookable item-types under the "Activities" category
+/// (previously excluded on purpose from ParseAvailableSites); category nodes (including
+/// activity sub-categories like "Tower" and "Throwing Range") and site item-types are excluded.
+/// </summary>
+public class OsmServiceAvailableActivitiesTests
+{
+    private static string Catalogue() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "OsmItems", "items-catalogue-list.json"));
+
+    [Fact]
+    public void ParseAvailableActivities_IncludesActivityUnderActivitiesRoot()
+    {
+        var activities = OsmService.ParseAvailableActivities(Catalogue());
+        var archery = activities.SingleOrDefault(a => a.Id == "4962");
+        Assert.NotNull(archery);
+        Assert.Equal("ACTIVITY - Archery", archery!.Name);
+    }
+
+    [Fact]
+    public void ParseAvailableActivities_IncludesActivityNestedUnderASubCategory()
+        // 8054 "ACTIVITY - Abseiling" is nested under the "Tower" sub-category (10376),
+        // itself under "Activities" — confirms arbitrary nesting depth is walked.
+        => Assert.Contains(OsmService.ParseAvailableActivities(Catalogue()), a => a.Id == "8054" && a.Name == "ACTIVITY - Abseiling");
+
+    [Fact]
+    public void ParseAvailableActivities_ExcludesSites()
+    {
+        var activities = OsmService.ParseAvailableActivities(Catalogue());
+        // 1387 Hayvern, 1404 Birch are site item-types (under Campsites/Indoor Accommodation), not activities.
+        Assert.DoesNotContain(activities, a => a.Id is "1387" or "1404");
+    }
+
+    [Fact]
+    public void ParseAvailableActivities_ExcludesCategoryNodesThemselves()
+    {
+        var activities = OsmService.ParseAvailableActivities(Catalogue());
+        // 10290 Activities, 10376 Tower, 10377 Throwing Range, 10374 Pond are categories, not bookable activities.
+        Assert.DoesNotContain(activities, a => a.Id is "10290" or "10376" or "10377" or "10374");
+    }
+
+    [Fact]
+    public void ParseAvailableActivities_AllEntriesHaveIdAndName()
+    {
+        var activities = OsmService.ParseAvailableActivities(Catalogue());
+        Assert.NotEmpty(activities);
+        Assert.All(activities, a =>
+        {
+            Assert.False(string.IsNullOrWhiteSpace(a.Id));
+            Assert.False(string.IsNullOrWhiteSpace(a.Name));
+        });
+    }
+
+    [Fact]
+    public void ParseAvailableActivities_ReturnsEmpty_ForBlankInput()
+        => Assert.Empty(OsmService.ParseAvailableActivities(""));
+
+    [Fact]
+    public void ParseAvailableActivities_HandlesActivitiesNestedUnderASubCategory()
+    {
+        // Activities(1) → "Water Sports" sub-category(2) → leaf activity(3). The leaf is an
+        // activity; the sub-category (itself a parent) is excluded.
+        const string json = """
+        {"data":[
+            {"id":1,"parent_id":0,"name":"Activities"},
+            {"id":2,"parent_id":1,"name":"Water Sports"},
+            {"id":3,"parent_id":2,"name":"ACTIVITY - Canoeing"}
+        ]}
+        """;
+        var activities = OsmService.ParseAvailableActivities(json);
+        Assert.Contains(activities, a => a.Id == "3" && a.Name == "ACTIVITY - Canoeing");
+        Assert.DoesNotContain(activities, a => a.Id == "2");
+    }
+}

--- a/BookingsAssistant.Tests/Services/OsmServiceCheckAvailabilityTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceCheckAvailabilityTests.cs
@@ -1,0 +1,114 @@
+using System.Net;
+using BookingsAssistant.Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Direct HTTP-level coverage for OsmService.CheckAvailabilityAsync: confirms it hits the same
+/// per-item availability endpoint as CreateBookingItemAsync's slot-resolution step (see
+/// OsmServiceItemMutationTests for ResolveSlotId itself) and reports Available/Reason based on
+/// whether a slot covers the requested window. Mirrors the fake-HttpMessageHandler pattern used
+/// in OsmServiceGetAvailableActivitiesTests.
+/// </summary>
+public class OsmServiceCheckAvailabilityTests
+{
+    private static IConfiguration BuildConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Osm:CampsiteId"] = "219",
+                ["Osm:SectionId"] = "2"
+            })
+            .Build();
+
+    private class FakeOsmAuthService : IOsmAuthService
+    {
+        public Task<string> GetValidAccessTokenAsync(int userId) => Task.FromResult("fake-token");
+        public string GetAuthorizationUrl(string redirectUri) => string.Empty;
+        public Task<bool> HandleCallbackAsync(string code, int userId, string redirectUri) => Task.FromResult(true);
+    }
+
+    private class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public RecordingHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastRequest = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    private static string Availability1387() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "OsmItems", "availability-1387.json"));
+
+    private static OsmService MakeService(HttpMessageHandler handler) =>
+        new(new HttpClient(handler), BuildConfig(), NullLogger<OsmService>.Instance,
+            new FakeOsmAuthService(), new OsmRateLimitCooldown());
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_RequestsTheItemAvailabilityEndpoint()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(Availability1387()) };
+        var handler = new RecordingHandler(response);
+        var service = MakeService(handler);
+
+        await service.CheckAvailabilityAsync("179743", "1387", new DateTime(2027, 12, 4), new DateTime(2027, 12, 5));
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
+        var url = handler.LastRequest.RequestUri!.ToString();
+        Assert.Contains("/v3/campsites/items/1387/availability", url);
+        Assert.Contains("booking_id=179743", url);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_ReturnsAvailableTrue_WhenSlotMatchesDateRange()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(Availability1387()) };
+        var service = MakeService(new RecordingHandler(response));
+
+        var result = await service.CheckAvailabilityAsync("179743", "1387", new DateTime(2027, 12, 4), new DateTime(2027, 12, 5));
+
+        Assert.True(result.Available);
+        Assert.Null(result.Reason);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_ReturnsAvailableFalseWithReason_WhenNoSlotMatchesDateRange()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(Availability1387()) };
+        var service = MakeService(new RecordingHandler(response));
+
+        var result = await service.CheckAvailabilityAsync("179743", "1387", new DateTime(2030, 1, 1), new DateTime(2030, 1, 2));
+
+        Assert.False(result.Available);
+        Assert.NotNull(result.Reason);
+        Assert.Contains("2030-01-01", result.Reason);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_Throws_WhenOsmReturnsUnauthorized()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        var service = MakeService(new RecordingHandler(response));
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.CheckAvailabilityAsync("179743", "1387", new DateTime(2027, 12, 4), new DateTime(2027, 12, 5)));
+        Assert.Contains("OSM", ex.Message);
+    }
+
+    [Fact]
+    public async Task CheckAvailabilityAsync_Throws_WhenOsmReturnsOtherError()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.InternalServerError) { Content = new StringContent("boom") };
+        var service = MakeService(new RecordingHandler(response));
+
+        await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.CheckAvailabilityAsync("179743", "1387", new DateTime(2027, 12, 4), new DateTime(2027, 12, 5)));
+    }
+}

--- a/BookingsAssistant.Tests/Services/OsmServiceGetAvailableActivitiesTests.cs
+++ b/BookingsAssistant.Tests/Services/OsmServiceGetAvailableActivitiesTests.cs
@@ -1,0 +1,82 @@
+using System.Net;
+using BookingsAssistant.Api.Services;
+using Microsoft.Extensions.Configuration;
+using Microsoft.Extensions.Logging.Abstractions;
+
+namespace BookingsAssistant.Tests.Services;
+
+/// <summary>
+/// Direct HTTP-level coverage for OsmService.GetAvailableActivitiesAsync: confirms it hits the
+/// same catalogue endpoint as GetAvailableSitesAsync and returns the activities parsed by
+/// ParseAvailableActivities. Mirrors the fake-HttpMessageHandler pattern used in
+/// OsmRateLimitCooldownTests / OpenWebUiClientTests — everywhere else, OsmService is exercised
+/// via FakeOsmService, which never calls the real HTTP path.
+/// </summary>
+public class OsmServiceGetAvailableActivitiesTests
+{
+    private static IConfiguration BuildConfig() =>
+        new ConfigurationBuilder()
+            .AddInMemoryCollection(new Dictionary<string, string?>
+            {
+                ["Osm:CampsiteId"] = "219",
+                ["Osm:SectionId"] = "2"
+            })
+            .Build();
+
+    private class FakeOsmAuthService : IOsmAuthService
+    {
+        public Task<string> GetValidAccessTokenAsync(int userId) => Task.FromResult("fake-token");
+        public string GetAuthorizationUrl(string redirectUri) => string.Empty;
+        public Task<bool> HandleCallbackAsync(string code, int userId, string redirectUri) => Task.FromResult(true);
+    }
+
+    private class RecordingHandler : HttpMessageHandler
+    {
+        private readonly HttpResponseMessage _response;
+        public HttpRequestMessage? LastRequest { get; private set; }
+        public RecordingHandler(HttpResponseMessage response) => _response = response;
+
+        protected override Task<HttpResponseMessage> SendAsync(HttpRequestMessage request, CancellationToken ct)
+        {
+            LastRequest = request;
+            return Task.FromResult(_response);
+        }
+    }
+
+    private static string Catalogue() =>
+        File.ReadAllText(Path.Combine(AppContext.BaseDirectory, "Fixtures", "OsmItems", "items-catalogue-list.json"));
+
+    [Fact]
+    public async Task GetAvailableActivitiesAsync_RequestsTheCampsiteItemsCatalogueEndpoint_AndReturnsParsedActivities()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.OK) { Content = new StringContent(Catalogue()) };
+        var handler = new RecordingHandler(response);
+        var service = new OsmService(new HttpClient(handler), BuildConfig(), NullLogger<OsmService>.Instance,
+            new FakeOsmAuthService(), new OsmRateLimitCooldown());
+
+        var activities = await service.GetAvailableActivitiesAsync("179743");
+
+        Assert.NotNull(handler.LastRequest);
+        Assert.Equal(HttpMethod.Get, handler.LastRequest!.Method);
+        var url = handler.LastRequest.RequestUri!.ToString();
+        Assert.Contains("/v3/campsites/219/items", url);
+        Assert.Contains("booking_id=179743", url);
+        Assert.Contains("mode=booking", url);
+
+        Assert.Contains(activities, a => a.Id == "4962" && a.Name == "ACTIVITY - Archery");
+        Assert.DoesNotContain(activities, a => a.Id == "1387"); // a site, not an activity
+    }
+
+    [Fact]
+    public async Task GetAvailableActivitiesAsync_Throws_WhenOsmReturnsUnauthorized()
+    {
+        var response = new HttpResponseMessage(HttpStatusCode.Unauthorized);
+        var handler = new RecordingHandler(response);
+        var service = new OsmService(new HttpClient(handler), BuildConfig(), NullLogger<OsmService>.Instance,
+            new FakeOsmAuthService(), new OsmRateLimitCooldown());
+
+        var ex = await Assert.ThrowsAsync<InvalidOperationException>(
+            () => service.GetAvailableActivitiesAsync("179743"));
+        Assert.Contains("OSM", ex.Message);
+    }
+}

--- a/BookingsAssistant.Web/src/components/BookingDetail.addActivity.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.addActivity.test.tsx
@@ -69,7 +69,6 @@ describe('add-activity action', () => {
   });
 
   it('disables Add activity until an activity, both dates, and number of people are filled in', async () => {
-    const user = userEvent.setup();
     renderDetail();
     await screen.findByText(/Booking #179743/);
 

--- a/BookingsAssistant.Web/src/components/BookingDetail.addActivity.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.addActivity.test.tsx
@@ -1,0 +1,93 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BookingDetail from './BookingDetail';
+import { bookingsApi } from '../services/apiClient';
+import type { BookingActionResult, BookingItem } from '../types';
+
+vi.mock('../services/apiClient', () => ({
+  bookingsApi: {
+    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(), getAvailableActivities: vi.fn(),
+    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(), addActivity: vi.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const api = bookingsApi as any;
+
+const booking = {
+  id: 1, osmBookingId: '179743', customerName: 'Test', startDate: '2027-12-04',
+  endDate: '2027-12-05', status: 'Provisional', fullDetails: '', comments: [],
+};
+const initialItems: BookingItem[] = [];
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/bookings/1']}>
+      <Routes><Route path="/bookings/:id" element={<BookingDetail />} /></Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getById.mockResolvedValue(booking);
+  api.getItems.mockResolvedValue(initialItems);
+  api.getAvailableSites.mockResolvedValue([]);
+  api.getAvailableActivities.mockResolvedValue([
+    { id: '4962', name: 'ACTIVITY - Archery' },
+    { id: '4961', name: 'ACTIVITY - Air Rifle Shooting' },
+  ]);
+});
+
+describe('add-activity action', () => {
+  it('submits a new activity after confirmation and shows a success banner', async () => {
+    const result: BookingActionResult = {
+      created: ['999'], deleted: [], status: 'completed', message: 'Added new activity item 999.',
+      items: [{
+        itemId: '999', type: 'activity', activityId: '4962', label: 'ACTIVITY - Archery',
+        startDate: '2027-12-04', startTime: '10:00', endTime: '12:00',
+      }],
+    };
+    api.addActivity.mockResolvedValue(result);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const select = await screen.findByLabelText(/^activity$/i);
+    await user.selectOptions(select, '4962');
+    await user.type(screen.getByLabelText(/start date/i), '2027-12-04');
+    await user.type(screen.getByLabelText(/end date/i), '2027-12-04');
+    await user.type(screen.getByLabelText(/number of people/i), '8');
+    await user.click(screen.getByRole('button', { name: /^add activity$/i }));   // open confirm gate
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.addActivity).toHaveBeenCalledWith(1, {
+      activityId: '4962', startDate: '2027-12-04', endDate: '2027-12-04', numberPeople: 8,
+    }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/added new activity/i);
+  });
+
+  it('disables Add activity until an activity, both dates, and number of people are filled in', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    expect(screen.getByRole('button', { name: /^add activity$/i })).toBeDisabled();
+  });
+
+  it('cancelling the confirmation does not call the API', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.selectOptions(await screen.findByLabelText(/^activity$/i), '4962');
+    await user.type(screen.getByLabelText(/start date/i), '2027-12-04');
+    await user.type(screen.getByLabelText(/end date/i), '2027-12-04');
+    await user.type(screen.getByLabelText(/number of people/i), '8');
+    await user.click(screen.getByRole('button', { name: /^add activity$/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(api.addActivity).not.toHaveBeenCalled();
+  });
+});

--- a/BookingsAssistant.Web/src/components/BookingDetail.addActivity.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.addActivity.test.tsx
@@ -89,4 +89,18 @@ describe('add-activity action', () => {
 
     expect(api.addActivity).not.toHaveBeenCalled();
   });
+
+  it('disables Add activity until a positive number of people is entered', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    await user.selectOptions(await screen.findByLabelText(/^activity$/i), '4962');
+    await user.type(screen.getByLabelText(/start date/i), '2027-12-04');
+    await user.type(screen.getByLabelText(/end date/i), '2027-12-04');
+    expect(screen.getByRole('button', { name: /^add activity$/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/number of people/i), '0');
+    expect(screen.getByRole('button', { name: /^add activity$/i })).toBeDisabled();
+  });
 });

--- a/BookingsAssistant.Web/src/components/BookingDetail.auditNote.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.auditNote.test.tsx
@@ -8,8 +8,8 @@ import type { BookingActionResult, BookingItem } from '../types';
 
 vi.mock('../services/apiClient', () => ({
   bookingsApi: {
-    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(),
-    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(),
+    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(), getAvailableActivities: vi.fn(),
+    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(), addActivity: vi.fn(),
   },
 }));
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,6 +40,7 @@ beforeEach(() => {
   api.getAvailableSites.mockResolvedValue([
     { id: '1387', name: 'Hayvern' }, { id: '1404', name: 'Birch' },
   ]);
+  api.getAvailableActivities.mockResolvedValue([]);
 });
 
 describe('audit-trail note field', () => {

--- a/BookingsAssistant.Web/src/components/BookingDetail.changeNumbers.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.changeNumbers.test.tsx
@@ -1,0 +1,111 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BookingDetail from './BookingDetail';
+import { bookingsApi } from '../services/apiClient';
+import type { BookingActionResult, BookingItem } from '../types';
+
+vi.mock('../services/apiClient', () => ({
+  bookingsApi: {
+    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(), getAvailableActivities: vi.fn(),
+    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(), addActivity: vi.fn(), removeActivity: vi.fn(),
+    changeNumbers: vi.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const api = bookingsApi as any;
+
+const booking = {
+  id: 1, osmBookingId: '179743', customerName: 'Test', startDate: '2027-12-04',
+  endDate: '2027-12-05', status: 'Provisional', fullDetails: '', comments: [],
+};
+const activity: BookingItem = { itemId: '411468', type: 'activity', activityId: '4961', label: 'Air Rifle', startDate: '2027-12-05', startTime: '09:00', endTime: '10:00' };
+const site: BookingItem = { itemId: '411467', type: 'site', siteId: '1387', label: 'Hayvern', startDate: '2027-12-04', endDate: '2027-12-05' };
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/bookings/1']}>
+      <Routes><Route path="/bookings/:id" element={<BookingDetail />} /></Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getById.mockResolvedValue(booking);
+  api.getItems.mockResolvedValue([activity, site]);
+  api.getAvailableSites.mockResolvedValue([]);
+  api.getAvailableActivities.mockResolvedValue([]);
+});
+
+describe('change-numbers action', () => {
+  it('submits a new headcount for an item after confirmation and shows a success banner', async () => {
+    const result: BookingActionResult = {
+      created: ['999'], deleted: ['411468'], status: 'completed',
+      message: "Replaced 1 item(s) successfully.", items: [site],
+    };
+    api.changeNumbers.mockResolvedValue(result);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const activityRow = screen.getByText('Air Rifle').closest('div')!.parentElement!;
+    await user.click(within(activityRow).getByRole('button', { name: /change numbers/i }));
+    await user.type(screen.getByLabelText(/new number of people/i), '10');
+    await user.click(screen.getByRole('button', { name: /^update$/i }));   // open confirm gate
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.changeNumbers).toHaveBeenCalledWith(1, {
+      itemId: '411468', newNumberPeople: 10,
+    }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/replaced 1 item/i);
+  });
+
+  it('disables the submit button until a positive number is entered', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const activityRow = screen.getByText('Air Rifle').closest('div')!.parentElement!;
+    await user.click(within(activityRow).getByRole('button', { name: /change numbers/i }));
+    expect(screen.getByRole('button', { name: /^update$/i })).toBeDisabled();
+
+    await user.type(screen.getByLabelText(/new number of people/i), '0');
+    expect(screen.getByRole('button', { name: /^update$/i })).toBeDisabled();
+  });
+
+  it('includes an optional note in the request', async () => {
+    api.changeNumbers.mockResolvedValue({
+      created: ['999'], deleted: ['411467'], status: 'completed', message: 'Replaced 1 item(s) successfully.', items: [],
+    } as BookingActionResult);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const siteRow = screen.getByText('Hayvern').closest('div')!.parentElement!;
+    await user.click(within(siteRow).getByRole('button', { name: /change numbers/i }));
+    await user.type(screen.getByLabelText(/new number of people/i), '15');
+    await user.click(screen.getByRole('button', { name: /^update$/i }));
+    await user.type(screen.getByLabelText(/add a note/i), 'group grew');
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.changeNumbers).toHaveBeenCalledWith(1, {
+      itemId: '411467', newNumberPeople: 15, note: 'group grew',
+    }));
+  });
+
+  it('cancelling the confirmation does not call the API', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const activityRow = screen.getByText('Air Rifle').closest('div')!.parentElement!;
+    await user.click(within(activityRow).getByRole('button', { name: /change numbers/i }));
+    await user.type(screen.getByLabelText(/new number of people/i), '10');
+    await user.click(screen.getByRole('button', { name: /^update$/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(api.changeNumbers).not.toHaveBeenCalled();
+  });
+});

--- a/BookingsAssistant.Web/src/components/BookingDetail.itemActions.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.itemActions.test.tsx
@@ -8,8 +8,8 @@ import type { BookingActionResult, BookingItem } from '../types';
 
 vi.mock('../services/apiClient', () => ({
   bookingsApi: {
-    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(),
-    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(),
+    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(), getAvailableActivities: vi.fn(),
+    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(), addActivity: vi.fn(),
   },
 }));
 // eslint-disable-next-line @typescript-eslint/no-explicit-any
@@ -40,6 +40,7 @@ beforeEach(() => {
   api.getAvailableSites.mockResolvedValue([
     { id: '1387', name: 'Hayvern' }, { id: '1404', name: 'Birch' }, { id: '1386', name: 'Alpha House' },
   ]);
+  api.getAvailableActivities.mockResolvedValue([]);
 });
 
 describe('move-activity action', () => {

--- a/BookingsAssistant.Web/src/components/BookingDetail.moveDates.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.moveDates.test.tsx
@@ -11,9 +11,11 @@ vi.mock('../services/apiClient', () => ({
     getById: vi.fn(),
     getItems: vi.fn(),
     getAvailableSites: vi.fn(),
+    getAvailableActivities: vi.fn(),
     moveDates: vi.fn(),
     moveActivity: vi.fn(),
     changeSite: vi.fn(),
+    addActivity: vi.fn(),
   },
 }));
 
@@ -41,6 +43,7 @@ beforeEach(() => {
   api.getById.mockResolvedValue(booking);
   api.getItems.mockResolvedValue(initialItems);
   api.getAvailableSites.mockResolvedValue([]);
+  api.getAvailableActivities.mockResolvedValue([]);
 });
 
 describe('move-dates action', () => {

--- a/BookingsAssistant.Web/src/components/BookingDetail.removeActivity.test.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.removeActivity.test.tsx
@@ -1,0 +1,107 @@
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, waitFor, within } from '@testing-library/react';
+import userEvent from '@testing-library/user-event';
+import { MemoryRouter, Routes, Route } from 'react-router-dom';
+import BookingDetail from './BookingDetail';
+import { bookingsApi } from '../services/apiClient';
+import type { BookingActionResult, BookingItem } from '../types';
+
+vi.mock('../services/apiClient', () => ({
+  bookingsApi: {
+    getById: vi.fn(), getItems: vi.fn(), getAvailableSites: vi.fn(), getAvailableActivities: vi.fn(),
+    moveDates: vi.fn(), moveActivity: vi.fn(), changeSite: vi.fn(), addActivity: vi.fn(), removeActivity: vi.fn(),
+  },
+}));
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+const api = bookingsApi as any;
+
+const booking = {
+  id: 1, osmBookingId: '179743', customerName: 'Test', startDate: '2027-12-04',
+  endDate: '2027-12-05', status: 'Provisional', fullDetails: '', comments: [],
+};
+const activity: BookingItem = { itemId: '411468', type: 'activity', activityId: '4961', label: 'Air Rifle', startDate: '2027-12-05', startTime: '09:00', endTime: '10:00' };
+const site: BookingItem = { itemId: '411467', type: 'site', siteId: '1387', label: 'Hayvern', startDate: '2027-12-04', endDate: '2027-12-05' };
+
+function renderDetail() {
+  return render(
+    <MemoryRouter initialEntries={['/bookings/1']}>
+      <Routes><Route path="/bookings/:id" element={<BookingDetail />} /></Routes>
+    </MemoryRouter>
+  );
+}
+
+beforeEach(() => {
+  vi.clearAllMocks();
+  api.getById.mockResolvedValue(booking);
+  api.getItems.mockResolvedValue([activity, site]);
+  api.getAvailableSites.mockResolvedValue([]);
+  api.getAvailableActivities.mockResolvedValue([]);
+});
+
+describe('remove-activity action', () => {
+  it('removes an activity item after confirmation and shows a success banner', async () => {
+    const result: BookingActionResult = {
+      created: [], deleted: ['411468'], status: 'completed', message: "Removed 'Air Rifle'.", items: [site],
+    };
+    api.removeActivity.mockResolvedValue(result);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const activityRow = screen.getByText('Air Rifle').closest('div')!.parentElement!;
+    await user.click(within(activityRow).getByRole('button', { name: /^remove$/i }));
+
+    // Confirmation gate appears; no API call yet
+    expect(api.removeActivity).not.toHaveBeenCalled();
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.removeActivity).toHaveBeenCalledWith(1, { itemId: '411468' }));
+    expect(await screen.findByRole('status')).toHaveTextContent(/removed 'air rifle'/i);
+  });
+
+  it('removes a site item after confirmation', async () => {
+    const result: BookingActionResult = {
+      created: [], deleted: ['411467'], status: 'completed', message: "Removed 'Hayvern'.", items: [activity],
+    };
+    api.removeActivity.mockResolvedValue(result);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const siteRow = screen.getByText('Hayvern').closest('div')!.parentElement!;
+    await user.click(within(siteRow).getByRole('button', { name: /^remove$/i }));
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.removeActivity).toHaveBeenCalledWith(1, { itemId: '411467' }));
+  });
+
+  it('cancelling the confirmation does not call the API', async () => {
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const activityRow = screen.getByText('Air Rifle').closest('div')!.parentElement!;
+    await user.click(within(activityRow).getByRole('button', { name: /^remove$/i }));
+    await user.click(screen.getByRole('button', { name: /cancel/i }));
+
+    expect(api.removeActivity).not.toHaveBeenCalled();
+  });
+
+  it('includes an optional note in the request', async () => {
+    api.removeActivity.mockResolvedValue({
+      created: [], deleted: ['411468'], status: 'completed', message: "Removed 'Air Rifle'.", items: [],
+    } as BookingActionResult);
+    const user = userEvent.setup();
+    renderDetail();
+    await screen.findByText(/Booking #179743/);
+
+    const activityRow = screen.getByText('Air Rifle').closest('div')!.parentElement!;
+    await user.click(within(activityRow).getByRole('button', { name: /^remove$/i }));
+    await user.type(screen.getByLabelText(/add a note/i), 'customer cancelled');
+    await user.click(screen.getByRole('button', { name: /confirm/i }));
+
+    await waitFor(() => expect(api.removeActivity).toHaveBeenCalledWith(1, {
+      itemId: '411468', note: 'customer cancelled',
+    }));
+  });
+});

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -10,9 +10,10 @@ import type {
   ChangeSiteRequest,
   MoveActivityRequest,
   MoveDatesRequest,
+  RemoveActivityRequest,
 } from '../types';
 
-type ItemActionKind = 'move-activity' | 'change-site';
+type ItemActionKind = 'move-activity' | 'change-site' | 'remove-activity';
 
 /** Tailwind classes for the action result banner, keyed by BookingActionResult.status. */
 function actionBannerClass(status: string): string {
@@ -208,6 +209,21 @@ export default function BookingDetail() {
     if (selectedSite) req.newSiteName = selectedSite.name;
     if (note.trim()) req.note = note.trim();
     runAction(() => bookingsApi.changeSite(parseInt(id), req));
+  };
+
+  // Remove is a hard delete with no fields to fill in first, so it skips the intermediate
+  // panel that move-activity/change-site use and opens straight into the confirm gate.
+  const openRemoveActivity = (itemId: string) => {
+    setActiveItemAction({ itemId, kind: 'remove-activity' });
+    setConfirmingItemAction(true);
+    setNote('');
+  };
+
+  const handleRemoveActivity = (itemId: string) => {
+    if (!id) return;
+    const req: RemoveActivityRequest = { itemId };
+    if (note.trim()) req.note = note.trim();
+    runAction(() => bookingsApi.removeActivity(parseInt(id), req));
   };
 
   const canAddActivity =
@@ -485,6 +501,35 @@ export default function BookingDetail() {
                         Change site
                       </button>
                     )}
+                    <button
+                      onClick={() => openRemoveActivity(item.itemId)}
+                      disabled={actionInProgress}
+                      className="ml-2 px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
+                    >
+                      Remove
+                    </button>
+                  </div>
+                )}
+
+                {/* Remove form — irreversible, so it opens straight into the confirm gate. */}
+                {activeItemAction?.itemId === item.itemId && activeItemAction.kind === 'remove-activity' && (
+                  <div className="mt-3 border-t pt-3 space-y-2">
+                    <div className="text-sm text-gray-700 space-y-2">
+                      <p>Permanently remove '{item.label}' from this booking? This cannot be undone.</p>
+                      <div>
+                        <label htmlFor={`remove-note-${item.itemId}`} className="block text-sm font-medium text-gray-700">Add a note (optional)</label>
+                        <textarea id={`remove-note-${item.itemId}`} value={note}
+                          onChange={(e) => setNote(e.target.value)} disabled={actionInProgress}
+                          className="w-full p-2 border border-gray-300 rounded resize-none" rows={2} />
+                      </div>
+                      <div>
+                        <button onClick={() => handleRemoveActivity(item.itemId)} disabled={actionInProgress}
+                          className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50">
+                          {actionInProgress ? 'Working…' : 'Confirm'}</button>
+                        <button onClick={() => setActiveItemAction(null)} disabled={actionInProgress}
+                          className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                      </div>
+                    </div>
                   </div>
                 )}
 

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -229,11 +229,14 @@ export default function BookingDetail() {
     runAction(() => bookingsApi.removeActivity(parseInt(id), req));
   };
 
+  // Parsed once and reused by both the "Update" button's disabled check and the submit
+  // handler, rather than re-parsing newNumberPeople in three separate places.
+  const parsedNewNumberPeople = parseInt(newNumberPeople, 10);
+  const isNewNumberPeopleValid = !Number.isNaN(parsedNewNumberPeople) && parsedNewNumberPeople > 0;
+
   const handleChangeNumbers = (itemId: string) => {
-    if (!id) return;
-    const people = parseInt(newNumberPeople, 10);
-    if (Number.isNaN(people) || people <= 0) return;
-    const req: ChangeNumbersRequest = { itemId, newNumberPeople: people };
+    if (!id || !isNewNumberPeopleValid) return;
+    const req: ChangeNumbersRequest = { itemId, newNumberPeople: parsedNewNumberPeople };
     if (note.trim()) req.note = note.trim();
     runAction(() => bookingsApi.changeNumbers(parseInt(id), req));
   };
@@ -564,11 +567,8 @@ export default function BookingDetail() {
                     {!confirmingItemAction ? (
                       <div>
                         <button
-                          onClick={() => {
-                            const people = parseInt(newNumberPeople, 10);
-                            if (!Number.isNaN(people) && people > 0) setConfirmingItemAction(true);
-                          }}
-                          disabled={actionInProgress || !(parseInt(newNumberPeople, 10) > 0)}
+                          onClick={() => { if (isNewNumberPeopleValid) setConfirmingItemAction(true); }}
+                          disabled={actionInProgress || !isNewNumberPeopleValid}
                           className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">Update</button>
                         <button onClick={() => setActiveItemAction(null)} disabled={actionInProgress}
                           className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -7,13 +7,14 @@ import type {
   BookingActionResult,
   BookingDetail as BookingDetailType,
   BookingItem,
+  ChangeNumbersRequest,
   ChangeSiteRequest,
   MoveActivityRequest,
   MoveDatesRequest,
   RemoveActivityRequest,
 } from '../types';
 
-type ItemActionKind = 'move-activity' | 'change-site' | 'remove-activity';
+type ItemActionKind = 'move-activity' | 'change-site' | 'remove-activity' | 'change-numbers';
 
 /** Tailwind classes for the action result banner, keyed by BookingActionResult.status. */
 function actionBannerClass(status: string): string {
@@ -54,6 +55,7 @@ export default function BookingDetail() {
   const [newStartTime, setNewStartTime] = useState('');
   const [newEndTime, setNewEndTime] = useState('');
   const [newSiteId, setNewSiteId] = useState('');
+  const [newNumberPeople, setNewNumberPeople] = useState('');
   const [note, setNote] = useState('');
 
   // Add-activity — a brand-new item, not tied to an existing one, so it gets its own form
@@ -189,6 +191,7 @@ export default function BookingDetail() {
     setNewStartTime('');
     setNewEndTime('');
     setNewSiteId('');
+    setNewNumberPeople('');
     setNote('');
   };
 
@@ -224,6 +227,15 @@ export default function BookingDetail() {
     const req: RemoveActivityRequest = { itemId };
     if (note.trim()) req.note = note.trim();
     runAction(() => bookingsApi.removeActivity(parseInt(id), req));
+  };
+
+  const handleChangeNumbers = (itemId: string) => {
+    if (!id) return;
+    const people = parseInt(newNumberPeople, 10);
+    if (Number.isNaN(people) || people <= 0) return;
+    const req: ChangeNumbersRequest = { itemId, newNumberPeople: people };
+    if (note.trim()) req.note = note.trim();
+    runAction(() => bookingsApi.changeNumbers(parseInt(id), req));
   };
 
   const canAddActivity =
@@ -502,6 +514,13 @@ export default function BookingDetail() {
                       </button>
                     )}
                     <button
+                      onClick={() => openItemAction(item.itemId, 'change-numbers')}
+                      disabled={actionInProgress}
+                      className="ml-2 px-3 py-1 text-sm bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+                    >
+                      Change numbers
+                    </button>
+                    <button
                       onClick={() => openRemoveActivity(item.itemId)}
                       disabled={actionInProgress}
                       className="ml-2 px-3 py-1 text-sm bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50"
@@ -530,6 +549,48 @@ export default function BookingDetail() {
                           className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
                       </div>
                     </div>
+                  </div>
+                )}
+
+                {/* Change-numbers form */}
+                {activeItemAction?.itemId === item.itemId && activeItemAction.kind === 'change-numbers' && (
+                  <div className="mt-3 border-t pt-3 space-y-2">
+                    <div>
+                      <label htmlFor={`np-${item.itemId}`} className="block text-sm font-medium text-gray-700">New number of people</label>
+                      <input id={`np-${item.itemId}`} type="number" min={1} value={newNumberPeople}
+                        onChange={(e) => setNewNumberPeople(e.target.value)} disabled={actionInProgress}
+                        className="w-24 p-2 border border-gray-300 rounded" />
+                    </div>
+                    {!confirmingItemAction ? (
+                      <div>
+                        <button
+                          onClick={() => {
+                            const people = parseInt(newNumberPeople, 10);
+                            if (!Number.isNaN(people) && people > 0) setConfirmingItemAction(true);
+                          }}
+                          disabled={actionInProgress || !(parseInt(newNumberPeople, 10) > 0)}
+                          className="px-3 py-1 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50">Update</button>
+                        <button onClick={() => setActiveItemAction(null)} disabled={actionInProgress}
+                          className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                      </div>
+                    ) : (
+                      <div className="text-sm text-gray-700 space-y-2">
+                        <p>Recreate this item with {newNumberPeople} people, then delete the original?</p>
+                        <div>
+                          <label htmlFor={`note-${item.itemId}`} className="block text-sm font-medium text-gray-700">Add a note (optional)</label>
+                          <textarea id={`note-${item.itemId}`} value={note}
+                            onChange={(e) => setNote(e.target.value)} disabled={actionInProgress}
+                            className="w-full p-2 border border-gray-300 rounded resize-none" rows={2} />
+                        </div>
+                        <div>
+                          <button onClick={() => handleChangeNumbers(item.itemId)} disabled={actionInProgress}
+                            className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50">
+                            {actionInProgress ? 'Working…' : 'Confirm'}</button>
+                          <button onClick={() => setConfirmingItemAction(false)} disabled={actionInProgress}
+                            className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400">Cancel</button>
+                        </div>
+                      </div>
+                    )}
                   </div>
                 )}
 

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -2,6 +2,7 @@ import { useState, useEffect } from 'react';
 import { useParams, useNavigate } from 'react-router-dom';
 import { bookingsApi } from '../services/apiClient';
 import type {
+  AddActivityRequest,
   AvailableSite,
   BookingActionResult,
   BookingDetail as BookingDetailType,
@@ -54,6 +55,18 @@ export default function BookingDetail() {
   const [newSiteId, setNewSiteId] = useState('');
   const [note, setNote] = useState('');
 
+  // Add-activity — a brand-new item, not tied to an existing one, so it gets its own form
+  // state and confirm gate rather than reusing the per-item fields above.
+  const [availableActivities, setAvailableActivities] = useState<AvailableSite[]>([]);
+  const [confirmingAddActivity, setConfirmingAddActivity] = useState(false);
+  const [newActivityId, setNewActivityId] = useState('');
+  const [activityStartDate, setActivityStartDate] = useState('');
+  const [activityEndDate, setActivityEndDate] = useState('');
+  const [activityStartTime, setActivityStartTime] = useState('');
+  const [activityEndTime, setActivityEndTime] = useState('');
+  const [activityNumberPeople, setActivityNumberPeople] = useState('');
+  const [activityNote, setActivityNote] = useState('');
+
   useEffect(() => {
     const fetchBooking = async () => {
       if (!id) return;
@@ -102,6 +115,14 @@ export default function BookingDetail() {
       .catch(() => setAvailableSites([]));
   }, [id]);
 
+  useEffect(() => {
+    if (!id) return;
+    // Activities for the add-activity dropdown; best-effort (empty list disables the form).
+    bookingsApi.getAvailableActivities(parseInt(id))
+      .then(setAvailableActivities)
+      .catch(() => setAvailableActivities([]));
+  }, [id]);
+
   const handlePostComment = async () => {
     if (!newComment.trim() || !id) return;
     setPosting(true);
@@ -139,6 +160,14 @@ export default function BookingDetail() {
       setActiveItemAction(null);
       setConfirmingItemAction(false);
       setNote('');
+      setConfirmingAddActivity(false);
+      setNewActivityId('');
+      setActivityStartDate('');
+      setActivityEndDate('');
+      setActivityStartTime('');
+      setActivityEndTime('');
+      setActivityNumberPeople('');
+      setActivityNote('');
     }
   };
 
@@ -179,6 +208,24 @@ export default function BookingDetail() {
     if (selectedSite) req.newSiteName = selectedSite.name;
     if (note.trim()) req.note = note.trim();
     runAction(() => bookingsApi.changeSite(parseInt(id), req));
+  };
+
+  const canAddActivity =
+    !!newActivityId && !!activityStartDate && !!activityEndDate && !!activityNumberPeople;
+
+  const handleAddActivity = () => {
+    const numberPeople = parseInt(activityNumberPeople, 10);
+    if (!id || !canAddActivity || Number.isNaN(numberPeople)) return;
+    const req: AddActivityRequest = {
+      activityId: newActivityId,
+      startDate: activityStartDate,
+      endDate: activityEndDate,
+      numberPeople,
+    };
+    if (activityStartTime) req.startTime = activityStartTime;
+    if (activityEndTime) req.endTime = activityEndTime;
+    if (activityNote.trim()) req.note = activityNote.trim();
+    runAction(() => bookingsApi.addActivity(parseInt(id), req));
   };
 
   if (loading) {
@@ -548,6 +595,87 @@ export default function BookingDetail() {
           </div>
         ) : (
           <p className="text-gray-500">No items on this booking.</p>
+        )}
+      </div>
+
+      {/* Add Activity — a brand-new item, so it's its own section rather than per-item. */}
+      <div className="bg-white rounded-lg shadow p-6 mb-6">
+        <h2 className="text-xl font-semibold text-gray-800 mb-4">Add Activity</h2>
+
+        {availableActivities.length === 0 ? (
+          <p className="text-gray-500">No activities available to add.</p>
+        ) : (
+          <div className="space-y-2">
+            <div>
+              <label htmlFor="activityId" className="block text-sm font-medium text-gray-700">Activity</label>
+              <select id="activityId" value={newActivityId}
+                onChange={(e) => setNewActivityId(e.target.value)} disabled={actionInProgress}
+                className="p-2 border border-gray-300 rounded">
+                <option value="">Select an activity…</option>
+                {availableActivities.map((a) => <option key={a.id} value={a.id}>{a.name}</option>)}
+              </select>
+            </div>
+            <div>
+              <label htmlFor="activityStartDate" className="block text-sm font-medium text-gray-700">Start date</label>
+              <input id="activityStartDate" type="date" value={activityStartDate}
+                onChange={(e) => setActivityStartDate(e.target.value)} disabled={actionInProgress}
+                className="p-2 border border-gray-300 rounded" />
+            </div>
+            <div>
+              <label htmlFor="activityEndDate" className="block text-sm font-medium text-gray-700">End date</label>
+              <input id="activityEndDate" type="date" value={activityEndDate}
+                onChange={(e) => setActivityEndDate(e.target.value)} disabled={actionInProgress}
+                className="p-2 border border-gray-300 rounded" />
+            </div>
+            <div>
+              <label htmlFor="activityStartTime" className="block text-sm font-medium text-gray-700">Start time (optional)</label>
+              <input id="activityStartTime" type="time" value={activityStartTime}
+                onChange={(e) => setActivityStartTime(e.target.value)} disabled={actionInProgress}
+                className="p-2 border border-gray-300 rounded" />
+            </div>
+            <div>
+              <label htmlFor="activityEndTime" className="block text-sm font-medium text-gray-700">End time (optional)</label>
+              <input id="activityEndTime" type="time" value={activityEndTime}
+                onChange={(e) => setActivityEndTime(e.target.value)} disabled={actionInProgress}
+                className="p-2 border border-gray-300 rounded" />
+            </div>
+            <div>
+              <label htmlFor="activityNumberPeople" className="block text-sm font-medium text-gray-700">Number of people</label>
+              <input id="activityNumberPeople" type="number" min={1} value={activityNumberPeople}
+                onChange={(e) => setActivityNumberPeople(e.target.value)} disabled={actionInProgress}
+                className="w-24 p-2 border border-gray-300 rounded" />
+            </div>
+
+            {!confirmingAddActivity ? (
+              <button
+                onClick={() => { if (canAddActivity) setConfirmingAddActivity(true); }}
+                disabled={actionInProgress || !canAddActivity}
+                className="px-4 py-2 bg-blue-600 text-white rounded hover:bg-blue-700 disabled:opacity-50"
+              >
+                Add activity
+              </button>
+            ) : (
+              <div className="text-sm text-gray-700 space-y-2">
+                <p>Add this activity to the booking?</p>
+                <div>
+                  <label htmlFor="activityNote" className="block text-sm font-medium text-gray-700">Add a note (optional)</label>
+                  <textarea id="activityNote" value={activityNote}
+                    onChange={(e) => setActivityNote(e.target.value)} disabled={actionInProgress}
+                    className="w-full p-2 border border-gray-300 rounded resize-none" rows={2} />
+                </div>
+                <div>
+                  <button onClick={handleAddActivity} disabled={actionInProgress}
+                    className="px-3 py-1 bg-red-600 text-white rounded hover:bg-red-700 disabled:opacity-50">
+                    {actionInProgress ? 'Working…' : 'Confirm'}
+                  </button>
+                  <button onClick={() => setConfirmingAddActivity(false)} disabled={actionInProgress}
+                    className="ml-2 px-3 py-1 bg-gray-300 text-gray-800 rounded hover:bg-gray-400 disabled:opacity-50">
+                    Cancel
+                  </button>
+                </div>
+              </div>
+            )}
+          </div>
         )}
       </div>
 

--- a/BookingsAssistant.Web/src/components/BookingDetail.tsx
+++ b/BookingsAssistant.Web/src/components/BookingDetail.tsx
@@ -241,17 +241,22 @@ export default function BookingDetail() {
     runAction(() => bookingsApi.changeNumbers(parseInt(id), req));
   };
 
+  // Parsed once and reused by both the "Add activity" button's disabled check and the submit
+  // handler, mirroring parsedNewNumberPeople/isNewNumberPeopleValid above.
+  const parsedActivityNumberPeople = parseInt(activityNumberPeople, 10);
+  const isActivityNumberPeopleValid =
+    !Number.isNaN(parsedActivityNumberPeople) && parsedActivityNumberPeople > 0;
+
   const canAddActivity =
-    !!newActivityId && !!activityStartDate && !!activityEndDate && !!activityNumberPeople;
+    !!newActivityId && !!activityStartDate && !!activityEndDate && isActivityNumberPeopleValid;
 
   const handleAddActivity = () => {
-    const numberPeople = parseInt(activityNumberPeople, 10);
-    if (!id || !canAddActivity || Number.isNaN(numberPeople)) return;
+    if (!id || !canAddActivity) return;
     const req: AddActivityRequest = {
       activityId: newActivityId,
       startDate: activityStartDate,
       endDate: activityEndDate,
-      numberPeople,
+      numberPeople: parsedActivityNumberPeople,
     };
     if (activityStartTime) req.startTime = activityStartTime;
     if (activityEndTime) req.endTime = activityEndTime;

--- a/BookingsAssistant.Web/src/components/Triage.test.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.test.tsx
@@ -222,4 +222,25 @@ describe('action rendering', () => {
     const templateEmailRow = screen.getByText(/send template email/i).closest('div')!.parentElement!;
     expect(within(templateEmailRow).getByText(/not_attempted/i)).toBeInTheDocument();
   });
+
+  it('renders an addActivity action with a readable description', async () => {
+    api.list.mockResolvedValue([{
+      id: 4,
+      status: 'AwaitingApproval',
+      sourceEmailText: 'Can we add an archery session?',
+      osmBookingId: '179746',
+      actionsJson: JSON.stringify([
+        { type: 'addActivity', activityId: '4962', newStartDate: '2026-08-02', newStartTime: '10:00', numberPeople: 8 },
+      ]),
+      executionResultJson: null,
+      createdAt: '2026-07-21T09:00:00Z',
+    }]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #4/i }));
+
+    expect(screen.getByText(/add activity 4962/i)).toBeInTheDocument();
+    expect(screen.getByText(/8 people/i)).toBeInTheDocument();
+  });
 });

--- a/BookingsAssistant.Web/src/components/Triage.test.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.test.tsx
@@ -263,4 +263,24 @@ describe('action rendering', () => {
 
     expect(screen.getByText(/remove item 411468/i)).toBeInTheDocument();
   });
+
+  it('renders a changeNumbers action with a readable description', async () => {
+    api.list.mockResolvedValue([{
+      id: 6,
+      status: 'AwaitingApproval',
+      sourceEmailText: 'Two more people are joining our archery session.',
+      osmBookingId: '179748',
+      actionsJson: JSON.stringify([
+        { type: 'changeNumbers', itemId: '411468', newNumberPeople: 10, note: 'two more joined' },
+      ]),
+      executionResultJson: null,
+      createdAt: '2026-07-23T09:00:00Z',
+    }]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #6/i }));
+
+    expect(screen.getByText(/change numbers for item 411468 to 10/i)).toBeInTheDocument();
+  });
 });

--- a/BookingsAssistant.Web/src/components/Triage.test.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.test.tsx
@@ -190,6 +190,40 @@ describe('plan detail actions', () => {
   });
 });
 
+describe('draft warning banner', () => {
+  it('shows a visible warning banner when the plan has a draftWarning', async () => {
+    api.list.mockResolvedValue([{
+      id: 9,
+      status: 'AwaitingApproval',
+      sourceEmailText: 'Can you add an archery session?',
+      osmBookingId: '179751',
+      actionsJson: JSON.stringify([
+        { type: 'addActivity', activityId: '4962', newStartDate: '2026-08-02', newEndDate: '2026-08-02', numberPeople: 8 },
+      ]),
+      draftWarning: 'addActivity for activityId "4962" (2026-08-02 to 2026-08-02) is not available: Fully booked',
+      executionResultJson: null,
+      createdAt: '2026-07-25T09:00:00Z',
+    }]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #9/i }));
+
+    expect(screen.getByText(/fully booked/i)).toBeInTheDocument();
+  });
+
+  it('does not show a warning banner when the plan has no draftWarning', async () => {
+    api.list.mockResolvedValue([executedPlan]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #2/i }));
+
+    expect(screen.queryByText(/not available/i)).not.toBeInTheDocument();
+    expect(screen.queryByText(/fully booked/i)).not.toBeInTheDocument();
+  });
+});
+
 describe('action rendering', () => {
   it('renders a draftEmailReply action as copyable text and an OSM action as a readable description', async () => {
     api.create.mockResolvedValue(draftReplyPlan);

--- a/BookingsAssistant.Web/src/components/Triage.test.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.test.tsx
@@ -243,4 +243,24 @@ describe('action rendering', () => {
     expect(screen.getByText(/add activity 4962/i)).toBeInTheDocument();
     expect(screen.getByText(/8 people/i)).toBeInTheDocument();
   });
+
+  it('renders a removeActivity action with a readable description', async () => {
+    api.list.mockResolvedValue([{
+      id: 5,
+      status: 'AwaitingApproval',
+      sourceEmailText: 'Please cancel our archery session',
+      osmBookingId: '179747',
+      actionsJson: JSON.stringify([
+        { type: 'removeActivity', itemId: '411468', note: 'customer cancelled' },
+      ]),
+      executionResultJson: null,
+      createdAt: '2026-07-22T09:00:00Z',
+    }]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #5/i }));
+
+    expect(screen.getByText(/remove item 411468/i)).toBeInTheDocument();
+  });
 });

--- a/BookingsAssistant.Web/src/components/Triage.test.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.test.tsx
@@ -264,6 +264,58 @@ describe('action rendering', () => {
     expect(screen.getByText(/remove item 411468/i)).toBeInTheDocument();
   });
 
+  it('renders a checkAvailability action with a readable description and its available detail', async () => {
+    api.list.mockResolvedValue([{
+      id: 7,
+      status: 'Executed',
+      sourceEmailText: null,
+      osmBookingId: '179749',
+      actionsJson: JSON.stringify([
+        { type: 'checkAvailability', activityId: '4962', newStartDate: '2026-08-02', newEndDate: '2026-08-02' },
+      ]),
+      executionResultJson: JSON.stringify([
+        { type: 'checkAvailability', status: 'succeeded', detail: 'Available' },
+      ]),
+      createdAt: '2026-07-24T09:00:00Z',
+    }]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #7/i }));
+
+    expect(screen.getByText(/check availability.*4962/i)).toBeInTheDocument();
+    const row = screen.getByText(/check availability.*4962/i).closest('div')!.parentElement!;
+    expect(within(row).getByText(/succeeded/i)).toBeInTheDocument();
+    expect(within(row).getByText(/^available$/i)).toBeInTheDocument();
+  });
+
+  it('renders a checkAvailability action result as succeeded even when unavailable', async () => {
+    // The important behavioral distinction: "not available" is still a succeeded query, not a
+    // failure -- the status badge must read "succeeded", with the unavailability explained via
+    // the detail text, not the (failure-only) reason text.
+    api.list.mockResolvedValue([{
+      id: 8,
+      status: 'Executed',
+      sourceEmailText: null,
+      osmBookingId: '179750',
+      actionsJson: JSON.stringify([
+        { type: 'checkAvailability', activityId: '4962', newStartDate: '2026-08-02', newEndDate: '2026-08-02' },
+      ]),
+      executionResultJson: JSON.stringify([
+        { type: 'checkAvailability', status: 'succeeded', detail: 'Not available: No available slot for 2026-08-02 to 2026-08-02' },
+      ]),
+      createdAt: '2026-07-24T09:00:00Z',
+    }]);
+    const user = userEvent.setup();
+    renderTriage();
+
+    await user.click(await screen.findByRole('button', { name: /plan #8/i }));
+
+    const row = screen.getByText(/check availability.*4962/i).closest('div')!.parentElement!;
+    expect(within(row).getByText(/succeeded/i)).toBeInTheDocument();
+    expect(within(row).getByText(/not available/i)).toBeInTheDocument();
+  });
+
   it('renders a changeNumbers action with a readable description', async () => {
     api.list.mockResolvedValue([{
       id: 6,

--- a/BookingsAssistant.Web/src/components/Triage.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.tsx
@@ -40,6 +40,11 @@ function describeAction(action: PlanAction): string {
       const when = [action.newStartDate, action.newStartTime].filter(Boolean).join(' ');
       return `Move activity ${action.itemId}${when ? ` to ${when}` : ''}`;
     }
+    case 'addActivity': {
+      const when = [action.newStartDate, action.newStartTime].filter(Boolean).join(' ');
+      const people = action.numberPeople != null ? ` for ${action.numberPeople} people` : '';
+      return `Add activity ${action.activityId}${when ? ` on ${when}` : ''}${people}`;
+    }
     default:
       return `Unknown action: ${action.type}`;
   }

--- a/BookingsAssistant.Web/src/components/Triage.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.tsx
@@ -49,6 +49,10 @@ function describeAction(action: PlanAction): string {
       return `Remove item ${action.itemId}${action.note ? ` — ${action.note}` : ''}`;
     case 'changeNumbers':
       return `Change numbers for item ${action.itemId} to ${action.newNumberPeople ?? '?'}${action.note ? ` — ${action.note}` : ''}`;
+    case 'checkAvailability': {
+      const when = [action.newStartDate, action.newEndDate].filter(Boolean).join(' to ');
+      return `Check availability for ${action.activityId}${when ? ` (${when})` : ''}`;
+    }
     default:
       return `Unknown action: ${action.type}`;
   }
@@ -108,6 +112,7 @@ function PlanActionRow({ action, result }: { action: PlanAction; result?: PlanAc
             {result.status}
           </span>
           {result.reason && <span className="ml-2 text-xs text-red-700">{result.reason}</span>}
+          {result.detail && <span className="ml-2 text-xs text-gray-700">{result.detail}</span>}
         </div>
       )}
     </div>

--- a/BookingsAssistant.Web/src/components/Triage.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.tsx
@@ -47,6 +47,8 @@ function describeAction(action: PlanAction): string {
     }
     case 'removeActivity':
       return `Remove item ${action.itemId}${action.note ? ` — ${action.note}` : ''}`;
+    case 'changeNumbers':
+      return `Change numbers for item ${action.itemId} to ${action.newNumberPeople ?? '?'}${action.note ? ` — ${action.note}` : ''}`;
     default:
       return `Unknown action: ${action.type}`;
   }

--- a/BookingsAssistant.Web/src/components/Triage.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.tsx
@@ -45,6 +45,8 @@ function describeAction(action: PlanAction): string {
       const people = action.numberPeople != null ? ` for ${action.numberPeople} people` : '';
       return `Add activity ${action.activityId}${when ? ` on ${when}` : ''}${people}`;
     }
+    case 'removeActivity':
+      return `Remove item ${action.itemId}${action.note ? ` — ${action.note}` : ''}`;
     default:
       return `Unknown action: ${action.type}`;
   }

--- a/BookingsAssistant.Web/src/components/Triage.tsx
+++ b/BookingsAssistant.Web/src/components/Triage.tsx
@@ -143,6 +143,13 @@ function PlanDetail({ plan, onApprove, onReject, busy }: PlanDetailProps) {
         <p className="text-sm text-gray-600 mb-2">Booking: {plan.osmBookingId}</p>
       )}
 
+      {plan.draftWarning && (
+        <div className="mb-4 p-3 bg-amber-50 border border-amber-300 rounded text-sm text-amber-800">
+          <span className="font-semibold">Availability warning: </span>
+          {plan.draftWarning}
+        </div>
+      )}
+
       {plan.sourceEmailText && (
         <div className="mb-4">
           <h3 className="text-sm font-semibold text-gray-700 mb-1">Source email</h3>

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -1,5 +1,6 @@
 import axios from 'axios';
 import type {
+  AddActivityRequest,
   AvailableSite,
   Booking,
   BookingActionResult,
@@ -94,6 +95,16 @@ export const bookingsApi = {
 
   moveDates: async (id: number, req: MoveDatesRequest): Promise<BookingActionResult> => {
     const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/move-dates`, req);
+    return response.data;
+  },
+
+  getAvailableActivities: async (id: number): Promise<AvailableSite[]> => {
+    const response = await apiClient.get<AvailableSite[]>(`/bookings/${id}/available-activities`);
+    return response.data;
+  },
+
+  addActivity: async (id: number, req: AddActivityRequest): Promise<BookingActionResult> => {
+    const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/add-activity`, req);
     return response.data;
   },
 };

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -6,6 +6,7 @@ import type {
   BookingActionResult,
   BookingDetail,
   BookingItem,
+  ChangeNumbersRequest,
   ChangeSiteRequest,
   BookingStats,
   MoveActivityRequest,
@@ -111,6 +112,11 @@ export const bookingsApi = {
 
   removeActivity: async (id: number, req: RemoveActivityRequest): Promise<BookingActionResult> => {
     const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/remove-activity`, req);
+    return response.data;
+  },
+
+  changeNumbers: async (id: number, req: ChangeNumbersRequest): Promise<BookingActionResult> => {
+    const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/change-numbers`, req);
     return response.data;
   },
 };

--- a/BookingsAssistant.Web/src/services/apiClient.ts
+++ b/BookingsAssistant.Web/src/services/apiClient.ts
@@ -11,6 +11,7 @@ import type {
   MoveActivityRequest,
   MoveDatesRequest,
   ProposedPlan,
+  RemoveActivityRequest,
 } from '../types';
 
 const apiClient = axios.create({
@@ -105,6 +106,11 @@ export const bookingsApi = {
 
   addActivity: async (id: number, req: AddActivityRequest): Promise<BookingActionResult> => {
     const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/add-activity`, req);
+    return response.data;
+  },
+
+  removeActivity: async (id: number, req: RemoveActivityRequest): Promise<BookingActionResult> => {
+    const response = await apiClient.post<BookingActionResult>(`/bookings/${id}/actions/remove-activity`, req);
     return response.data;
   },
 };

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -117,6 +117,13 @@ export interface AddActivityRequest {
   note?: string;
 }
 
+/** Request to remove (hard-delete) an existing item — activity or site — from a booking. */
+export interface RemoveActivityRequest {
+  itemId: string;
+  /** Optional free-text note appended to the auto-generated audit comment. */
+  note?: string;
+}
+
 /** A bookable site/pitch a booked item can be moved to (for change-site). */
 export interface AvailableSite {
   id: string;
@@ -163,7 +170,7 @@ export interface PlanAction {
   /** addActivity */
   newEndDate?: string;
   numberPeople?: number;
-  /** moveDates / changeSite / moveActivity / addActivity */
+  /** moveDates / changeSite / moveActivity / addActivity / removeActivity */
   note?: string;
 }
 

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -105,6 +105,18 @@ export interface MoveDatesRequest {
   note?: string;
 }
 
+/** Request to add a brand-new activity item to a booking (no existing item to clone). */
+export interface AddActivityRequest {
+  activityId: string;
+  startDate: string;
+  endDate: string;
+  startTime?: string;
+  endTime?: string;
+  numberPeople: number;
+  /** Optional free-text note appended to the auto-generated audit comment. */
+  note?: string;
+}
+
 /** A bookable site/pitch a booked item can be moved to (for change-site). */
 export interface AvailableSite {
   id: string;
@@ -142,11 +154,16 @@ export interface PlanAction {
   /** changeSite */
   newSiteId?: string;
   newSiteName?: string;
-  /** moveActivity */
+  /** addActivity */
+  activityId?: string;
+  /** moveActivity / addActivity */
   newStartDate?: string;
   newStartTime?: string;
   newEndTime?: string;
-  /** moveDates / changeSite / moveActivity */
+  /** addActivity */
+  newEndDate?: string;
+  numberPeople?: number;
+  /** moveDates / changeSite / moveActivity / addActivity */
   note?: string;
 }
 

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -124,6 +124,14 @@ export interface RemoveActivityRequest {
   note?: string;
 }
 
+/** Request to change the headcount (number of people) on an existing item. */
+export interface ChangeNumbersRequest {
+  itemId: string;
+  newNumberPeople: number;
+  /** Optional free-text note appended to the auto-generated audit comment. */
+  note?: string;
+}
+
 /** A bookable site/pitch a booked item can be moved to (for change-site). */
 export interface AvailableSite {
   id: string;
@@ -170,7 +178,9 @@ export interface PlanAction {
   /** addActivity */
   newEndDate?: string;
   numberPeople?: number;
-  /** moveDates / changeSite / moveActivity / addActivity / removeActivity */
+  /** changeNumbers */
+  newNumberPeople?: number;
+  /** moveDates / changeSite / moveActivity / addActivity / removeActivity / changeNumbers */
   note?: string;
 }
 

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -148,6 +148,13 @@ export interface ProposedPlan {
   osmBookingId?: string | null;
   /** JSON-encoded array of PlanAction, in execution order. */
   actionsJson?: string | null;
+  /**
+   * Set when drafting succeeded but an automatic availability pre-check found a date-carrying
+   * action (currently addActivity) whose slot was still unavailable after drafting's one retry.
+   * Drafting isn't failed for this — the plan is saved as normal — but a human reviewing it
+   * here should see the conflict before approving.
+   */
+  draftWarning?: string | null;
   /** JSON-encoded array of PlanActionExecutionResult, parallel to the actions array. */
   executionResultJson?: string | null;
   createdAt: string;

--- a/BookingsAssistant.Web/src/types/index.ts
+++ b/BookingsAssistant.Web/src/types/index.ts
@@ -169,18 +169,18 @@ export interface PlanAction {
   /** changeSite */
   newSiteId?: string;
   newSiteName?: string;
-  /** addActivity */
+  /** addActivity / checkAvailability */
   activityId?: string;
-  /** moveActivity / addActivity */
+  /** moveActivity / addActivity / checkAvailability */
   newStartDate?: string;
   newStartTime?: string;
   newEndTime?: string;
-  /** addActivity */
+  /** addActivity / checkAvailability */
   newEndDate?: string;
   numberPeople?: number;
   /** changeNumbers */
   newNumberPeople?: number;
-  /** moveDates / changeSite / moveActivity / addActivity / removeActivity / changeNumbers */
+  /** moveDates / changeSite / moveActivity / addActivity / removeActivity / changeNumbers / checkAvailability */
   note?: string;
 }
 
@@ -190,4 +190,10 @@ export interface PlanActionExecutionResult {
   /** One of: "succeeded", "failed", "not_attempted". */
   status: 'succeeded' | 'failed' | 'not_attempted';
   reason?: string | null;
+  /**
+   * Present for actions that produce a result beyond success/failure (currently only
+   * "checkAvailability" — e.g. "Available" or "Not available: ..."). Unlike `reason`, this is
+   * populated on a "succeeded" outcome too.
+   */
+  detail?: string | null;
 }

--- a/bookings-assistant/config.yaml
+++ b/bookings-assistant/config.yaml
@@ -1,5 +1,5 @@
 name: Bookings Assistant
-version: 0.11.0
+version: 0.12.0
 slug: bookings-assistant
 description: Manage scout campsite bookings from OSM
 url: https://github.com/piers-williams/bookings-helper


### PR DESCRIPTION
## Summary

Extends the existing AI-drafted "plan" system (draft → human approve/reject → execute against
OSM) with four new action types — `addActivity`, `removeActivity`, `changeNumbers`,
`checkAvailability` — plus an automatic availability pre-check that runs at drafting time for
`addActivity` proposals, with a retry-then-flag mechanism when a slot turns out to be
unavailable.

Delivered as five sequential, independently-tested chunks:
`add-activity` → `remove-activity` → `change-numbers` → `check-availability` →
`drafting-availability-precheck`.

## Approach

Each new action type follows the existing move-activity/change-site pattern end-to-end:
model (request DTO) → `IOsmService`/`IBookingItemActionService` → `BookingActionsController`
REST endpoint → `PlanDraftingService` schema validation → `PlanExecutionService` mapping →
`Triage.tsx` description. `addActivity` and `removeActivity` are genuinely new mutation shapes
(direct create, direct delete) rather than the clone-then-delete-original engine the other
actions share; `changeNumbers` reuses that existing clone engine by adding a
`NewNumberPeople` override to `ItemReplacement`/`BuildCreateSpec`.

`checkAvailability` is the first read-only plan action: it never mutates OSM, so
`PlanExecutionService.ExecuteActionAsync`'s return type changed from `Task` to `Task<string?>`
across all seven action types, to carry a `Detail` string (e.g. "Available" / "Not available:
...") back on a *successful* result — "not available" is a normal outcome of a query, not a
failure.

The drafting-time pre-check reuses `checkAvailability`'s underlying `IOsmService.CheckAvailabilityAsync`
to inspect any `addActivity` action the LLM proposes, before the plan is ever saved, so a human
reviewer sees an availability conflict immediately rather than after later attempting to execute
the plan.

## Key decisions

- **Shared one-retry budget between JSON-validity and availability checks.** Drafting already
  allowed itself one retry when the LLM returned invalid JSON. Rather than adding an independent
  retry budget for availability conflicts, the two failure reasons share the same single retry:
  whichever occurs on the first attempt, the retry prompt describes it and the retry's outcome
  is final either way.
- **Only `addActivity` is pre-checked at drafting time, not `moveActivity`.** `moveActivity`'s
  schema has no `newEndDate`, and its `itemId` refers to an item already on the booking rather
  than the catalogue item-type id the availability endpoint needs — there's no meaningful date
  range to pre-check. Documented inline in `PlanDraftingService.CheckActionsAvailabilityAsync`.
- **`BookingActionStatus.Failed` for non-throwing delete failures.** `RemoveActivityAsync` treats
  OSM returning `false` from `DeleteBookingItemAsync` (declined without an exception) as a
  `Failed` result, keeping "the delete didn't happen" distinguishable from "an OSM/auth error
  occurred" (which still propagates as an exception → 401/502).
- **Draft-only / no-send email scope explicitly excluded** — this PR only extends the
  plan-drafting/execution surface for booking mutations; email capture/sending remains out of
  scope, consistent with the project's existing "raw email addresses are never stored" posture.

## Testing strategy

277 backend tests / 63 frontend tests pass. Coverage follows the existing pattern per action:
controller-level tests for each new endpoint (happy path, 400s, 404s, 401/502 via `FakeOsmService`
error injection), drafting-service tests for schema validation of each new action shape,
execution-service tests for the OSM-call mapping, and `Triage.test.tsx` tests for the UI
description/status rendering of each new action — including the edge case that `checkAvailability`
reports `succeeded` even when the slot is unavailable. The availability pre-check has its own
dedicated suite in `PlanCreateTests.cs` covering the shared-retry-budget edge case and
"non-date-carrying actions skip the check entirely."

## Review guidance

Focus review time on `PlanDraftingService.DraftPlanAsync`/`EvaluateAttemptAsync`/
`CheckActionsAvailabilityAsync` — the shared-retry-budget logic is the trickiest control flow
in this PR (reads clearly thanks to named `DraftAttempt`/`AvailabilityConflict` types, but worth
a careful read). Everything else follows an established, repeated pattern across the 5 chunks.

## Security & quality review

- **Security review:** clean — no HIGH/MEDIUM findings. No auth regressions, no PII exposure
  beyond existing patterns, no injection risk in new OSM URL construction or LLM-JSON parsing.
- **Quality gate:** code clarity 8 clear / 4 unclear (all minor, two resolved before this PR —
  see below); tests 4 good / 1 missing (resolved); no over-engineering; cross-cutting naming
  consistency across all 5 chunks confirmed clean.
- Two small findings from review were fixed in this branch before opening the PR: added
  `NumberPeople > 0` validation to `addActivity` (server + client), mirroring the existing
  `changeNumbers` validation, plus a matching test; and corrected a misleading log message in
  the shared `GetItemsSafeAsync` helper.

## Release note

Home Assistant addon version bumped **0.11.0 → 0.12.0** (minor — new user-visible AI plan
capabilities), per this repo's established convention of bumping `bookings-assistant/config.yaml`
in the same PR as any deployable change.

> The AI assistant can now propose adding a new activity booking, removing an existing booking
> item, and changing headcount on a booking — in addition to its existing reschedule/change-site/
> move-dates/comment/email-draft actions. It can also check activity availability before proposing
> a change, and flags a plan with a visible warning if a proposed date turns out to be unavailable,
> rather than silently drafting an unworkable plan.

🤖 Generated with [Claude Code](https://claude.com/claude-code)